### PR TITLE
build: add includedir to Cflags in pkg-config file

### DIFF
--- a/src/smm-asset.pc.in
+++ b/src/smm-asset.pc.in
@@ -8,4 +8,4 @@ Description: Library to act as an Asset for Search Management Map
 URL: https://github.com/canterbury-air-patrol/smm-asset
 Version: @VERSION@
 Libs: -lsmmasset
-Cflags:
+Cflags: -I${includedir}


### PR DESCRIPTION
## Description

This allows consumers to find the library headers when installed to a non-standard prefix.

## Summary by Sourcery

Build:
- Adjust the pkg-config template to add the include directory to the Cflags field for downstream consumers.