### PR TITLE
security: enable TLS verification by default and add opt-out API

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: Install Deps
-      run: sudo apt install -y libcurl4-openssl-dev libtidy-dev libjansson-dev
+      run: sudo apt update && sudo apt install -y libcurl4-openssl-dev libtidy-dev libjansson-dev
     - name: autogen
       run: ./autogen.sh
     - name: configure

--- a/src/smm-asset-curl.c
+++ b/src/smm-asset-curl.c
@@ -97,6 +97,7 @@ smm_connection_curl_retrieve_url_r (smm_connection conn, const char *path, const
 
 	pthread_mutex_lock (&conn->lock);
 	CURL *curl = conn->curl;
+	bool verify_tls = conn->verify_tls;
 	if (curl == NULL)
 	{
 		DEBUG ("creating curl object\n");
@@ -115,8 +116,8 @@ smm_connection_curl_retrieve_url_r (smm_connection conn, const char *path, const
 	}
 
 	curl_easy_setopt (curl, CURLOPT_FAILONERROR, true);
-	curl_easy_setopt (curl, CURLOPT_SSL_VERIFYPEER, 0L);
-	curl_easy_setopt (curl, CURLOPT_SSL_VERIFYHOST, 0L);
+	curl_easy_setopt (curl, CURLOPT_SSL_VERIFYPEER, verify_tls ? 1L : 0L);
+	curl_easy_setopt (curl, CURLOPT_SSL_VERIFYHOST, verify_tls ? 2L : 0L);
 	curl_easy_setopt (curl, CURLOPT_COOKIEFILE, "");
 	curl_easy_setopt (curl, CURLOPT_FOLLOWLOCATION, 0L);
 	curl_easy_setopt (curl, CURLOPT_URL, res->full_uri);
@@ -255,7 +256,7 @@ extract_csrfmiddlewaretoken (TidyDoc tdoc, TidyNode tnod, char **token)
 
 
 bool
-smm_connection_login (smm_connection connection)
+smm_asset_connection_login (smm_connection connection)
 {
 	bool res = false;
 	TidyBuffer docbuf = { 0 };
@@ -369,7 +370,7 @@ smm_connection_curl_retrieve_url (smm_connection conn, const char *path, const c
 			else if (strstr (res->redirect_url, "accounts/login") != NULL)
 			{
 				DEBUG ("Login required\n");
-				if (smm_connection_login (conn))
+				if (smm_asset_connection_login (conn))
 				{
 					retry = true;
 				}

--- a/src/smm-asset-internal.h
+++ b/src/smm-asset-internal.h
@@ -49,6 +49,7 @@ struct smm_connection_s
 	CURL *curl;
 	char *csrfmiddlewaretoken;
 	pthread_mutex_t lock;
+	bool verify_tls;
 };
 
 struct smm_asset_s
@@ -92,7 +93,7 @@ size_t to_buffer (char *ptr, size_t size, size_t nmemb, void *userdata);
 void smm_curl_res_free (struct smm_curl_res_s *);
 struct smm_curl_res_s *smm_connection_curl_retrieve_url (smm_connection conn, const char *path, const char *post_data,
 							 size_t (*write_func) (char *ptr, size_t size, size_t nmemb, void *userdata), void *write_data, bool json);
-bool smm_connection_login (smm_connection connection);
+bool smm_asset_connection_login (smm_connection connection);
 
 smm_asset smm_asset_create (smm_connection connection, const char *name, const char *type, long long asset_id, long long asset_type_id);
 void smm_asset_free_asset (smm_asset assets);

--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -53,9 +53,8 @@ smm_asset_connect (const char *host, const char *user, const char *pass)
 	conn->host = strdup (host);
 	conn->user = strdup (user);
 	conn->pass = strdup (pass);
+	conn->verify_tls = true;
 	pthread_mutex_init (&conn->lock, NULL);
-
-	smm_connection_login (conn);
 
 	return conn;
 }
@@ -68,6 +67,17 @@ smm_asset_connection_get_state (smm_connection connection)
 		return SMM_CONNECTION_UNKNOWN;
 	}
 	return connection->state;
+}
+
+void
+smm_asset_connection_tls_verify_set (smm_connection connection, bool verify)
+{
+	if (connection != NULL)
+	{
+		pthread_mutex_lock (&connection->lock);
+		connection->verify_tls = verify;
+		pthread_mutex_unlock (&connection->lock);
+	}
 }
 
 void

--- a/src/smm-asset.h
+++ b/src/smm-asset.h
@@ -116,6 +116,14 @@ smm_connection smm_asset_connect (const char *host, const char *user, const char
  */
 smm_connection_status smm_asset_connection_get_state (smm_connection connection);
 
+/**
+ * Enable/disable TLS verification for a connection.
+ * TLS verification is enabled by default.
+ *
+ * @param connection the smm_connection object
+ * @param verify true to enable TLS verification, false to disable
+ */
+void smm_asset_connection_tls_verify_set (smm_connection connection, bool verify);
 
 /**
  * Close a connection to smm and free associated resources


### PR DESCRIPTION
## Description

This ensures that the library validates server certificates by default, preventing MITM attacks on the login process. An explicit API is provided to disable verification for development or local testing.

## Summary by Sourcery

Enable TLS certificate verification by default for asset connections and provide a configurable API to toggle TLS verification, while updating the login flow and CI build dependencies.

New Features:
- Add a public API to enable or disable TLS verification per connection, with verification enabled by default.

Enhancements:
- Wire the connection-level TLS verification flag into libcurl options to control SSL peer and host verification.
- Initialize connections with TLS verification enabled when creating new asset connections.
- Rename the internal login helper to better reflect its asset-specific behavior.

CI:
- Update the GitHub Actions build workflow to run apt update before installing build dependencies.