### PR TITLE
Use the asset id instead of name when reporting position

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([libsmm-asset], [0.2.3])
+AC_INIT([libsmm-asset], [0.3.1])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign])
 
 AC_CONFIG_HEADERS([config.h])

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
-libsmm-asset (0.2.3) unstable; urgency=medium
+libsmm-asset (0.3.1) unstable; urgency=medium
 
   * Updated
 
- -- Scott Parlane <sjp@canterburyairpatrol.org>  Sun, 19 Jul 2020 00:00:00 +0000
+ -- Scott Parlane <sjp@canterburyairpatrol.org>  Sat, 04 May 2024 00:00:00 +0000
 

--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -331,7 +331,7 @@ smm_asset_report_position (smm_asset asset, double latitude, double longitude, u
 	struct buffer_s buf = { NULL, 0 };
 
 	char *page = NULL;
-	if (asprintf (&page, "/data/assets/%s/position/add/?lat=%lf&lon=%lf&alt=%u&bearing=%u&fix=%u", asset->name, latitude, longitude, altitude, bearing, fix)
+	if (asprintf (&page, "/data/assets/%lld/position/add/?lat=%lf&lon=%lf&alt=%u&bearing=%u&fix=%u", asset->asset_id, latitude, longitude, altitude, bearing, fix)
 	    < 0)
 	{
 		return false;


### PR DESCRIPTION
## Description

search-management-map has been updated to use the asset's id instead of the name in the url to refer to the asset

See: https://github.com/canterbury-air-patrol/search-management-map/issues/318

## Checklist
- [x] I/we wrote this code my/ourself
- [ ] I have tested this change in my environment
- [ ] I have tested existing related functionality is not impacted by this change