### PR TITLE
Add ci tests

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,10 @@
+---
+Language: Cpp
+BasedOnStyle: GNU
+IndentWidth: 8
+UseTab: Always
+BreakBeforeBraces: GNU
+AllowShortIfStatementsOnASingleLine: false
+IndentCaseLabels: true
+ColumnLimit: 120
+...

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,12 +14,18 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: Install Deps
-      run: sudo apt update && sudo apt install -y libcurl4-openssl-dev libtidy-dev libjansson-dev
+      run: sudo apt update && sudo apt install -y libcurl4-openssl-dev libtidy-dev libjansson-dev check
     - name: autogen
       run: ./autogen.sh
     - name: configure
       run: ./configure
     - name: make
       run: make
+    - name: Start Docker SMM
+      run: |
+        docker compose -f tests/docker-compose.yml up -d
+        ./tests/provision.sh
+    - name: make check
+      run: make check
     - name: make distcheck
       run: make distcheck

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,5 @@
 ACLOCAL_AMFLAGS = -I m4
 
-SUBDIRS = src
+SUBDIRS = src tests
 
 EXTRA_DIST = debian

--- a/configure.ac
+++ b/configure.ac
@@ -12,11 +12,13 @@ LT_INIT([disable-static pic-only])
 PKG_CHECK_MODULES([TIDY],[tidy])
 PKG_CHECK_MODULES([CURL],[libcurl])
 PKG_CHECK_MODULES([JANSSON],[jansson])
+PKG_CHECK_MODULES([CHECK], [check >= 0.9.4])
 
 AC_CHECK_HEADERS([tidy.h],[],[
 AC_CHECK_HEADERS([tidy/tidy.h])])
 
 AC_CONFIG_FILES([Makefile
 	src/Makefile
+	tests/Makefile
 	src/smm-asset.pc])
 AC_OUTPUT

--- a/src/smm-asset-curl.c
+++ b/src/smm-asset-curl.c
@@ -21,8 +21,8 @@
  */
 #include "config.h"
 
-#include "smm-asset.h"
 #include "smm-asset-internal.h"
+#include "smm-asset.h"
 
 #include <pthread.h>
 #include <stdlib.h>
@@ -38,7 +38,8 @@
 #error No tidy header(s)
 #endif
 
-enum http_return_codes {
+enum http_return_codes
+{
 	HTTP_SUCCESS = 200,
 	HTTP_MOVED_PERMANENTLY = 301,
 	HTTP_FOUND = 302,
@@ -49,12 +50,12 @@ void
 smm_curl_res_free (struct smm_curl_res_s *res)
 {
 	if (res)
-	{
-		free (res->full_uri);
-		free (res->redirect_url);
-		free (res->content_type);
-		free (res);
-	}
+		{
+			free (res->full_uri);
+			free (res->redirect_url);
+			free (res->content_type);
+			free (res);
+		}
 }
 
 static size_t
@@ -67,12 +68,12 @@ size_t
 to_buffer (char *ptr, size_t size, size_t nmemb, void *userdata)
 {
 	size_t new_bytes = size * nmemb;
-	struct buffer_s *buf = (struct buffer_s *) userdata;
+	struct buffer_s *buf = (struct buffer_s *)userdata;
 	char *tmp = realloc (buf->data, buf->bytes + new_bytes + 1);
 	if (tmp == NULL)
-	{
-		return 0;
-	}
+		{
+			return 0;
+		}
 	buf->data = tmp;
 	memcpy (&buf->data[buf->bytes], ptr, new_bytes);
 	buf->bytes += new_bytes;
@@ -83,37 +84,38 @@ to_buffer (char *ptr, size_t size, size_t nmemb, void *userdata)
 
 static struct smm_curl_res_s *
 smm_connection_curl_retrieve_url_r (smm_connection conn, const char *path, const char *post_data,
-				   size_t (*write_func) (char *ptr, size_t size, size_t nmemb, void *userdata), void *write_data, bool json)
+				    size_t (*write_func) (char *ptr, size_t size, size_t nmemb, void *userdata),
+				    void *write_data, bool json)
 {
 	struct smm_curl_res_s *res = NULL;
 
-	DEBUG ("(%p, %s, %s, %p)\n", (void *) conn, path, post_data, write_data);
+	DEBUG ("(%p, %s, %s, %p)\n", (void *)conn, path, post_data, write_data);
 
 	if (conn == NULL || path == NULL)
-	{
-		DEBUG ("conn or path is NULL\n");
-		return NULL;
-	}
+		{
+			DEBUG ("conn or path is NULL\n");
+			return NULL;
+		}
 
 	pthread_mutex_lock (&conn->lock);
 	CURL *curl = conn->curl;
 	bool verify_tls = conn->verify_tls;
 	if (curl == NULL)
-	{
-		DEBUG ("creating curl object\n");
-		curl = curl_easy_init ();
-		conn->curl = curl;
-	}
+		{
+			DEBUG ("creating curl object\n");
+			curl = curl_easy_init ();
+			conn->curl = curl;
+		}
 
-	res = (struct smm_curl_res_s *) calloc (1, sizeof (struct smm_curl_res_s));
+	res = (struct smm_curl_res_s *)calloc (1, sizeof (struct smm_curl_res_s));
 
 	if (asprintf (&res->full_uri, "%s%s", conn->host, path) < 0)
-	{
-		free (res);
-		DEBUG ("failed to allocate full_uri");
-		pthread_mutex_unlock (&conn->lock);
-		return NULL;
-	}
+		{
+			free (res);
+			DEBUG ("failed to allocate full_uri");
+			pthread_mutex_unlock (&conn->lock);
+			return NULL;
+		}
 
 	curl_easy_setopt (curl, CURLOPT_FAILONERROR, true);
 	curl_easy_setopt (curl, CURLOPT_SSL_VERIFYPEER, verify_tls ? 1L : 0L);
@@ -123,36 +125,36 @@ smm_connection_curl_retrieve_url_r (smm_connection conn, const char *path, const
 	curl_easy_setopt (curl, CURLOPT_URL, res->full_uri);
 
 	if (post_data)
-	{
-		curl_easy_setopt (curl, CURLOPT_REFERER, res->full_uri);
-		curl_easy_setopt (curl, CURLOPT_POSTFIELDS, post_data);
-		curl_easy_setopt (curl, CURLOPT_POST, 1);
-	}
+		{
+			curl_easy_setopt (curl, CURLOPT_REFERER, res->full_uri);
+			curl_easy_setopt (curl, CURLOPT_POSTFIELDS, post_data);
+			curl_easy_setopt (curl, CURLOPT_POST, 1);
+		}
 	else
-	{
-		curl_easy_setopt (curl, CURLOPT_REFERER, NULL);
-		curl_easy_setopt (curl, CURLOPT_POSTFIELDS, NULL);
-		curl_easy_setopt (curl, CURLOPT_POST, 0);
-	}
+		{
+			curl_easy_setopt (curl, CURLOPT_REFERER, NULL);
+			curl_easy_setopt (curl, CURLOPT_POSTFIELDS, NULL);
+			curl_easy_setopt (curl, CURLOPT_POST, 0);
+		}
 
 	if (write_func)
-	{
-		curl_easy_setopt (curl, CURLOPT_WRITEFUNCTION, write_func);
-		curl_easy_setopt (curl, CURLOPT_WRITEDATA, write_data);
-	}
+		{
+			curl_easy_setopt (curl, CURLOPT_WRITEFUNCTION, write_func);
+			curl_easy_setopt (curl, CURLOPT_WRITEDATA, write_data);
+		}
 	else
-	{
-		curl_easy_setopt (curl, CURLOPT_WRITEFUNCTION, eat_data);
-		curl_easy_setopt (curl, CURLOPT_WRITEDATA, NULL);
-	}
+		{
+			curl_easy_setopt (curl, CURLOPT_WRITEFUNCTION, eat_data);
+			curl_easy_setopt (curl, CURLOPT_WRITEDATA, NULL);
+		}
 
 	struct curl_slist *headers = NULL;
 
 	if (json)
-	{
-		headers = curl_slist_append (headers, "Accept: application/json");
-		curl_easy_setopt (curl, CURLOPT_HTTPHEADER, headers);
-	}
+		{
+			headers = curl_slist_append (headers, "Accept: application/json");
+			curl_easy_setopt (curl, CURLOPT_HTTPHEADER, headers);
+		}
 
 	DEBUG ("fetching %s\n", res->full_uri);
 	CURLcode cres = curl_easy_perform (curl);
@@ -166,28 +168,28 @@ smm_connection_curl_retrieve_url_r (smm_connection conn, const char *path, const
 	curl_easy_getinfo (curl, CURLINFO_RESPONSE_CODE, &res->httpcode);
 	DEBUG ("httpcode = %li\n", res->httpcode);
 	switch (res->httpcode)
-	{
-		case HTTP_SUCCESS:
 		{
-			char *ct = NULL;
-			if (curl_easy_getinfo (curl, CURLINFO_CONTENT_TYPE, &ct) == CURLE_OK)
-			{
-				res->content_type = strdup (ct);
-			}
+			case HTTP_SUCCESS:
+				{
+					char *ct = NULL;
+					if (curl_easy_getinfo (curl, CURLINFO_CONTENT_TYPE, &ct) == CURLE_OK)
+						{
+							res->content_type = strdup (ct);
+						}
+				}
+				break;
+			case HTTP_MOVED_PERMANENTLY:
+			case HTTP_FOUND:
+			case HTTP_SEE_OTHER:
+				{
+					char *redirect_url = NULL;
+					if (curl_easy_getinfo (curl, CURLINFO_REDIRECT_URL, &redirect_url) == CURLE_OK)
+						{
+							res->redirect_url = strdup (redirect_url);
+						}
+				}
+				break;
 		}
-			break;
-		case HTTP_MOVED_PERMANENTLY:
-		case HTTP_FOUND:
-		case HTTP_SEE_OTHER:
-		{
-			char *redirect_url = NULL;
-			if (curl_easy_getinfo (curl, CURLINFO_REDIRECT_URL, &redirect_url) == CURLE_OK)
-			{
-				res->redirect_url = strdup (redirect_url);
-			}
-		}
-			break;
-	}
 
 	/* Clear anything we set in the curl object */
 	curl_easy_setopt (curl, CURLOPT_URL, NULL);
@@ -197,7 +199,7 @@ smm_connection_curl_retrieve_url_r (smm_connection conn, const char *path, const
 	curl_easy_setopt (curl, CURLOPT_WRITEFUNCTION, NULL);
 	curl_easy_setopt (curl, CURLOPT_WRITEDATA, NULL);
 
-	pthread_mutex_unlock(&conn->lock);
+	pthread_mutex_unlock (&conn->lock);
 
 	DEBUG ("Done\n");
 
@@ -207,7 +209,7 @@ smm_connection_curl_retrieve_url_r (smm_connection conn, const char *path, const
 static size_t
 populate_tidy (char *ptr, size_t size, size_t nmemb, void *userdata)
 {
-	tidyBufAppend ((TidyBuffer *) userdata, ptr, size * nmemb);
+	tidyBufAppend ((TidyBuffer *)userdata, ptr, size * nmemb);
 	return size * nmemb;
 }
 
@@ -216,71 +218,101 @@ extract_csrfmiddlewaretoken (TidyDoc tdoc, TidyNode tnod, char **token)
 {
 	bool res = false;
 	for (TidyNode child = tidyGetChild (tnod); child; child = tidyGetNext (child))
-	{
-		ctmbstr name = tidyNodeGetName (child);
-		if (name)
 		{
-			if (strcmp (name, "input") == 0)
-			{
-				bool is_csrf = false;
-				ctmbstr value = NULL;
-				/* check the attributes */
-				for (TidyAttr attr = tidyAttrFirst (child); attr; attr = tidyAttrNext (attr))
+			ctmbstr name = tidyNodeGetName (child);
+			if (name)
 				{
-					ctmbstr attrName = tidyAttrName (attr);
-					if (strcmp (attrName, "name") == 0)
-					{
-						if (strcmp (tidyAttrValue (attr), "csrfmiddlewaretoken") == 0)
+					if (strcmp (name, "input") == 0)
 						{
-							is_csrf = true;
+							bool is_csrf = false;
+							ctmbstr value = NULL;
+							/* check the attributes */
+							for (TidyAttr attr = tidyAttrFirst (child); attr;
+							     attr = tidyAttrNext (attr))
+								{
+									ctmbstr attrName = tidyAttrName (attr);
+									if (strcmp (attrName, "name") == 0)
+										{
+											if (strcmp (
+												tidyAttrValue (attr),
+												"csrfmiddlewaretoken")
+											    == 0)
+												{
+													is_csrf = true;
+												}
+										}
+									else if (strcmp (attrName, "value") == 0)
+										{
+											value = tidyAttrValue (attr);
+										}
+								}
+							if (is_csrf && value)
+								{
+									size_t len = strlen (value);
+									if (len > 0 && len < 256)
+										{
+											/* Validate token characters:
+											 * [A-Za-z0-9_\-] */
+											bool valid = true;
+											for (size_t i = 0; i < len; i++)
+												{
+													if (!((value[i]
+														   >= 'a'
+													       && value[i]
+														      <= 'z')
+													      || (value[i]
+														      >= 'A'
+														  && value[i]
+															 <= 'Z')
+													      || (value[i]
+														      >= '0'
+														  && value[i]
+															 <= '9')
+													      || (value
+														      [i]
+														  == '_')
+													      || (value
+														      [i]
+														  == '-')))
+														{
+															valid
+															    = false;
+															break;
+														}
+												}
+											if (valid)
+												{
+													*token
+													    = strdup (
+														value);
+													return true;
+												}
+											else
+												{
+													DEBUG (
+													    "CSRF "
+													    "token "
+													    "contains "
+													    "invalid "
+													    "characters"
+													    "\n");
+												}
+										}
+									else
+										{
+											DEBUG ("CSRF token has invalid "
+											       "length: %zu\n",
+											       len);
+										}
+								}
 						}
-					}
-					else if (strcmp (attrName, "value") == 0)
-					{
-						value = tidyAttrValue (attr);
-					}
 				}
-				if (is_csrf && value)
+			res = extract_csrfmiddlewaretoken (tdoc, child, token);
+			if (res)
 				{
-					size_t len = strlen (value);
-					if (len > 0 && len < 256)
-					{
-						/* Validate token characters: [A-Za-z0-9_\-] */
-						bool valid = true;
-						for (size_t i = 0; i < len; i++)
-						{
-							if (!((value[i] >= 'a' && value[i] <= 'z') ||
-							      (value[i] >= 'A' && value[i] <= 'Z') ||
-							      (value[i] >= '0' && value[i] <= '9') ||
-							      (value[i] == '_') || (value[i] == '-')))
-							{
-								valid = false;
-								break;
-							}
-						}
-						if (valid)
-						{
-							*token = strdup (value);
-							return true;
-						}
-						else
-						{
-							DEBUG ("CSRF token contains invalid characters\n");
-						}
-					}
-					else
-					{
-						DEBUG ("CSRF token has invalid length: %zu\n", len);
-					}
+					return res;
 				}
-			}
 		}
-		res = extract_csrfmiddlewaretoken (tdoc, child, token);
-		if (res)
-		{
-			return res;
-		}
-	}
 	return res;
 }
 
@@ -292,20 +324,20 @@ smm_parse_csrf_token (const char *data, size_t len)
 	TidyDoc tdoc = tidyCreate ();
 
 	if (tdoc == NULL)
-	{
-		return NULL;
-	}
+		{
+			return NULL;
+		}
 
 	tidyOptSetBool (tdoc, TidyForceOutput, yes);
 	tidyOptSetInt (tdoc, TidyWrapLen, 4096);
 	tidyBufInit (&docbuf);
-	tidyBufAppend (&docbuf, (void *) data, len);
+	tidyBufAppend (&docbuf, (void *)data, len);
 
 	if (tidyParseBuffer (tdoc, &docbuf) >= 0)
-	{
-		tidyCleanAndRepair (tdoc);
-		extract_csrfmiddlewaretoken (tdoc, tidyGetRoot (tdoc), &token);
-	}
+		{
+			tidyCleanAndRepair (tdoc);
+			extract_csrfmiddlewaretoken (tdoc, tidyGetRoot (tdoc), &token);
+		}
 
 	tidyBufFree (&docbuf);
 	tidyRelease (tdoc);
@@ -322,55 +354,65 @@ smm_asset_connection_login (smm_connection connection)
 	tidyBufInit (&docbuf);
 
 	/* Get the login page, so we can get the csrf cookie + token */
-	struct smm_curl_res_s *res_get = smm_connection_curl_retrieve_url (connection, "/accounts/login/", NULL, populate_tidy, &docbuf, false);
+	struct smm_curl_res_s *res_get
+	    = smm_connection_curl_retrieve_url (connection, "/accounts/login/", NULL, populate_tidy, &docbuf, false);
 
 	if (res_get && res_get->success && res_get->httpcode == HTTP_SUCCESS)
-	{
-		/* find the input token with the csrfmiddlewaretoken */
-		connection->csrfmiddlewaretoken = smm_parse_csrf_token ((const char *)docbuf.bp, docbuf.size);
-
-		if (connection->csrfmiddlewaretoken)
 		{
-			char *post_data = NULL;
-			char *esc_csrf = curl_easy_escape (connection->curl, connection->csrfmiddlewaretoken, 0);
-			char *esc_user = curl_easy_escape (connection->curl, connection->user, 0);
-			char *esc_pass = curl_easy_escape (connection->curl, connection->pass, 0);
+			/* find the input token with the csrfmiddlewaretoken */
+			connection->csrfmiddlewaretoken = smm_parse_csrf_token ((const char *)docbuf.bp, docbuf.size);
 
-			if (esc_csrf && esc_user && esc_pass && asprintf
-			    (&post_data, "csrfmiddlewaretoken=%s&username=%s&password=%s", esc_csrf, esc_user, esc_pass) >= 0)
-			{
-				struct smm_curl_res_s *res_post = smm_connection_curl_retrieve_url (connection, "/accounts/login/", post_data, NULL, NULL, false);
-				if (res_post && res_post->success && res_post->httpcode == HTTP_FOUND)
+			if (connection->csrfmiddlewaretoken)
 				{
-					res = true;
-					connection->state = SMM_CONNECTION_CONNECTED;
+					char *post_data = NULL;
+					char *esc_csrf
+					    = curl_easy_escape (connection->curl, connection->csrfmiddlewaretoken, 0);
+					char *esc_user = curl_easy_escape (connection->curl, connection->user, 0);
+					char *esc_pass = curl_easy_escape (connection->curl, connection->pass, 0);
+
+					if (esc_csrf && esc_user && esc_pass
+					    && asprintf (&post_data, "csrfmiddlewaretoken=%s&username=%s&password=%s",
+							 esc_csrf, esc_user, esc_pass)
+						   >= 0)
+						{
+							struct smm_curl_res_s *res_post
+							    = smm_connection_curl_retrieve_url (
+								connection, "/accounts/login/", post_data, NULL, NULL,
+								false);
+							if (res_post && res_post->success
+							    && res_post->httpcode == HTTP_FOUND)
+								{
+									res = true;
+									connection->state = SMM_CONNECTION_CONNECTED;
+								}
+							else
+								{
+									connection->state
+									    = SMM_CONNECTION_AUTHENTICATION_FAILURE;
+								}
+							smm_curl_res_free (res_post);
+							free (post_data);
+						}
+					curl_free (esc_csrf);
+					curl_free (esc_user);
+					curl_free (esc_pass);
 				}
-				else
+			else
 				{
-					connection->state = SMM_CONNECTION_AUTHENTICATION_FAILURE;
+					DEBUG ("Failed to find CSRF token in login page\n");
+					connection->state = SMM_CONNECTION_PROTOCOL_ERROR;
 				}
-				smm_curl_res_free (res_post);
-				free (post_data);
-			}
-			curl_free (esc_csrf);
-			curl_free (esc_user);
-			curl_free (esc_pass);
 		}
-		else
-		{
-			DEBUG ("Failed to find CSRF token in login page\n");
-			connection->state = SMM_CONNECTION_PROTOCOL_ERROR;
-		}
-	}
 	else if (!res_get)
-	{
-		DEBUG ("No res object returned\n");
-		connection->state = SMM_CONNECTION_NO_HOST_CONNECTION;
-	}
+		{
+			DEBUG ("No res object returned\n");
+			connection->state = SMM_CONNECTION_NO_HOST_CONNECTION;
+		}
 	else
-	{
-		DEBUG ("success = %s, httpcode = %li\n", res_get->success ? "true" : "false", res_get->httpcode);
-	}
+		{
+			DEBUG ("success = %s, httpcode = %li\n", res_get->success ? "true" : "false",
+			       res_get->httpcode);
+		}
 	smm_curl_res_free (res_get);
 
 	tidyBufFree (&docbuf);
@@ -380,67 +422,77 @@ smm_asset_connection_login (smm_connection connection)
 
 struct smm_curl_res_s *
 smm_connection_curl_retrieve_url (smm_connection conn, const char *path, const char *post_data,
-				  size_t (*write_func) (char *ptr, size_t size, size_t nmemb, void *userdata), void *write_data, bool json)
+				  size_t (*write_func) (char *ptr, size_t size, size_t nmemb, void *userdata),
+				  void *write_data, bool json)
 {
 	bool retry = true;
 	int retries = 0;
-	struct smm_curl_res_s *res = smm_connection_curl_retrieve_url_r (conn, path, post_data, write_func, write_data, json);
+	struct smm_curl_res_s *res
+	    = smm_connection_curl_retrieve_url_r (conn, path, post_data, write_func, write_data, json);
 
 	while (retry && retries < 3 && res != NULL)
-	{
-		retry = false;
-		retries++;
-		if (res->success && res->httpcode == HTTP_FOUND && res->redirect_url)
 		{
-			DEBUG ("Got redirected to (%s) accessing %s\n", res->redirect_url, path);
-			/* It's possible we need to upgrade to https */
-			if (strncmp (conn->host, "https://", 8) != 0 && strncmp (res->redirect_url, "https://", 8) == 0)
-			{
-				/* Upgrade to https */
-				DEBUG ("Upgrading to https\n");
-				char *new_host = NULL;
-				if (strncmp (conn->host, "http://", 7) == 0)
+			retry = false;
+			retries++;
+			if (res->success && res->httpcode == HTTP_FOUND && res->redirect_url)
 				{
-					if (asprintf (&new_host, "https://%s", &conn->host[7]) < 0)
-					{
-						DEBUG ("Failed to create new host\n");
-					}
-				}
-				else
-				{
-					if (asprintf (&new_host, "https://%s", conn->host) < 0)
-					{
-						DEBUG ("Failed to create new host\n");
-					}
-				}
-				if (new_host)
-				{
-					free (conn->host);
-					conn->host = new_host;
-					retry = true;
-				}
-			}
+					DEBUG ("Got redirected to (%s) accessing %s\n", res->redirect_url, path);
+					/* It's possible we need to upgrade to https */
+					if (strncmp (conn->host, "https://", 8) != 0
+					    && strncmp (res->redirect_url, "https://", 8) == 0)
+						{
+							/* Upgrade to https */
+							DEBUG ("Upgrading to https\n");
+							char *new_host = NULL;
+							if (strncmp (conn->host, "http://", 7) == 0)
+								{
+									if (asprintf (&new_host, "https://%s",
+										      &conn->host[7])
+									    < 0)
+										{
+											DEBUG ("Failed to create new "
+											       "host\n");
+										}
+								}
+							else
+								{
+									if (asprintf (&new_host, "https://%s",
+										      conn->host)
+									    < 0)
+										{
+											DEBUG ("Failed to create new "
+											       "host\n");
+										}
+								}
+							if (new_host)
+								{
+									free (conn->host);
+									conn->host = new_host;
+									retry = true;
+								}
+						}
 
-			if (!retry && strstr (res->redirect_url, "accounts/login") != NULL)
-			{
-				DEBUG ("Login required\n");
-				if (smm_asset_connection_login (conn))
-				{
-					retry = true;
-				}
-			}
+					if (!retry && strstr (res->redirect_url, "accounts/login") != NULL)
+						{
+							DEBUG ("Login required\n");
+							if (smm_asset_connection_login (conn))
+								{
+									retry = true;
+								}
+						}
 
-			if (!retry)
-			{
-				DEBUG ("Redirected to %s\n", res->redirect_url);
-			}
+					if (!retry)
+						{
+							DEBUG ("Redirected to %s\n", res->redirect_url);
+						}
+				}
+			if (retry && retries < 3)
+				{
+					smm_curl_res_free (res);
+					res = smm_connection_curl_retrieve_url_r (conn, path, post_data, write_func,
+										  write_data, json);
+				}
 		}
-		if (retry && retries < 3)
-		{
-			smm_curl_res_free (res);
-			res = smm_connection_curl_retrieve_url_r (conn, path, post_data, write_func, write_data, json);
-		}
-	}
 
 	return res;
 }

--- a/src/smm-asset-curl.c
+++ b/src/smm-asset-curl.c
@@ -394,36 +394,34 @@ smm_connection_curl_retrieve_url (smm_connection conn, const char *path, const c
 		{
 			DEBUG ("Got redirected to (%s) accessing %s\n", res->redirect_url, path);
 			/* It's possible we need to upgrade to https */
-			if (strncmp (conn->host, "https://", 8) != 0)
+			if (strncmp (conn->host, "https://", 8) != 0 && strncmp (res->redirect_url, "https://", 8) == 0)
 			{
-				if (strncmp (res->redirect_url, "https://", 8) == 0)
+				/* Upgrade to https */
+				DEBUG ("Upgrading to https\n");
+				char *new_host = NULL;
+				if (strncmp (conn->host, "http://", 7) == 0)
 				{
-					/* Upgrade to https */
-					DEBUG ("Upgrading to https\n");
-					char *new_host = NULL;
-					if (strncmp (conn->host, "http://", 7) == 0)
+					if (asprintf (&new_host, "https://%s", &conn->host[7]) < 0)
 					{
-						if (asprintf (&new_host, "https://%s", &conn->host[7]) < 0)
-						{
-							DEBUG ("Failed to create new host\n");
-						}
-					}
-					else
-					{
-						if (asprintf (&new_host, "https://%s", conn->host) < 0)
-						{
-							DEBUG ("Failed to create new host\n");
-						}
-					}
-					if (new_host)
-					{
-						free (conn->host);
-						conn->host = new_host;
-						retry = true;
+						DEBUG ("Failed to create new host\n");
 					}
 				}
+				else
+				{
+					if (asprintf (&new_host, "https://%s", conn->host) < 0)
+					{
+						DEBUG ("Failed to create new host\n");
+					}
+				}
+				if (new_host)
+				{
+					free (conn->host);
+					conn->host = new_host;
+					retry = true;
+				}
 			}
-			else if (strstr (res->redirect_url, "accounts/login") != NULL)
+
+			if (!retry && strstr (res->redirect_url, "accounts/login") != NULL)
 			{
 				DEBUG ("Login required\n");
 				if (smm_asset_connection_login (conn))
@@ -431,7 +429,8 @@ smm_connection_curl_retrieve_url (smm_connection conn, const char *path, const c
 					retry = true;
 				}
 			}
-			else
+
+			if (!retry)
 			{
 				DEBUG ("Redirected to %s\n", res->redirect_url);
 			}

--- a/src/smm-asset-curl.c
+++ b/src/smm-asset-curl.c
@@ -222,6 +222,8 @@ extract_csrfmiddlewaretoken (TidyDoc tdoc, TidyNode tnod, char **token)
 		{
 			if (strcmp (name, "input") == 0)
 			{
+				bool is_csrf = false;
+				ctmbstr value = NULL;
 				/* check the attributes */
 				for (TidyAttr attr = tidyAttrFirst (child); attr; attr = tidyAttrNext (attr))
 				{
@@ -230,16 +232,45 @@ extract_csrfmiddlewaretoken (TidyDoc tdoc, TidyNode tnod, char **token)
 					{
 						if (strcmp (tidyAttrValue (attr), "csrfmiddlewaretoken") == 0)
 						{
-							res = true;
+							is_csrf = true;
 						}
 					}
 					else if (strcmp (attrName, "value") == 0)
 					{
-						if (res)
+						value = tidyAttrValue (attr);
+					}
+				}
+				if (is_csrf && value)
+				{
+					size_t len = strlen (value);
+					if (len > 0 && len < 256)
+					{
+						/* Validate token characters: [A-Za-z0-9_\-] */
+						bool valid = true;
+						for (size_t i = 0; i < len; i++)
 						{
-							*token = strdup (tidyAttrValue (attr));
+							if (!((value[i] >= 'a' && value[i] <= 'z') ||
+							      (value[i] >= 'A' && value[i] <= 'Z') ||
+							      (value[i] >= '0' && value[i] <= '9') ||
+							      (value[i] == '_') || (value[i] == '-')))
+							{
+								valid = false;
+								break;
+							}
+						}
+						if (valid)
+						{
+							*token = strdup (value);
 							return true;
 						}
+						else
+						{
+							DEBUG ("CSRF token contains invalid characters\n");
+						}
+					}
+					else
+					{
+						DEBUG ("CSRF token has invalid length: %zu\n", len);
 					}
 				}
 			}
@@ -253,7 +284,34 @@ extract_csrfmiddlewaretoken (TidyDoc tdoc, TidyNode tnod, char **token)
 	return res;
 }
 
+char *
+smm_parse_csrf_token (const char *data, size_t len)
+{
+	char *token = NULL;
+	TidyBuffer docbuf = { 0 };
+	TidyDoc tdoc = tidyCreate ();
 
+	if (tdoc == NULL)
+	{
+		return NULL;
+	}
+
+	tidyOptSetBool (tdoc, TidyForceOutput, yes);
+	tidyOptSetInt (tdoc, TidyWrapLen, 4096);
+	tidyBufInit (&docbuf);
+	tidyBufAppend (&docbuf, (void *) data, len);
+
+	if (tidyParseBuffer (tdoc, &docbuf) >= 0)
+	{
+		tidyCleanAndRepair (tdoc);
+		extract_csrfmiddlewaretoken (tdoc, tidyGetRoot (tdoc), &token);
+	}
+
+	tidyBufFree (&docbuf);
+	tidyRelease (tdoc);
+
+	return token;
+}
 
 bool
 smm_asset_connection_login (smm_connection connection)
@@ -261,9 +319,6 @@ smm_asset_connection_login (smm_connection connection)
 	bool res = false;
 	TidyBuffer docbuf = { 0 };
 
-	TidyDoc tdoc = tidyCreate ();
-	tidyOptSetBool (tdoc, TidyForceOutput, yes);
-	tidyOptSetInt (tdoc, TidyWrapLen, 4096);
 	tidyBufInit (&docbuf);
 
 	/* Get the login page, so we can get the csrf cookie + token */
@@ -271,11 +326,8 @@ smm_asset_connection_login (smm_connection connection)
 
 	if (res_get && res_get->success && res_get->httpcode == HTTP_SUCCESS)
 	{
-		tidyParseBuffer (tdoc, &docbuf);
-		tidyCleanAndRepair (tdoc);
-
 		/* find the input token with the csrfmiddlewaretoken */
-		extract_csrfmiddlewaretoken (tdoc, tidyGetRoot (tdoc), &connection->csrfmiddlewaretoken);
+		connection->csrfmiddlewaretoken = smm_parse_csrf_token ((const char *)docbuf.bp, docbuf.size);
 
 		if (connection->csrfmiddlewaretoken)
 		{
@@ -304,6 +356,11 @@ smm_asset_connection_login (smm_connection connection)
 			curl_free (esc_user);
 			curl_free (esc_pass);
 		}
+		else
+		{
+			DEBUG ("Failed to find CSRF token in login page\n");
+			connection->state = SMM_CONNECTION_PROTOCOL_ERROR;
+		}
 	}
 	else if (!res_get)
 	{
@@ -317,7 +374,6 @@ smm_asset_connection_login (smm_connection connection)
 	smm_curl_res_free (res_get);
 
 	tidyBufFree (&docbuf);
-	tidyRelease (tdoc);
 
 	return res;
 }

--- a/src/smm-asset-internal.h
+++ b/src/smm-asset-internal.h
@@ -30,14 +30,15 @@
 #include <curl/curl.h>
 
 extern bool smm_debug;
-#define DEBUG(...) do \
-	{ \
-		if (smm_debug) \
-		{ \
-			printf ("%s:%i ", __func__, __LINE__);\
-			printf(__VA_ARGS__); \
-		} \
-	} \
+#define DEBUG(...)                                                                                                     \
+	do                                                                                                             \
+		{                                                                                                      \
+			if (smm_debug)                                                                                 \
+				{                                                                                      \
+					printf ("%s:%i ", __func__, __LINE__);                                         \
+					printf (__VA_ARGS__);                                                          \
+				}                                                                                      \
+		}                                                                                                      \
 	while (0)
 
 struct smm_connection_s
@@ -92,12 +93,16 @@ size_t to_buffer (char *ptr, size_t size, size_t nmemb, void *userdata);
 
 void smm_curl_res_free (struct smm_curl_res_s *);
 struct smm_curl_res_s *smm_connection_curl_retrieve_url (smm_connection conn, const char *path, const char *post_data,
-							 size_t (*write_func) (char *ptr, size_t size, size_t nmemb, void *userdata), void *write_data, bool json);
+							 size_t (*write_func) (char *ptr, size_t size, size_t nmemb,
+									       void *userdata),
+							 void *write_data, bool json);
 bool smm_asset_connection_login (smm_connection connection);
 char *smm_parse_csrf_token (const char *data, size_t len);
-bool smm_parse_assets (smm_connection connection, const char *data, size_t len, smm_assets * assets, size_t * assets_count);
-bool smm_parse_command (const char *data, size_t len, smm_asset_command * command, double *lat, double *lon);
-bool smm_parse_waypoints (const char *data, size_t len, smm_waypoints * waypoints, size_t * waypoints_count);
+bool smm_parse_assets (smm_connection connection, const char *data, size_t len, smm_assets *assets,
+		       size_t *assets_count);
+bool smm_parse_command (const char *data, size_t len, smm_asset_command *command, double *lat, double *lon);
+bool smm_parse_waypoints (const char *data, size_t len, smm_waypoints *waypoints, size_t *waypoints_count);
 
-smm_asset smm_asset_create (smm_connection connection, const char *name, const char *type, long long asset_id, long long asset_type_id);
+smm_asset smm_asset_create (smm_connection connection, const char *name, const char *type, long long asset_id,
+			    long long asset_type_id);
 void smm_asset_free_asset (smm_asset assets);

--- a/src/smm-asset-internal.h
+++ b/src/smm-asset-internal.h
@@ -95,6 +95,7 @@ struct smm_curl_res_s *smm_connection_curl_retrieve_url (smm_connection conn, co
 							 size_t (*write_func) (char *ptr, size_t size, size_t nmemb, void *userdata), void *write_data, bool json);
 bool smm_asset_connection_login (smm_connection connection);
 char *smm_parse_csrf_token (const char *data, size_t len);
+bool smm_parse_assets (smm_connection connection, const char *data, size_t len, smm_assets * assets, size_t * assets_count);
 
 smm_asset smm_asset_create (smm_connection connection, const char *name, const char *type, long long asset_id, long long asset_type_id);
 void smm_asset_free_asset (smm_asset assets);

--- a/src/smm-asset-internal.h
+++ b/src/smm-asset-internal.h
@@ -96,6 +96,7 @@ struct smm_curl_res_s *smm_connection_curl_retrieve_url (smm_connection conn, co
 bool smm_asset_connection_login (smm_connection connection);
 char *smm_parse_csrf_token (const char *data, size_t len);
 bool smm_parse_assets (smm_connection connection, const char *data, size_t len, smm_assets * assets, size_t * assets_count);
+bool smm_parse_command (const char *data, size_t len, smm_asset_command * command, double *lat, double *lon);
 
 smm_asset smm_asset_create (smm_connection connection, const char *name, const char *type, long long asset_id, long long asset_type_id);
 void smm_asset_free_asset (smm_asset assets);

--- a/src/smm-asset-internal.h
+++ b/src/smm-asset-internal.h
@@ -94,6 +94,7 @@ void smm_curl_res_free (struct smm_curl_res_s *);
 struct smm_curl_res_s *smm_connection_curl_retrieve_url (smm_connection conn, const char *path, const char *post_data,
 							 size_t (*write_func) (char *ptr, size_t size, size_t nmemb, void *userdata), void *write_data, bool json);
 bool smm_asset_connection_login (smm_connection connection);
+char *smm_parse_csrf_token (const char *data, size_t len);
 
 smm_asset smm_asset_create (smm_connection connection, const char *name, const char *type, long long asset_id, long long asset_type_id);
 void smm_asset_free_asset (smm_asset assets);

--- a/src/smm-asset-internal.h
+++ b/src/smm-asset-internal.h
@@ -97,6 +97,7 @@ bool smm_asset_connection_login (smm_connection connection);
 char *smm_parse_csrf_token (const char *data, size_t len);
 bool smm_parse_assets (smm_connection connection, const char *data, size_t len, smm_assets * assets, size_t * assets_count);
 bool smm_parse_command (const char *data, size_t len, smm_asset_command * command, double *lat, double *lon);
+bool smm_parse_waypoints (const char *data, size_t len, smm_waypoints * waypoints, size_t * waypoints_count);
 
 smm_asset smm_asset_create (smm_connection connection, const char *name, const char *type, long long asset_id, long long asset_type_id);
 void smm_asset_free_asset (smm_asset assets);

--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -255,58 +255,63 @@ smm_asset_type (smm_asset asset)
 	return NULL;
 }
 
-static bool
-smm_asset_update_command (smm_asset asset, struct buffer_s *buf)
+bool
+smm_parse_command (const char *data, size_t len, smm_asset_command * command, double *lat, double *lon)
 {
 	json_error_t json_error;
+	bool res = false;
 
-	json_t *json_root = json_loadb (buf->data, buf->bytes, 0, &json_error);
+	*command = SMM_COMMAND_UNKNOWN;
+
+	json_t *json_root = json_loadb (data, len, 0, &json_error);
 	if (json_root)
 	{
-		const char *command = NULL;
-
 		json_t *tmp = json_object_get (json_root, "action");
-		if (tmp)
+		if (json_is_string (tmp))
 		{
-			command = json_string_value (tmp);
-			if (strcmp (command, "GOTO") == 0)
+			const char *cmd_str = json_string_value (tmp);
+			if (cmd_str)
 			{
-				/* Get lat and long as well */
-				tmp = json_object_get (json_root, "latitude");
-				if (tmp)
+				res = true;
+				if (strcmp (cmd_str, "GOTO") == 0)
 				{
-					asset->last_command_lat = json_real_value (tmp);
+					/* Get lat and long as well */
+					tmp = json_object_get (json_root, "latitude");
+					if (json_is_real (tmp))
+					{
+						*lat = json_real_value (tmp);
+					}
+					tmp = json_object_get (json_root, "longitude");
+					if (json_is_real (tmp))
+					{
+						*lon = json_real_value (tmp);
+					}
+					*command = SMM_COMMAND_GOTO;
 				}
-				tmp = json_object_get (json_root, "longitude");
-				if (tmp)
+				else if (strcmp (cmd_str, "RON") == 0)
 				{
-					asset->last_command_lon = json_real_value (tmp);
+					*command = SMM_COMMAND_CONTINUE;
 				}
-				asset->last_command = SMM_COMMAND_GOTO;
-			}
-			else if (strcmp (command, "RON") == 0)
-			{
-				asset->last_command = SMM_COMMAND_CONTINUE;
-			}
-			else if (strcmp (command, "RTL") == 0)
-			{
-				asset->last_command = SMM_COMMAND_RTL;
-			}
-			else if (strcmp (command, "CIR") == 0)
-			{
-				asset->last_command = SMM_COMMAND_CIRCLE;
-			}
-			else if (strcmp (command, "AS") == 0)
-			{
-				asset->last_command = SMM_COMMAND_ABANDON_SEARCH;
-			}
-			else if (strcmp (command, "MC") == 0)
-			{
-				asset->last_command = SMM_COMMAND_MISSION_COMPLETE;
-			}
-			else
-			{
-				asset->last_command = SMM_COMMAND_UNKNOWN;
+				else if (strcmp (cmd_str, "RTL") == 0)
+				{
+					*command = SMM_COMMAND_RTL;
+				}
+				else if (strcmp (cmd_str, "CIR") == 0)
+				{
+					*command = SMM_COMMAND_CIRCLE;
+				}
+				else if (strcmp (cmd_str, "AS") == 0)
+				{
+					*command = SMM_COMMAND_ABANDON_SEARCH;
+				}
+				else if (strcmp (cmd_str, "MC") == 0)
+				{
+					*command = SMM_COMMAND_MISSION_COMPLETE;
+				}
+				else
+				{
+					*command = SMM_COMMAND_UNKNOWN;
+				}
 			}
 		}
 
@@ -314,11 +319,16 @@ smm_asset_update_command (smm_asset asset, struct buffer_s *buf)
 	}
 	else
 	{
-		printf ("Error on line %i: %s\n", json_error.line, json_error.text);
-		asset->last_command = SMM_COMMAND_UNKNOWN;
+		DEBUG ("JSON Parse Error on line %i: %s\n", json_error.line, json_error.text);
 	}
 
-	return true;
+	return res;
+}
+
+static bool
+smm_asset_update_command (smm_asset asset, struct buffer_s *buf)
+{
+	return smm_parse_command (buf->data, buf->bytes, &asset->last_command, &asset->last_command_lat, &asset->last_command_lon);
 }
 
 

--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -497,52 +497,80 @@ smm_parse_waypoints (const char *data, size_t len, smm_waypoints *waypoints, siz
 					if (json_array_size (json_features) == 1)
 						{
 							json_t *json_search = json_array_get (json_features, 0);
-							json_t *json_geometry
-							    = json_object_get (json_search, "geometry");
-							json_t *json_coords
-							    = json_object_get (json_geometry, "coordinates");
-							if (json_is_array (json_coords))
+							if (json_is_object (json_search))
 								{
-									size_t index = 0;
-									json_t *value = NULL;
-									json_array_foreach (json_coords, index, value)
-									{
-										double lat = 0.0;
-										double lon = 0.0;
-										json_t *json_lat
-										    = json_array_get (value, 1);
-										json_t *json_lon
-										    = json_array_get (value, 0);
-										lat = json_real_value (json_lat);
-										lon = json_real_value (json_lon);
-										smm_waypoint new_wp
-										    = smm_waypoint_create (lat, lon);
-										if (new_wp)
-											{
-												smm_waypoint *tmp = realloc (
-												    *waypoints,
-												    (*waypoints_count
-												     + 1)
-													* sizeof (
-													    smm_waypoint));
-												if (tmp)
+									json_t *json_geometry
+									    = json_object_get (json_search, "geometry");
+									if (json_is_object (json_geometry))
+										{
+											json_t *json_coords
+											    = json_object_get (
+												json_geometry,
+												"coordinates");
+											if (json_is_array (json_coords))
+												{
+													size_t index
+													    = 0;
+													json_t *value
+													    = NULL;
+													json_array_foreach (
+													    json_coords,
+													    index,
+													    value)
 													{
-														*waypoints
-														    = tmp;
-														(*waypoints)
-														    [*waypoints_count]
-														    = new_wp;
-														*waypoints_count
-														    += 1;
+														double
+														    lat
+														    = 0.0;
+														double
+														    lon
+														    = 0.0;
+														json_t *
+														    json_lat
+														    = json_array_get (
+															value,
+															1);
+														json_t *
+														    json_lon
+														    = json_array_get (
+															value,
+															0);
+														lat = json_real_value (
+														    json_lat);
+														lon = json_real_value (
+														    json_lon);
+														smm_waypoint
+														    new_wp
+														    = smm_waypoint_create (
+															lat,
+															lon);
+														if (new_wp)
+															{
+																smm_waypoint *tmp = realloc (
+																    *waypoints,
+																    (*waypoints_count
+																     + 1)
+																	* sizeof (
+																	    smm_waypoint));
+																if (tmp)
+																	{
+																		*waypoints
+																		    = tmp;
+																		(*waypoints)
+																		    [*waypoints_count]
+																		    = new_wp;
+																		*waypoints_count
+																		    += 1;
+																	}
+																else
+																	{
+																		smm_waypoint_free (
+																		    new_wp);
+																	}
+															}
 													}
-												else
-													{
-														smm_waypoint_free (
-														    new_wp);
-													}
-											}
-									}
-									res = true;
+													res = true;
+												}
+										}
 								}
 						}
 					else

--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -170,6 +170,12 @@ smm_parse_assets (smm_connection connection, const char *data, size_t len, smm_a
 								else
 									{
 										smm_asset_free_asset (new_asset);
+										smm_asset_free_assets (*assets,
+												       *assets_count);
+										*assets = NULL;
+										*assets_count = 0;
+										json_decref (json_root);
+										return false;
 									}
 							}
 					}

--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -476,11 +476,81 @@ smm_waypoint_free (smm_waypoint waypoint)
 
 
 bool
+smm_parse_waypoints (const char *data, size_t len, smm_waypoints * waypoints, size_t * waypoints_count)
+{
+	json_error_t json_error;
+	bool res = false;
+
+	/* Parse the waypoints */
+	*waypoints_count = 0;
+	*waypoints = NULL;
+
+	json_t *json_root = json_loadb (data, len, 0, &json_error);
+	if (json_root)
+	{
+		json_t *json_features = json_object_get (json_root, "features");
+		if (json_is_array (json_features))
+		{
+			if (json_array_size (json_features) == 1)
+			{
+				json_t *json_search = json_array_get (json_features, 0);
+				json_t *json_geometry = json_object_get (json_search, "geometry");
+				json_t *json_coords = json_object_get (json_geometry, "coordinates");
+				if (json_is_array (json_coords))
+				{
+					size_t index = 0;
+					json_t *value = NULL;
+					json_array_foreach (json_coords, index, value)
+					{
+						double lat = 0.0;
+						double lon = 0.0;
+						json_t *json_lat = json_array_get (value, 1);
+						json_t *json_lon = json_array_get (value, 0);
+						lat = json_real_value (json_lat);
+						lon = json_real_value (json_lon);
+						smm_waypoint new_wp = smm_waypoint_create (lat, lon);
+						if (new_wp)
+						{
+							smm_waypoint *tmp = realloc (*waypoints, (*waypoints_count + 1) * sizeof (smm_waypoint));
+							if (tmp)
+							{
+								*waypoints = tmp;
+								(*waypoints)[*waypoints_count] = new_wp;
+								*waypoints_count += 1;
+							}
+							else
+							{
+								smm_waypoint_free (new_wp);
+							}
+						}
+					}
+					res = true;
+				}
+			}
+			else
+			{
+				DEBUG ("GeoJSON features array size != 1 (%zi)\n", json_array_size (json_features));
+			}
+		}
+		else
+		{
+			DEBUG ("Didn't find features array in GeoJSON\n");
+		}
+		json_decref (json_root);
+	}
+	else
+	{
+		DEBUG ("JSON Parse Error on line %i: %s\n", json_error.line, json_error.text);
+	}
+
+	return res;
+}
+
+
+bool
 smm_search_get_waypoints (smm_search search, smm_waypoints * waypoints, size_t * waypoints_count)
 {
 	struct buffer_s buf = { NULL, 0 };
-	json_t *json_root = NULL;
-	json_error_t json_error;
 
 	struct smm_curl_res_s *res = smm_connection_curl_retrieve_url (search->asset->conn, search->url, NULL, to_buffer, &buf, true);
 
@@ -490,79 +560,17 @@ smm_search_get_waypoints (smm_search search, smm_waypoints * waypoints, size_t *
 	}
 	else if (!(res->success && res->httpcode == HTTP_SUCCESS))
 	{
-		/* Login, try again */
 		smm_curl_res_free (res);
+		free (buf.data);
 		return false;
 	}
-
 	smm_curl_res_free (res);
 
-
-	/* Parse the assets */
-	*waypoints_count = 0;
-	*waypoints = NULL;
-
-	json_root = json_loadb (buf.data, buf.bytes, 0, &json_error);
-	if (json_root)
-	{
-		json_t *json_features = json_object_get (json_root, "features");
-		if (json_features)
-		{
-			if (json_array_size (json_features) == 1)
-			{
-
-				printf ("Parsing waypoints\n");
-				size_t index = 0;
-				json_t *value = NULL;
-
-				json_t *json_search = json_array_get (json_features, 0);
-				if (json_search == NULL)
-				{
-					printf ("No json_search :(\n");
-				}
-				json_t *json_geometry = json_object_get (json_search, "geometry");
-				if (json_geometry == NULL)
-				{
-					printf ("No json_geometry \n");
-				}
-				json_t *json_coords = json_object_get (json_geometry, "coordinates");
-				if (json_coords == NULL)
-				{
-					printf ("No json_coords\n");
-				}
-				json_array_foreach (json_coords, index, value)
-				{
-					double lat = 0.0;
-					double lon = 0.0;
-					json_t *json_lat = json_array_get (value, 1);
-					json_t *json_lon = json_array_get (value, 0);
-					lat = json_real_value (json_lat);
-					lon = json_real_value (json_lon);
-					*(waypoints_count) += 1;
-					*waypoints = realloc (*waypoints, *waypoints_count * sizeof (smm_waypoint));
-					(*waypoints)[(*waypoints_count) - 1] = smm_waypoint_create (lat, lon);
-				}
-			}
-			else
-			{
-				printf ("array size != 1 (%zi)", json_array_size (json_features));
-			}
-		}
-		else
-		{
-			printf ("Didn't find waypoints\n");
-		}
-	}
-	else
-	{
-		printf ("Error on line %i: %s\n", json_error.line, json_error.text);
-	}
-
-	json_decref (json_root);
+	bool parse_res = smm_parse_waypoints (buf.data, buf.bytes, waypoints, waypoints_count);
 
 	free (buf.data);
 
-	return true;
+	return parse_res;
 }
 
 static bool

--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -29,7 +29,8 @@
 
 #include <jansson.h>
 
-enum http_return_codes {
+enum http_return_codes
+{
 	HTTP_SUCCESS = 200,
 };
 
@@ -46,9 +47,9 @@ smm_asset_connect (const char *host, const char *user, const char *pass)
 {
 	smm_connection conn = calloc (1, sizeof (struct smm_connection_s));
 	if (conn == NULL)
-	{
-		return NULL;
-	}
+		{
+			return NULL;
+		}
 
 	conn->host = strdup (host);
 	conn->user = strdup (user);
@@ -63,9 +64,9 @@ smm_connection_status
 smm_asset_connection_get_state (smm_connection connection)
 {
 	if (connection == NULL)
-	{
-		return SMM_CONNECTION_UNKNOWN;
-	}
+		{
+			return SMM_CONNECTION_UNKNOWN;
+		}
 	return connection->state;
 }
 
@@ -73,25 +74,25 @@ void
 smm_asset_connection_tls_verify_set (smm_connection connection, bool verify)
 {
 	if (connection != NULL)
-	{
-		pthread_mutex_lock (&connection->lock);
-		connection->verify_tls = verify;
-		pthread_mutex_unlock (&connection->lock);
-	}
+		{
+			pthread_mutex_lock (&connection->lock);
+			connection->verify_tls = verify;
+			pthread_mutex_unlock (&connection->lock);
+		}
 }
 
 void
 smm_connection_close (smm_connection connection)
 {
 	if (connection != NULL)
-	{
-		free (connection->host);
-		free (connection->user);
-		free (connection->pass);
-		free (connection->csrfmiddlewaretoken);
-		curl_easy_cleanup (connection->curl);
-		pthread_mutex_destroy(&connection->lock);
-	}
+		{
+			free (connection->host);
+			free (connection->user);
+			free (connection->pass);
+			free (connection->csrfmiddlewaretoken);
+			curl_easy_cleanup (connection->curl);
+			pthread_mutex_destroy (&connection->lock);
+		}
 	free (connection);
 }
 
@@ -109,7 +110,7 @@ smm_asset_create (smm_connection conn, const char *name, const char *type, long 
 }
 
 bool
-smm_parse_assets (smm_connection connection, const char *data, size_t len, smm_assets * assets, size_t * assets_count)
+smm_parse_assets (smm_connection connection, const char *data, size_t len, smm_assets *assets, size_t *assets_count)
 {
 	json_error_t json_error;
 	bool res = false;
@@ -120,88 +121,91 @@ smm_parse_assets (smm_connection connection, const char *data, size_t len, smm_a
 
 	json_t *json_root = json_loadb (data, len, 0, &json_error);
 	if (json_root)
-	{
-		json_t *json_assets = json_object_get (json_root, "assets");
-		if (json_is_array (json_assets))
 		{
-			size_t index = 0;
-			json_t *value = NULL;
+			json_t *json_assets = json_object_get (json_root, "assets");
+			if (json_is_array (json_assets))
+				{
+					size_t index = 0;
+					json_t *value = NULL;
 
-			json_array_foreach (json_assets, index, value)
-			{
-				const char *key = NULL;
-				json_t *val = NULL;
-				json_int_t asset_id = -1;
-				json_int_t asset_type_id = -1;
-				const char *name = NULL;
-				const char *type = NULL;
-				json_object_foreach (value, key, val)
-				{
-					if (strcmp (key, "id") == 0)
+					json_array_foreach (json_assets, index, value)
 					{
-						asset_id = json_integer_value (val);
+						const char *key = NULL;
+						json_t *val = NULL;
+						json_int_t asset_id = -1;
+						json_int_t asset_type_id = -1;
+						const char *name = NULL;
+						const char *type = NULL;
+						json_object_foreach (value, key, val)
+						{
+							if (strcmp (key, "id") == 0)
+								{
+									asset_id = json_integer_value (val);
+								}
+							else if (strcmp (key, "type_id") == 0)
+								{
+									asset_type_id = json_integer_value (val);
+								}
+							else if (strcmp (key, "name") == 0)
+								{
+									name = json_string_value (val);
+								}
+							else if (strcmp (key, "type_name") == 0)
+								{
+									type = json_string_value (val);
+								}
+						}
+						smm_asset new_asset = smm_asset_create (connection, name, type,
+											asset_id, asset_type_id);
+						if (new_asset)
+							{
+								smm_asset *tmp = realloc (
+								    *assets, (*assets_count + 1) * sizeof (smm_asset));
+								if (tmp)
+									{
+										*assets = tmp;
+										(*assets)[*assets_count] = new_asset;
+										*assets_count += 1;
+									}
+								else
+									{
+										smm_asset_free_asset (new_asset);
+									}
+							}
 					}
-					else if (strcmp (key, "type_id") == 0)
-					{
-						asset_type_id = json_integer_value (val);
-					}
-					else if (strcmp (key, "name") == 0)
-					{
-						name = json_string_value (val);
-					}
-					else if (strcmp (key, "type_name") == 0)
-					{
-						type = json_string_value (val);
-					}
+					res = true;
 				}
-				smm_asset new_asset = smm_asset_create (connection, name, type, asset_id, asset_type_id);
-				if (new_asset)
+			else
 				{
-					smm_asset *tmp = realloc (*assets, (*assets_count + 1) * sizeof (smm_asset));
-					if (tmp)
-					{
-						*assets = tmp;
-						(*assets)[*assets_count] = new_asset;
-						*assets_count += 1;
-					}
-					else
-					{
-						smm_asset_free_asset (new_asset);
-					}
+					DEBUG ("Didn't find assets array in JSON\n");
 				}
-			}
-			res = true;
+			json_decref (json_root);
 		}
-		else
-		{
-			DEBUG ("Didn't find assets array in JSON\n");
-		}
-		json_decref (json_root);
-	}
 	else
-	{
-		DEBUG ("JSON Parse Error on line %i: %s\n", json_error.line, json_error.text);
-	}
+		{
+			DEBUG ("JSON Parse Error on line %i: %s\n", json_error.line, json_error.text);
+		}
 
 	return res;
 }
 
 bool
-smm_asset_get_assets (smm_connection connection, smm_assets * assets, size_t * assets_count)
+smm_asset_get_assets (smm_connection connection, smm_assets *assets, size_t *assets_count)
 {
 	struct buffer_s buf = { NULL, 0 };
 
-	struct smm_curl_res_s *res = smm_connection_curl_retrieve_url (connection, "/assets/", NULL, to_buffer, &buf, true);
+	struct smm_curl_res_s *res
+	    = smm_connection_curl_retrieve_url (connection, "/assets/", NULL, to_buffer, &buf, true);
 	if (res == NULL)
-	{
-		return false;
-	}
+		{
+			return false;
+		}
 	if (!(res->success && res->httpcode == HTTP_SUCCESS))
-	{
-		smm_curl_res_free (res);
-		free (buf.data);
-		return false;
-	}
+		{
+			smm_curl_res_free (res);
+			free (buf.data);
+			return false;
+		}
 	smm_curl_res_free (res);
 
 	bool parse_res = smm_parse_assets (connection, buf.data, buf.bytes, assets, assets_count);
@@ -209,7 +213,6 @@ smm_asset_get_assets (smm_connection connection, smm_assets * assets, size_t * a
 	free (buf.data);
 	return parse_res;
 }
-
 
 void
 smm_asset_free_asset (smm_asset asset)
@@ -223,9 +226,9 @@ void
 smm_asset_free_assets (smm_assets assets, size_t assets_count)
 {
 	for (size_t i = 0; i < assets_count; i++)
-	{
-		smm_asset_free_asset (assets[i]);
-	}
+		{
+			smm_asset_free_asset (assets[i]);
+		}
 	free (assets);
 }
 
@@ -239,9 +242,9 @@ const char *
 smm_asset_name (smm_asset asset)
 {
 	if (asset)
-	{
-		return asset->name;
-	}
+		{
+			return asset->name;
+		}
 	return NULL;
 }
 
@@ -249,14 +252,14 @@ const char *
 smm_asset_type (smm_asset asset)
 {
 	if (asset)
-	{
-		return asset->type;
-	}
+		{
+			return asset->type;
+		}
 	return NULL;
 }
 
 bool
-smm_parse_command (const char *data, size_t len, smm_asset_command * command, double *lat, double *lon)
+smm_parse_command (const char *data, size_t len, smm_asset_command *command, double *lat, double *lon)
 {
 	json_error_t json_error;
 	bool res = false;
@@ -265,62 +268,62 @@ smm_parse_command (const char *data, size_t len, smm_asset_command * command, do
 
 	json_t *json_root = json_loadb (data, len, 0, &json_error);
 	if (json_root)
-	{
-		json_t *tmp = json_object_get (json_root, "action");
-		if (json_is_string (tmp))
 		{
-			const char *cmd_str = json_string_value (tmp);
-			if (cmd_str)
-			{
-				res = true;
-				if (strcmp (cmd_str, "GOTO") == 0)
+			json_t *tmp = json_object_get (json_root, "action");
+			if (json_is_string (tmp))
 				{
-					/* Get lat and long as well */
-					tmp = json_object_get (json_root, "latitude");
-					if (json_is_real (tmp))
-					{
-						*lat = json_real_value (tmp);
-					}
-					tmp = json_object_get (json_root, "longitude");
-					if (json_is_real (tmp))
-					{
-						*lon = json_real_value (tmp);
-					}
-					*command = SMM_COMMAND_GOTO;
+					const char *cmd_str = json_string_value (tmp);
+					if (cmd_str)
+						{
+							res = true;
+							if (strcmp (cmd_str, "GOTO") == 0)
+								{
+									/* Get lat and long as well */
+									tmp = json_object_get (json_root, "latitude");
+									if (json_is_real (tmp))
+										{
+											*lat = json_real_value (tmp);
+										}
+									tmp = json_object_get (json_root, "longitude");
+									if (json_is_real (tmp))
+										{
+											*lon = json_real_value (tmp);
+										}
+									*command = SMM_COMMAND_GOTO;
+								}
+							else if (strcmp (cmd_str, "RON") == 0)
+								{
+									*command = SMM_COMMAND_CONTINUE;
+								}
+							else if (strcmp (cmd_str, "RTL") == 0)
+								{
+									*command = SMM_COMMAND_RTL;
+								}
+							else if (strcmp (cmd_str, "CIR") == 0)
+								{
+									*command = SMM_COMMAND_CIRCLE;
+								}
+							else if (strcmp (cmd_str, "AS") == 0)
+								{
+									*command = SMM_COMMAND_ABANDON_SEARCH;
+								}
+							else if (strcmp (cmd_str, "MC") == 0)
+								{
+									*command = SMM_COMMAND_MISSION_COMPLETE;
+								}
+							else
+								{
+									*command = SMM_COMMAND_UNKNOWN;
+								}
+						}
 				}
-				else if (strcmp (cmd_str, "RON") == 0)
-				{
-					*command = SMM_COMMAND_CONTINUE;
-				}
-				else if (strcmp (cmd_str, "RTL") == 0)
-				{
-					*command = SMM_COMMAND_RTL;
-				}
-				else if (strcmp (cmd_str, "CIR") == 0)
-				{
-					*command = SMM_COMMAND_CIRCLE;
-				}
-				else if (strcmp (cmd_str, "AS") == 0)
-				{
-					*command = SMM_COMMAND_ABANDON_SEARCH;
-				}
-				else if (strcmp (cmd_str, "MC") == 0)
-				{
-					*command = SMM_COMMAND_MISSION_COMPLETE;
-				}
-				else
-				{
-					*command = SMM_COMMAND_UNKNOWN;
-				}
-			}
-		}
 
-		json_decref (json_root);
-	}
+			json_decref (json_root);
+		}
 	else
-	{
-		DEBUG ("JSON Parse Error on line %i: %s\n", json_error.line, json_error.text);
-	}
+		{
+			DEBUG ("JSON Parse Error on line %i: %s\n", json_error.line, json_error.text);
+		}
 
 	return res;
 }
@@ -328,9 +331,9 @@ smm_parse_command (const char *data, size_t len, smm_asset_command * command, do
 static bool
 smm_asset_update_command (smm_asset asset, struct buffer_s *buf)
 {
-	return smm_parse_command (buf->data, buf->bytes, &asset->last_command, &asset->last_command_lat, &asset->last_command_lon);
+	return smm_parse_command (buf->data, buf->bytes, &asset->last_command, &asset->last_command_lat,
+				  &asset->last_command_lon);
 }
-
 
 smm_asset_command
 smm_asset_last_command (smm_asset asset)
@@ -342,62 +345,63 @@ bool
 smm_asset_last_goto_pos (smm_asset asset, double *lat, double *lon)
 {
 	if (asset->last_command != SMM_COMMAND_GOTO)
-	{
-		return false;
-	}
+		{
+			return false;
+		}
 	if (lat == NULL || lon == NULL)
-	{
-		return false;
-	}
+		{
+			return false;
+		}
 	*lat = asset->last_command_lat;
 	*lon = asset->last_command_lon;
 	return true;
 }
 
-
 bool
-smm_asset_report_position (smm_asset asset, double latitude, double longitude, unsigned int altitude, uint16_t bearing, uint8_t fix)
+smm_asset_report_position (smm_asset asset, double latitude, double longitude, unsigned int altitude, uint16_t bearing,
+			   uint8_t fix)
 {
 	struct buffer_s buf = { NULL, 0 };
 
 	char *page = NULL;
-	if (asprintf (&page, "/data/assets/%lld/position/add/?lat=%lf&lon=%lf&alt=%u&bearing=%u&fix=%u", asset->asset_id, latitude, longitude, altitude, bearing, fix)
+	if (asprintf (&page, "/data/assets/%lld/position/add/?lat=%lf&lon=%lf&alt=%u&bearing=%u&fix=%u",
+		      asset->asset_id, latitude, longitude, altitude, bearing, fix)
 	    < 0)
-	{
-		return false;
-	}
+		{
+			return false;
+		}
 
 	struct smm_curl_res_s *res = smm_connection_curl_retrieve_url (asset->conn, page, NULL, to_buffer, &buf, false);
 	if (res == NULL)
-	{
-		free (page);
-		return false;
-	}
+		{
+			free (page);
+			return false;
+		}
 	if (!(res->success && res->httpcode == HTTP_SUCCESS))
-	{
-		smm_curl_res_free (res);
-		free (page);
-		return false;
-	}
+		{
+			smm_curl_res_free (res);
+			free (page);
+			return false;
+		}
 
 	free (page);
 
 	/* if json data was returned, update the current action */
 	if (res->content_type != NULL && strcmp (res->content_type, "application/json") == 0)
-	{
-		smm_asset_update_command (asset, &buf);
-	}
+		{
+			smm_asset_update_command (asset, &buf);
+		}
 	else
-	{
-		if (buf.data && strncmp (buf.data, "Continue", buf.bytes) == 0)
 		{
-			asset->last_command = SMM_COMMAND_CONTINUE;
+			if (buf.data && strncmp (buf.data, "Continue", buf.bytes) == 0)
+				{
+					asset->last_command = SMM_COMMAND_CONTINUE;
+				}
+			else
+				{
+					asset->last_command = SMM_COMMAND_NONE;
+				}
 		}
-		else
-		{
-			asset->last_command = SMM_COMMAND_NONE;
-		}
-	}
 
 	free (buf.data);
 
@@ -423,9 +427,9 @@ uint64_t
 smm_search_distance (smm_search search)
 {
 	if (search)
-	{
-		return search->distance;
-	}
+		{
+			return search->distance;
+		}
 	return 0;
 }
 
@@ -433,19 +437,19 @@ uint64_t
 smm_search_length (smm_search search)
 {
 	if (search)
-	{
-		return search->length;
-	}
+		{
+			return search->length;
+		}
 	return 0;
 }
 
 uint64_t
-smm_search_sweep_width(smm_search search)
+smm_search_sweep_width (smm_search search)
 {
 	if (search)
-	{
-		return search->sweep_width;
-	}
+		{
+			return search->sweep_width;
+		}
 	return 0;
 }
 
@@ -453,10 +457,10 @@ void
 smm_search_destroy (smm_search search)
 {
 	if (search)
-	{
-		free (search->url);
-		free (search);
-	}
+		{
+			free (search->url);
+			free (search);
+		}
 }
 
 static smm_waypoint
@@ -474,9 +478,8 @@ smm_waypoint_free (smm_waypoint waypoint)
 	free (waypoint);
 }
 
-
 bool
-smm_parse_waypoints (const char *data, size_t len, smm_waypoints * waypoints, size_t * waypoints_count)
+smm_parse_waypoints (const char *data, size_t len, smm_waypoints *waypoints, size_t *waypoints_count)
 {
 	json_error_t json_error;
 	bool res = false;
@@ -487,83 +490,99 @@ smm_parse_waypoints (const char *data, size_t len, smm_waypoints * waypoints, si
 
 	json_t *json_root = json_loadb (data, len, 0, &json_error);
 	if (json_root)
-	{
-		json_t *json_features = json_object_get (json_root, "features");
-		if (json_is_array (json_features))
 		{
-			if (json_array_size (json_features) == 1)
-			{
-				json_t *json_search = json_array_get (json_features, 0);
-				json_t *json_geometry = json_object_get (json_search, "geometry");
-				json_t *json_coords = json_object_get (json_geometry, "coordinates");
-				if (json_is_array (json_coords))
+			json_t *json_features = json_object_get (json_root, "features");
+			if (json_is_array (json_features))
 				{
-					size_t index = 0;
-					json_t *value = NULL;
-					json_array_foreach (json_coords, index, value)
-					{
-						double lat = 0.0;
-						double lon = 0.0;
-						json_t *json_lat = json_array_get (value, 1);
-						json_t *json_lon = json_array_get (value, 0);
-						lat = json_real_value (json_lat);
-						lon = json_real_value (json_lon);
-						smm_waypoint new_wp = smm_waypoint_create (lat, lon);
-						if (new_wp)
+					if (json_array_size (json_features) == 1)
 						{
-							smm_waypoint *tmp = realloc (*waypoints, (*waypoints_count + 1) * sizeof (smm_waypoint));
-							if (tmp)
-							{
-								*waypoints = tmp;
-								(*waypoints)[*waypoints_count] = new_wp;
-								*waypoints_count += 1;
-							}
-							else
-							{
-								smm_waypoint_free (new_wp);
-							}
+							json_t *json_search = json_array_get (json_features, 0);
+							json_t *json_geometry
+							    = json_object_get (json_search, "geometry");
+							json_t *json_coords
+							    = json_object_get (json_geometry, "coordinates");
+							if (json_is_array (json_coords))
+								{
+									size_t index = 0;
+									json_t *value = NULL;
+									json_array_foreach (json_coords, index, value)
+									{
+										double lat = 0.0;
+										double lon = 0.0;
+										json_t *json_lat
+										    = json_array_get (value, 1);
+										json_t *json_lon
+										    = json_array_get (value, 0);
+										lat = json_real_value (json_lat);
+										lon = json_real_value (json_lon);
+										smm_waypoint new_wp
+										    = smm_waypoint_create (lat, lon);
+										if (new_wp)
+											{
+												smm_waypoint *tmp = realloc (
+												    *waypoints,
+												    (*waypoints_count
+												     + 1)
+													* sizeof (
+													    smm_waypoint));
+												if (tmp)
+													{
+														*waypoints
+														    = tmp;
+														(*waypoints)
+														    [*waypoints_count]
+														    = new_wp;
+														*waypoints_count
+														    += 1;
+													}
+												else
+													{
+														smm_waypoint_free (
+														    new_wp);
+													}
+											}
+									}
+									res = true;
+								}
 						}
-					}
-					res = true;
+					else
+						{
+							DEBUG ("GeoJSON features array size != 1 (%zi)\n",
+							       json_array_size (json_features));
+						}
 				}
-			}
 			else
-			{
-				DEBUG ("GeoJSON features array size != 1 (%zi)\n", json_array_size (json_features));
-			}
+				{
+					DEBUG ("Didn't find features array in GeoJSON\n");
+				}
+			json_decref (json_root);
 		}
-		else
-		{
-			DEBUG ("Didn't find features array in GeoJSON\n");
-		}
-		json_decref (json_root);
-	}
 	else
-	{
-		DEBUG ("JSON Parse Error on line %i: %s\n", json_error.line, json_error.text);
-	}
+		{
+			DEBUG ("JSON Parse Error on line %i: %s\n", json_error.line, json_error.text);
+		}
 
 	return res;
 }
 
-
 bool
-smm_search_get_waypoints (smm_search search, smm_waypoints * waypoints, size_t * waypoints_count)
+smm_search_get_waypoints (smm_search search, smm_waypoints *waypoints, size_t *waypoints_count)
 {
 	struct buffer_s buf = { NULL, 0 };
 
-	struct smm_curl_res_s *res = smm_connection_curl_retrieve_url (search->asset->conn, search->url, NULL, to_buffer, &buf, true);
+	struct smm_curl_res_s *res
+	    = smm_connection_curl_retrieve_url (search->asset->conn, search->url, NULL, to_buffer, &buf, true);
 
 	if (res == NULL)
-	{
-		return false;
-	}
+		{
+			return false;
+		}
 	else if (!(res->success && res->httpcode == HTTP_SUCCESS))
-	{
-		smm_curl_res_free (res);
-		free (buf.data);
-		return false;
-	}
+		{
+			smm_curl_res_free (res);
+			free (buf.data);
+			return false;
+		}
 	smm_curl_res_free (res);
 
 	bool parse_res = smm_parse_waypoints (buf.data, buf.bytes, waypoints, waypoints_count);
@@ -579,25 +598,27 @@ smm_search_action (smm_search search, const char *action)
 	char *action_page = NULL;
 	struct buffer_s buf = { NULL, 0 };
 
-	if (asprintf (&action_page, "%s%s/?asset_id=%lli", search->url, action, smm_asset_get_asset_id (search->asset)) < 0)
-	{
-		return false;
-	}
+	if (asprintf (&action_page, "%s%s/?asset_id=%lli", search->url, action, smm_asset_get_asset_id (search->asset))
+	    < 0)
+		{
+			return false;
+		}
 	if (action_page == NULL)
-	{
-		return false;
-	}
+		{
+			return false;
+		}
 
-	struct smm_curl_res_s *res = smm_connection_curl_retrieve_url (search->asset->conn, action_page, NULL, to_buffer, &buf, false);
+	struct smm_curl_res_s *res
+	    = smm_connection_curl_retrieve_url (search->asset->conn, action_page, NULL, to_buffer, &buf, false);
 	if (res == NULL)
-	{
-		return false;
-	}
+		{
+			return false;
+		}
 	else if (!(res->success && res->httpcode == HTTP_SUCCESS))
-	{
-		smm_curl_res_free (res);
-		return false;
-	}
+		{
+			smm_curl_res_free (res);
+			return false;
+		}
 
 	smm_curl_res_free (res);
 	free (action_page);
@@ -624,9 +645,9 @@ void
 smm_waypoints_free (smm_waypoints waypoints, size_t waypoints_count)
 {
 	for (size_t i = 0; i < waypoints_count; i++)
-	{
-		smm_waypoint_free (waypoints[i]);
-	}
+		{
+			smm_waypoint_free (waypoints[i]);
+		}
 	free (waypoints);
 }
 
@@ -637,62 +658,64 @@ smm_asset_get_search (smm_asset asset, double latitude, double longitude)
 	struct buffer_s buf = { NULL, 0 };
 
 	char *page = NULL;
-	if (asprintf (&page, "/search/find/closest/?asset_id=%lli&latitude=%lf&longitude=%lf", asset->asset_id, latitude, longitude) < 0)
-	{
-		return NULL;
-	}
+	if (asprintf (&page, "/search/find/closest/?asset_id=%lli&latitude=%lf&longitude=%lf", asset->asset_id,
+		      latitude, longitude)
+	    < 0)
+		{
+			return NULL;
+		}
 
 	struct smm_curl_res_s *res = smm_connection_curl_retrieve_url (asset->conn, page, NULL, to_buffer, &buf, false);
 	if (res == NULL)
-	{
-		free (page);
-		return false;
-	}
+		{
+			free (page);
+			return false;
+		}
 	if (!(res->success && res->httpcode == HTTP_SUCCESS))
-	{
-		/* login and try again */
-		smm_curl_res_free (res);
-		free (page);
-		return false;
-	}
+		{
+			/* login and try again */
+			smm_curl_res_free (res);
+			free (page);
+			return false;
+		}
 	free (page);
 
 	if (res->content_type != NULL && strcmp (res->content_type, "application/json") == 0)
-	{
-		json_t *json_root = NULL;
-		json_error_t json_error;
-
-		json_root = json_loadb (buf.data, buf.bytes, 0, &json_error);
-		if (json_root)
 		{
-			const char *url = NULL;
-			uint64_t distance = 0;
-			uint64_t length = 0;
-			uint64_t sweep_width = 0;
-			json_t *tmp = json_object_get (json_root, "object_url");
-			if (tmp)
-			{
-				url = json_string_value (tmp);
-			}
-			tmp = json_object_get (json_root, "distance");
-			if (tmp)
-			{
-				distance = json_integer_value (tmp);
-			}
-			tmp = json_object_get (json_root, "length");
-			if (tmp)
-			{
-				length = json_integer_value (tmp);
-			}
-			tmp = json_object_get (json_root, "sweep_width");
-			if (tmp)
-			{
-				sweep_width = json_integer_value (tmp);
-			}
-			search = smm_search_create (asset, url, length, distance, sweep_width);
-			json_decref (json_root);
+			json_t *json_root = NULL;
+			json_error_t json_error;
+
+			json_root = json_loadb (buf.data, buf.bytes, 0, &json_error);
+			if (json_root)
+				{
+					const char *url = NULL;
+					uint64_t distance = 0;
+					uint64_t length = 0;
+					uint64_t sweep_width = 0;
+					json_t *tmp = json_object_get (json_root, "object_url");
+					if (tmp)
+						{
+							url = json_string_value (tmp);
+						}
+					tmp = json_object_get (json_root, "distance");
+					if (tmp)
+						{
+							distance = json_integer_value (tmp);
+						}
+					tmp = json_object_get (json_root, "length");
+					if (tmp)
+						{
+							length = json_integer_value (tmp);
+						}
+					tmp = json_object_get (json_root, "sweep_width");
+					if (tmp)
+						{
+							sweep_width = json_integer_value (tmp);
+						}
+					search = smm_search_create (asset, url, length, distance, sweep_width);
+					json_decref (json_root);
+				}
 		}
-	}
 	smm_curl_res_free (res);
 	free (buf.data);
 	return search;

--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -109,32 +109,20 @@ smm_asset_create (smm_connection conn, const char *name, const char *type, long 
 }
 
 bool
-smm_asset_get_assets (smm_connection connection, smm_assets * assets, size_t * assets_count)
+smm_parse_assets (smm_connection connection, const char *data, size_t len, smm_assets * assets, size_t * assets_count)
 {
-	struct buffer_s buf = { NULL, 0 };
 	json_error_t json_error;
-
-	struct smm_curl_res_s *res = smm_connection_curl_retrieve_url (connection, "/assets/", NULL, to_buffer, &buf, true);
-	if (res == NULL)
-	{
-		return false;
-	}
-	if (!(res->success && res->httpcode == HTTP_SUCCESS))
-	{
-		smm_curl_res_free (res);
-		return false;
-	}
-	smm_curl_res_free (res);
+	bool res = false;
 
 	/* Parse the assets */
 	*assets_count = 0;
 	*assets = NULL;
 
-	json_t *json_root = json_loadb (buf.data, buf.bytes, 0, &json_error);
+	json_t *json_root = json_loadb (data, len, 0, &json_error);
 	if (json_root)
 	{
 		json_t *json_assets = json_object_get (json_root, "assets");
-		if (json_assets)
+		if (json_is_array (json_assets))
 		{
 			size_t index = 0;
 			json_t *value = NULL;
@@ -165,38 +153,61 @@ smm_asset_get_assets (smm_connection connection, smm_assets * assets, size_t * a
 					{
 						type = json_string_value (val);
 					}
+				}
+				smm_asset new_asset = smm_asset_create (connection, name, type, asset_id, asset_type_id);
+				if (new_asset)
+				{
+					smm_asset *tmp = realloc (*assets, (*assets_count + 1) * sizeof (smm_asset));
+					if (tmp)
+					{
+						*assets = tmp;
+						(*assets)[*assets_count] = new_asset;
+						*assets_count += 1;
+					}
 					else
 					{
-						if (json_is_integer (val))
-						{
-							printf ("%s = %lli\n", key, json_integer_value (val));
-						}
-						else if (json_is_string (val))
-						{
-							printf ("%s = %s\n", key, json_string_value (val));
-						}
+						smm_asset_free_asset (new_asset);
 					}
 				}
-				*(assets_count) += 1;
-				*assets = realloc (*assets, *assets_count * sizeof (smm_asset));
-				(*assets)[(*assets_count) - 1] = smm_asset_create (connection, name, type, asset_id, asset_type_id);
 			}
+			res = true;
 		}
 		else
 		{
-			printf ("Didn't find assets\n");
+			DEBUG ("Didn't find assets array in JSON\n");
 		}
+		json_decref (json_root);
 	}
 	else
 	{
-		printf ("Error on line %i: %s\n", json_error.line, json_error.text);
+		DEBUG ("JSON Parse Error on line %i: %s\n", json_error.line, json_error.text);
 	}
 
-	json_decref (json_root);
+	return res;
+}
 
+bool
+smm_asset_get_assets (smm_connection connection, smm_assets * assets, size_t * assets_count)
+{
+	struct buffer_s buf = { NULL, 0 };
+
+	struct smm_curl_res_s *res = smm_connection_curl_retrieve_url (connection, "/assets/", NULL, to_buffer, &buf, true);
+	if (res == NULL)
+	{
+		return false;
+	}
+	if (!(res->success && res->httpcode == HTTP_SUCCESS))
+	{
+		smm_curl_res_free (res);
+		free (buf.data);
+		return false;
+	}
+	smm_curl_res_free (res);
+
+	bool parse_res = smm_parse_assets (connection, buf.data, buf.bytes, assets, assets_count);
 
 	free (buf.data);
-	return true;
+	return parse_res;
 }
 
 

--- a/src/smm-asset.h
+++ b/src/smm-asset.h
@@ -65,13 +65,13 @@ typedef struct smm_waypoint_s **smm_waypoints;
  */
 typedef enum
 {
-	SMM_CONNECTION_UNKNOWN,	/*!< Unknown state or invalid object */
-	SMM_CONNECTION_CONNECTED,	/*!< Currently connected */
-	SMM_CONNECTION_HOST_INVALID,	/*!< Host URL invalid, i.e. not http(s):// or not a valid domain */
-	SMM_CONNECTION_NO_HOST_CONNECTION,	/*!< Unable to connect to host */
-	SMM_CONNECTION_AUTHENTICATION_FAILURE,	/*!< Unable to authenticate with host */
-	SMM_CONNECTION_PROTOCOL_ERROR,	/*!< Unexpected response from host */
-	SMM_CONNECTION_FAILURE,	/*!< Unable to communicate, for another reason */
+	SMM_CONNECTION_UNKNOWN,		       /*!< Unknown state or invalid object */
+	SMM_CONNECTION_CONNECTED,	       /*!< Currently connected */
+	SMM_CONNECTION_HOST_INVALID,	       /*!< Host URL invalid, i.e. not http(s):// or not a valid domain */
+	SMM_CONNECTION_NO_HOST_CONNECTION,     /*!< Unable to connect to host */
+	SMM_CONNECTION_AUTHENTICATION_FAILURE, /*!< Unable to authenticate with host */
+	SMM_CONNECTION_PROTOCOL_ERROR,	       /*!< Unexpected response from host */
+	SMM_CONNECTION_FAILURE,		       /*!< Unable to communicate, for another reason */
 } smm_connection_status;
 
 /**
@@ -79,14 +79,14 @@ typedef enum
  */
 typedef enum
 {
-	SMM_COMMAND_NONE,	/*!< No restriction on current operation */
-	SMM_COMMAND_CIRCLE,	/*!< Circle/Hold at current position */
-	SMM_COMMAND_RTL,	/*!< Return to launch site */
-	SMM_COMMAND_GOTO,	/*!< Goto to the specified position */
-	SMM_COMMAND_CONTINUE,	/*!< Previous command revoked, resume own navigation */
-	SMM_COMMAND_ABANDON_SEARCH, /*!< Abandon the current search, expect reassignment */
+	SMM_COMMAND_NONE,	      /*!< No restriction on current operation */
+	SMM_COMMAND_CIRCLE,	      /*!< Circle/Hold at current position */
+	SMM_COMMAND_RTL,	      /*!< Return to launch site */
+	SMM_COMMAND_GOTO,	      /*!< Goto to the specified position */
+	SMM_COMMAND_CONTINUE,	      /*!< Previous command revoked, resume own navigation */
+	SMM_COMMAND_ABANDON_SEARCH,   /*!< Abandon the current search, expect reassignment */
 	SMM_COMMAND_MISSION_COMPLETE, /*!< The mission has concluded, return to base */
-	SMM_COMMAND_UNKNOWN,	/*!< The command from the server is not known */
+	SMM_COMMAND_UNKNOWN,	      /*!< The command from the server is not known */
 } smm_asset_command;
 
 /**
@@ -142,7 +142,7 @@ void smm_connection_close (smm_connection connection);
  *
  * @return true if assets were successfully retrieved (even if there are none), false if there was an error
  */
-bool smm_asset_get_assets (smm_connection connection, smm_assets * assets, size_t * assets_count);
+bool smm_asset_get_assets (smm_connection connection, smm_assets *assets, size_t *assets_count);
 
 /**
  * Free a set of assets
@@ -182,7 +182,8 @@ const char *smm_asset_type (smm_asset asset);
  *
  * @return true if the position was reported to the server
  */
-bool smm_asset_report_position (smm_asset asset, double latitude, double longitude, unsigned int altitude, uint16_t bearing, uint8_t fix);
+bool smm_asset_report_position (smm_asset asset, double latitude, double longitude, unsigned int altitude,
+				uint16_t bearing, uint8_t fix);
 
 /**
  * Get the last command we saw from the server
@@ -213,7 +214,8 @@ bool smm_asset_last_goto_pos (smm_asset asset, double *lat, double *lon);
  * @param latitude the current latitude of the asset in degrees
  * @param longitude the current longitude of the asset in degrees
  *
- * @return the closest or next queued search for this asset type, it will need to be accepted with @ref smm_search_accept before searching begins
+ * @return the closest or next queued search for this asset type, it will need to be accepted with @ref
+ * smm_search_accept before searching begins
  */
 smm_search smm_asset_get_search (smm_asset asset, double latitude, double longitude);
 
@@ -254,7 +256,7 @@ uint64_t smm_search_sweep_width (smm_search search);
  *
  * @return true if waypoints for the search were stored in waypoints
  */
-bool smm_search_get_waypoints (smm_search search, smm_waypoints * waypoints, size_t * waypoints_count);
+bool smm_search_get_waypoints (smm_search search, smm_waypoints *waypoints, size_t *waypoints_count);
 
 /**
  * Accept a search
@@ -263,7 +265,8 @@ bool smm_search_get_waypoints (smm_search search, smm_waypoints * waypoints, siz
  *
  * @param search the search to accept
  *
- * @return true if the server accepted this search begining, otherwise @ref smm_search_destory the search and @ref smm_asset_get_search again
+ * @return true if the server accepted this search begining, otherwise @ref smm_search_destory the search and @ref
+ * smm_asset_get_search again
  */
 bool smm_search_accept (smm_search search);
 

--- a/src/smm-asset.h
+++ b/src/smm-asset.h
@@ -70,6 +70,7 @@ typedef enum
 	SMM_CONNECTION_HOST_INVALID,	/*!< Host URL invalid, i.e. not http(s):// or not a valid domain */
 	SMM_CONNECTION_NO_HOST_CONNECTION,	/*!< Unable to connect to host */
 	SMM_CONNECTION_AUTHENTICATION_FAILURE,	/*!< Unable to authenticate with host */
+	SMM_CONNECTION_PROTOCOL_ERROR,	/*!< Unexpected response from host */
 	SMM_CONNECTION_FAILURE,	/*!< Unable to communicate, for another reason */
 } smm_connection_status;
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -7,3 +7,5 @@ check_smm_LDADD = $(top_builddir)/src/libsmmasset.la @CHECK_LIBS@
 integration_test_SOURCES = integration_test.c $(top_builddir)/src/smm-asset.h
 integration_test_CFLAGS = -I$(top_srcdir)/src
 integration_test_LDADD = $(top_builddir)/src/libsmmasset.la
+
+EXTRA_DIST = docker-compose.yml provision.sh

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,5 +1,9 @@
-TESTS = check_smm
-check_PROGRAMS = check_smm
+TESTS = check_smm integration_test
+check_PROGRAMS = check_smm integration_test
 check_smm_SOURCES = check_smm.c $(top_builddir)/src/smm-asset.h
 check_smm_CFLAGS = @CHECK_CFLAGS@ -I$(top_srcdir)/src
 check_smm_LDADD = $(top_builddir)/src/libsmmasset.la @CHECK_LIBS@
+
+integration_test_SOURCES = integration_test.c $(top_builddir)/src/smm-asset.h
+integration_test_CFLAGS = -I$(top_srcdir)/src
+integration_test_LDADD = $(top_builddir)/src/libsmmasset.la

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,0 +1,5 @@
+TESTS = check_smm
+check_PROGRAMS = check_smm
+check_smm_SOURCES = check_smm.c $(top_builddir)/src/smm-asset.h
+check_smm_CFLAGS = @CHECK_CFLAGS@ -I$(top_srcdir)/src
+check_smm_LDADD = $(top_builddir)/src/libsmmasset.la @CHECK_LIBS@

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -1,7 +1,9 @@
 #include "smm-asset-internal.h"
 #include "smm-asset.h"
 #include <check.h>
+#include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 START_TEST (test_csrf_extraction)
 {

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -123,6 +123,24 @@ START_TEST(test_command_parsing_unknown)
 }
 END_TEST
 
+START_TEST(test_waypoint_parsing)
+{
+    const char *json = "{\"features\": [{\"geometry\": {\"coordinates\": [[172.6, -43.5], [172.7, -43.6]]}}]}";
+    smm_waypoints waypoints;
+    size_t count;
+    bool res = smm_parse_waypoints(json, strlen(json), &waypoints, &count);
+    
+    ck_assert_uint_eq(res, true);
+    ck_assert_uint_eq(count, 2);
+    ck_assert_ldouble_eq_tol(waypoints[0]->lat, -43.5, 0.0001);
+    ck_assert_ldouble_eq_tol(waypoints[0]->lon, 172.6, 0.0001);
+    ck_assert_ldouble_eq_tol(waypoints[1]->lat, -43.6, 0.0001);
+    ck_assert_ldouble_eq_tol(waypoints[1]->lon, 172.7, 0.0001);
+    
+    smm_waypoints_free(waypoints, count);
+}
+END_TEST
+
 Suite * smm_suite(void)
 {
     Suite *s;
@@ -148,6 +166,10 @@ Suite * smm_suite(void)
     tcase_add_test(tc_commands, test_command_parsing_rtl);
     tcase_add_test(tc_commands, test_command_parsing_unknown);
     suite_add_tcase(s, tc_commands);
+
+    TCase *tc_waypoints = tcase_create("Waypoints");
+    tcase_add_test(tc_waypoints, test_waypoint_parsing);
+    suite_add_tcase(s, tc_waypoints);
 
     return s;
 }

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -1,25 +1,60 @@
 #include <stdlib.h>
 #include <check.h>
 #include "smm-asset.h"
+#include "smm-asset-internal.h"
 
-START_TEST(test_placeholder)
+START_TEST(test_csrf_extraction)
 {
-    ck_assert_int_eq(1, 1);
+    const char *html = "<html><body><input type=\"hidden\" name=\"csrfmiddlewaretoken\" value=\"abcd1234\"></body></html>";
+    char *token = smm_parse_csrf_token(html, strlen(html));
+    ck_assert_ptr_nonnull(token);
+    ck_assert_str_eq(token, "abcd1234");
+    free(token);
+}
+END_TEST
+
+START_TEST(test_csrf_extraction_missing)
+{
+    const char *html = "<html><body><input type=\"hidden\" name=\"somethingelse\" value=\"abcd1234\"></body></html>";
+    char *token = smm_parse_csrf_token(html, strlen(html));
+    ck_assert_ptr_null(token);
+}
+END_TEST
+
+START_TEST(test_csrf_extraction_invalid_chars)
+{
+    const char *html = "<html><body><input type=\"hidden\" name=\"csrfmiddlewaretoken\" value=\"abcd!@#$\"></body></html>";
+    char *token = smm_parse_csrf_token(html, strlen(html));
+    ck_assert_ptr_null(token);
+}
+END_TEST
+
+START_TEST(test_csrf_extraction_too_long)
+{
+    char html[1024];
+    char value[300];
+    memset(value, 'a', 299);
+    value[299] = '\0';
+    snprintf(html, sizeof(html), "<html><body><input type=\"hidden\" name=\"csrfmiddlewaretoken\" value=\"%s\"></body></html>", value);
+    
+    char *token = smm_parse_csrf_token(html, strlen(html));
+    ck_assert_ptr_null(token);
 }
 END_TEST
 
 Suite * smm_suite(void)
 {
     Suite *s;
-    TCase *tc_core;
+    TCase *tc_csrf;
 
     s = suite_create("SMM");
 
-    /* Core test case */
-    tc_core = tcase_create("Core");
-
-    tcase_add_test(tc_core, test_placeholder);
-    suite_add_tcase(s, tc_core);
+    tc_csrf = tcase_create("CSRF");
+    tcase_add_test(tc_csrf, test_csrf_extraction);
+    tcase_add_test(tc_csrf, test_csrf_extraction_missing);
+    tcase_add_test(tc_csrf, test_csrf_extraction_invalid_chars);
+    tcase_add_test(tc_csrf, test_csrf_extraction_too_long);
+    suite_add_tcase(s, tc_csrf);
 
     return s;
 }

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -1,190 +1,197 @@
-#include <stdlib.h>
-#include <check.h>
-#include "smm-asset.h"
 #include "smm-asset-internal.h"
+#include "smm-asset.h"
+#include <check.h>
+#include <stdlib.h>
 
-START_TEST(test_csrf_extraction)
+START_TEST (test_csrf_extraction)
 {
-    const char *html = "<html><body><input type=\"hidden\" name=\"csrfmiddlewaretoken\" value=\"abcd1234\"></body></html>";
-    char *token = smm_parse_csrf_token(html, strlen(html));
-    ck_assert_ptr_nonnull(token);
-    ck_assert_str_eq(token, "abcd1234");
-    free(token);
+	const char *html
+	    = "<html><body><input type=\"hidden\" name=\"csrfmiddlewaretoken\" value=\"abcd1234\"></body></html>";
+	char *token = smm_parse_csrf_token (html, strlen (html));
+	ck_assert_ptr_nonnull (token);
+	ck_assert_str_eq (token, "abcd1234");
+	free (token);
 }
 END_TEST
 
-START_TEST(test_csrf_extraction_missing)
+START_TEST (test_csrf_extraction_missing)
 {
-    const char *html = "<html><body><input type=\"hidden\" name=\"somethingelse\" value=\"abcd1234\"></body></html>";
-    char *token = smm_parse_csrf_token(html, strlen(html));
-    ck_assert_ptr_null(token);
+	const char *html
+	    = "<html><body><input type=\"hidden\" name=\"somethingelse\" value=\"abcd1234\"></body></html>";
+	char *token = smm_parse_csrf_token (html, strlen (html));
+	ck_assert_ptr_null (token);
 }
 END_TEST
 
-START_TEST(test_csrf_extraction_invalid_chars)
+START_TEST (test_csrf_extraction_invalid_chars)
 {
-    const char *html = "<html><body><input type=\"hidden\" name=\"csrfmiddlewaretoken\" value=\"abcd!@#$\"></body></html>";
-    char *token = smm_parse_csrf_token(html, strlen(html));
-    ck_assert_ptr_null(token);
+	const char *html
+	    = "<html><body><input type=\"hidden\" name=\"csrfmiddlewaretoken\" value=\"abcd!@#$\"></body></html>";
+	char *token = smm_parse_csrf_token (html, strlen (html));
+	ck_assert_ptr_null (token);
 }
 END_TEST
 
-START_TEST(test_csrf_extraction_too_long)
+START_TEST (test_csrf_extraction_too_long)
 {
-    char html[1024];
-    char value[300];
-    memset(value, 'a', 299);
-    value[299] = '\0';
-    snprintf(html, sizeof(html), "<html><body><input type=\"hidden\" name=\"csrfmiddlewaretoken\" value=\"%s\"></body></html>", value);
-    
-    char *token = smm_parse_csrf_token(html, strlen(html));
-    ck_assert_ptr_null(token);
+	char html[1024];
+	char value[300];
+	memset (value, 'a', 299);
+	value[299] = '\0';
+	snprintf (html, sizeof (html),
+		  "<html><body><input type=\"hidden\" name=\"csrfmiddlewaretoken\" value=\"%s\"></body></html>", value);
+
+	char *token = smm_parse_csrf_token (html, strlen (html));
+	ck_assert_ptr_null (token);
 }
 END_TEST
 
-START_TEST(test_assets_parsing)
+START_TEST (test_assets_parsing)
 {
-    const char *json = "{\"assets\": [{\"id\": 1, \"type_id\": 2, \"name\": \"Asset 1\", \"type_name\": \"Type 1\"}, {\"id\": 3, \"type_id\": 4, \"name\": \"Asset 2\", \"type_name\": \"Type 2\"}]}";
-    smm_assets assets;
-    size_t count;
-    bool res = smm_parse_assets(NULL, json, strlen(json), &assets, &count);
-    
-    ck_assert_uint_eq(res, true);
-    ck_assert_uint_eq(count, 2);
-    ck_assert_str_eq(smm_asset_name(assets[0]), "Asset 1");
-    ck_assert_str_eq(smm_asset_type(assets[0]), "Type 1");
-    ck_assert_str_eq(smm_asset_name(assets[1]), "Asset 2");
-    ck_assert_str_eq(smm_asset_type(assets[1]), "Type 2");
-    
-    smm_asset_free_assets(assets, count);
+	const char *json = "{\"assets\": [{\"id\": 1, \"type_id\": 2, \"name\": \"Asset 1\", \"type_name\": \"Type "
+			   "1\"}, {\"id\": 3, \"type_id\": 4, \"name\": \"Asset 2\", \"type_name\": \"Type 2\"}]}";
+	smm_assets assets;
+	size_t count;
+	bool res = smm_parse_assets (NULL, json, strlen (json), &assets, &count);
+
+	ck_assert_uint_eq (res, true);
+	ck_assert_uint_eq (count, 2);
+	ck_assert_str_eq (smm_asset_name (assets[0]), "Asset 1");
+	ck_assert_str_eq (smm_asset_type (assets[0]), "Type 1");
+	ck_assert_str_eq (smm_asset_name (assets[1]), "Asset 2");
+	ck_assert_str_eq (smm_asset_type (assets[1]), "Type 2");
+
+	smm_asset_free_assets (assets, count);
 }
 END_TEST
 
-START_TEST(test_assets_parsing_empty)
+START_TEST (test_assets_parsing_empty)
 {
-    const char *json = "{\"assets\": []}";
-    smm_assets assets;
-    size_t count;
-    bool res = smm_parse_assets(NULL, json, strlen(json), &assets, &count);
-    
-    ck_assert_uint_eq(res, true);
-    ck_assert_uint_eq(count, 0);
-    ck_assert_ptr_null(assets);
+	const char *json = "{\"assets\": []}";
+	smm_assets assets;
+	size_t count;
+	bool res = smm_parse_assets (NULL, json, strlen (json), &assets, &count);
+
+	ck_assert_uint_eq (res, true);
+	ck_assert_uint_eq (count, 0);
+	ck_assert_ptr_null (assets);
 }
 END_TEST
 
-START_TEST(test_assets_parsing_invalid)
+START_TEST (test_assets_parsing_invalid)
 {
-    const char *json = "{\"not_assets\": []}";
-    smm_assets assets;
-    size_t count;
-    bool res = smm_parse_assets(NULL, json, strlen(json), &assets, &count);
-    
-    ck_assert_uint_eq(res, false);
-    ck_assert_uint_eq(count, 0);
+	const char *json = "{\"not_assets\": []}";
+	smm_assets assets;
+	size_t count;
+	bool res = smm_parse_assets (NULL, json, strlen (json), &assets, &count);
+
+	ck_assert_uint_eq (res, false);
+	ck_assert_uint_eq (count, 0);
 }
 END_TEST
 
-START_TEST(test_command_parsing_goto)
+START_TEST (test_command_parsing_goto)
 {
-    const char *json = "{\"action\": \"GOTO\", \"latitude\": -43.5, \"longitude\": 172.6}";
-    smm_asset_command cmd;
-    double lat = 0, lon = 0;
-    bool res = smm_parse_command(json, strlen(json), &cmd, &lat, &lon);
-    
-    ck_assert_uint_eq(res, true);
-    ck_assert_int_eq(cmd, SMM_COMMAND_GOTO);
-    ck_assert_ldouble_eq_tol(lat, -43.5, 0.0001);
-    ck_assert_ldouble_eq_tol(lon, 172.6, 0.0001);
+	const char *json = "{\"action\": \"GOTO\", \"latitude\": -43.5, \"longitude\": 172.6}";
+	smm_asset_command cmd;
+	double lat = 0, lon = 0;
+	bool res = smm_parse_command (json, strlen (json), &cmd, &lat, &lon);
+
+	ck_assert_uint_eq (res, true);
+	ck_assert_int_eq (cmd, SMM_COMMAND_GOTO);
+	ck_assert_ldouble_eq_tol (lat, -43.5, 0.0001);
+	ck_assert_ldouble_eq_tol (lon, 172.6, 0.0001);
 }
 END_TEST
 
-START_TEST(test_command_parsing_rtl)
+START_TEST (test_command_parsing_rtl)
 {
-    const char *json = "{\"action\": \"RTL\"}";
-    smm_asset_command cmd;
-    double lat = 0, lon = 0;
-    bool res = smm_parse_command(json, strlen(json), &cmd, &lat, &lon);
-    
-    ck_assert_uint_eq(res, true);
-    ck_assert_int_eq(cmd, SMM_COMMAND_RTL);
+	const char *json = "{\"action\": \"RTL\"}";
+	smm_asset_command cmd;
+	double lat = 0, lon = 0;
+	bool res = smm_parse_command (json, strlen (json), &cmd, &lat, &lon);
+
+	ck_assert_uint_eq (res, true);
+	ck_assert_int_eq (cmd, SMM_COMMAND_RTL);
 }
 END_TEST
 
-START_TEST(test_command_parsing_unknown)
+START_TEST (test_command_parsing_unknown)
 {
-    const char *json = "{\"action\": \"INVALID\"}";
-    smm_asset_command cmd;
-    double lat = 0, lon = 0;
-    bool res = smm_parse_command(json, strlen(json), &cmd, &lat, &lon);
-    
-    ck_assert_uint_eq(res, true);
-    ck_assert_int_eq(cmd, SMM_COMMAND_UNKNOWN);
+	const char *json = "{\"action\": \"INVALID\"}";
+	smm_asset_command cmd;
+	double lat = 0, lon = 0;
+	bool res = smm_parse_command (json, strlen (json), &cmd, &lat, &lon);
+
+	ck_assert_uint_eq (res, true);
+	ck_assert_int_eq (cmd, SMM_COMMAND_UNKNOWN);
 }
 END_TEST
 
-START_TEST(test_waypoint_parsing)
+START_TEST (test_waypoint_parsing)
 {
-    const char *json = "{\"features\": [{\"geometry\": {\"coordinates\": [[172.6, -43.5], [172.7, -43.6]]}}]}";
-    smm_waypoints waypoints;
-    size_t count;
-    bool res = smm_parse_waypoints(json, strlen(json), &waypoints, &count);
-    
-    ck_assert_uint_eq(res, true);
-    ck_assert_uint_eq(count, 2);
-    ck_assert_ldouble_eq_tol(waypoints[0]->lat, -43.5, 0.0001);
-    ck_assert_ldouble_eq_tol(waypoints[0]->lon, 172.6, 0.0001);
-    ck_assert_ldouble_eq_tol(waypoints[1]->lat, -43.6, 0.0001);
-    ck_assert_ldouble_eq_tol(waypoints[1]->lon, 172.7, 0.0001);
-    
-    smm_waypoints_free(waypoints, count);
+	const char *json = "{\"features\": [{\"geometry\": {\"coordinates\": [[172.6, -43.5], [172.7, -43.6]]}}]}";
+	smm_waypoints waypoints;
+	size_t count;
+	bool res = smm_parse_waypoints (json, strlen (json), &waypoints, &count);
+
+	ck_assert_uint_eq (res, true);
+	ck_assert_uint_eq (count, 2);
+	ck_assert_ldouble_eq_tol (waypoints[0]->lat, -43.5, 0.0001);
+	ck_assert_ldouble_eq_tol (waypoints[0]->lon, 172.6, 0.0001);
+	ck_assert_ldouble_eq_tol (waypoints[1]->lat, -43.6, 0.0001);
+	ck_assert_ldouble_eq_tol (waypoints[1]->lon, 172.7, 0.0001);
+
+	smm_waypoints_free (waypoints, count);
 }
 END_TEST
 
-Suite * smm_suite(void)
+Suite *
+smm_suite (void)
 {
-    Suite *s;
-    TCase *tc_csrf;
+	Suite *s;
+	TCase *tc_csrf;
 
-    s = suite_create("SMM");
+	s = suite_create ("SMM");
 
-    tc_csrf = tcase_create("CSRF");
-    tcase_add_test(tc_csrf, test_csrf_extraction);
-    tcase_add_test(tc_csrf, test_csrf_extraction_missing);
-    tcase_add_test(tc_csrf, test_csrf_extraction_invalid_chars);
-    tcase_add_test(tc_csrf, test_csrf_extraction_too_long);
-    suite_add_tcase(s, tc_csrf);
+	tc_csrf = tcase_create ("CSRF");
+	tcase_add_test (tc_csrf, test_csrf_extraction);
+	tcase_add_test (tc_csrf, test_csrf_extraction_missing);
+	tcase_add_test (tc_csrf, test_csrf_extraction_invalid_chars);
+	tcase_add_test (tc_csrf, test_csrf_extraction_too_long);
+	suite_add_tcase (s, tc_csrf);
 
-    TCase *tc_assets = tcase_create("Assets");
-    tcase_add_test(tc_assets, test_assets_parsing);
-    tcase_add_test(tc_assets, test_assets_parsing_empty);
-    tcase_add_test(tc_assets, test_assets_parsing_invalid);
-    suite_add_tcase(s, tc_assets);
+	TCase *tc_assets = tcase_create ("Assets");
+	tcase_add_test (tc_assets, test_assets_parsing);
+	tcase_add_test (tc_assets, test_assets_parsing_empty);
+	tcase_add_test (tc_assets, test_assets_parsing_invalid);
+	suite_add_tcase (s, tc_assets);
 
-    TCase *tc_commands = tcase_create("Commands");
-    tcase_add_test(tc_commands, test_command_parsing_goto);
-    tcase_add_test(tc_commands, test_command_parsing_rtl);
-    tcase_add_test(tc_commands, test_command_parsing_unknown);
-    suite_add_tcase(s, tc_commands);
+	TCase *tc_commands = tcase_create ("Commands");
+	tcase_add_test (tc_commands, test_command_parsing_goto);
+	tcase_add_test (tc_commands, test_command_parsing_rtl);
+	tcase_add_test (tc_commands, test_command_parsing_unknown);
+	suite_add_tcase (s, tc_commands);
 
-    TCase *tc_waypoints = tcase_create("Waypoints");
-    tcase_add_test(tc_waypoints, test_waypoint_parsing);
-    suite_add_tcase(s, tc_waypoints);
+	TCase *tc_waypoints = tcase_create ("Waypoints");
+	tcase_add_test (tc_waypoints, test_waypoint_parsing);
+	suite_add_tcase (s, tc_waypoints);
 
-    return s;
+	return s;
 }
 
-int main(void)
+int
+main (void)
 {
-    int number_failed;
-    Suite *s;
-    SRunner *sr;
+	int number_failed;
+	Suite *s;
+	SRunner *sr;
 
-    s = smm_suite();
-    sr = srunner_create(s);
+	s = smm_suite ();
+	sr = srunner_create (s);
 
-    srunner_run_all(sr, CK_NORMAL);
-    number_failed = srunner_ntests_failed(sr);
-    srunner_free(sr);
-    return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+	srunner_run_all (sr, CK_NORMAL);
+	number_failed = srunner_ntests_failed (sr);
+	srunner_free (sr);
+	return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -42,6 +42,49 @@ START_TEST(test_csrf_extraction_too_long)
 }
 END_TEST
 
+START_TEST(test_assets_parsing)
+{
+    const char *json = "{\"assets\": [{\"id\": 1, \"type_id\": 2, \"name\": \"Asset 1\", \"type_name\": \"Type 1\"}, {\"id\": 3, \"type_id\": 4, \"name\": \"Asset 2\", \"type_name\": \"Type 2\"}]}";
+    smm_assets assets;
+    size_t count;
+    bool res = smm_parse_assets(NULL, json, strlen(json), &assets, &count);
+    
+    ck_assert_uint_eq(res, true);
+    ck_assert_uint_eq(count, 2);
+    ck_assert_str_eq(smm_asset_name(assets[0]), "Asset 1");
+    ck_assert_str_eq(smm_asset_type(assets[0]), "Type 1");
+    ck_assert_str_eq(smm_asset_name(assets[1]), "Asset 2");
+    ck_assert_str_eq(smm_asset_type(assets[1]), "Type 2");
+    
+    smm_asset_free_assets(assets, count);
+}
+END_TEST
+
+START_TEST(test_assets_parsing_empty)
+{
+    const char *json = "{\"assets\": []}";
+    smm_assets assets;
+    size_t count;
+    bool res = smm_parse_assets(NULL, json, strlen(json), &assets, &count);
+    
+    ck_assert_uint_eq(res, true);
+    ck_assert_uint_eq(count, 0);
+    ck_assert_ptr_null(assets);
+}
+END_TEST
+
+START_TEST(test_assets_parsing_invalid)
+{
+    const char *json = "{\"not_assets\": []}";
+    smm_assets assets;
+    size_t count;
+    bool res = smm_parse_assets(NULL, json, strlen(json), &assets, &count);
+    
+    ck_assert_uint_eq(res, false);
+    ck_assert_uint_eq(count, 0);
+}
+END_TEST
+
 Suite * smm_suite(void)
 {
     Suite *s;
@@ -55,6 +98,12 @@ Suite * smm_suite(void)
     tcase_add_test(tc_csrf, test_csrf_extraction_invalid_chars);
     tcase_add_test(tc_csrf, test_csrf_extraction_too_long);
     suite_add_tcase(s, tc_csrf);
+
+    TCase *tc_assets = tcase_create("Assets");
+    tcase_add_test(tc_assets, test_assets_parsing);
+    tcase_add_test(tc_assets, test_assets_parsing_empty);
+    tcase_add_test(tc_assets, test_assets_parsing_invalid);
+    suite_add_tcase(s, tc_assets);
 
     return s;
 }

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -85,6 +85,44 @@ START_TEST(test_assets_parsing_invalid)
 }
 END_TEST
 
+START_TEST(test_command_parsing_goto)
+{
+    const char *json = "{\"action\": \"GOTO\", \"latitude\": -43.5, \"longitude\": 172.6}";
+    smm_asset_command cmd;
+    double lat = 0, lon = 0;
+    bool res = smm_parse_command(json, strlen(json), &cmd, &lat, &lon);
+    
+    ck_assert_uint_eq(res, true);
+    ck_assert_int_eq(cmd, SMM_COMMAND_GOTO);
+    ck_assert_ldouble_eq_tol(lat, -43.5, 0.0001);
+    ck_assert_ldouble_eq_tol(lon, 172.6, 0.0001);
+}
+END_TEST
+
+START_TEST(test_command_parsing_rtl)
+{
+    const char *json = "{\"action\": \"RTL\"}";
+    smm_asset_command cmd;
+    double lat = 0, lon = 0;
+    bool res = smm_parse_command(json, strlen(json), &cmd, &lat, &lon);
+    
+    ck_assert_uint_eq(res, true);
+    ck_assert_int_eq(cmd, SMM_COMMAND_RTL);
+}
+END_TEST
+
+START_TEST(test_command_parsing_unknown)
+{
+    const char *json = "{\"action\": \"INVALID\"}";
+    smm_asset_command cmd;
+    double lat = 0, lon = 0;
+    bool res = smm_parse_command(json, strlen(json), &cmd, &lat, &lon);
+    
+    ck_assert_uint_eq(res, true);
+    ck_assert_int_eq(cmd, SMM_COMMAND_UNKNOWN);
+}
+END_TEST
+
 Suite * smm_suite(void)
 {
     Suite *s;
@@ -104,6 +142,12 @@ Suite * smm_suite(void)
     tcase_add_test(tc_assets, test_assets_parsing_empty);
     tcase_add_test(tc_assets, test_assets_parsing_invalid);
     suite_add_tcase(s, tc_assets);
+
+    TCase *tc_commands = tcase_create("Commands");
+    tcase_add_test(tc_commands, test_command_parsing_goto);
+    tcase_add_test(tc_commands, test_command_parsing_rtl);
+    tcase_add_test(tc_commands, test_command_parsing_unknown);
+    suite_add_tcase(s, tc_commands);
 
     return s;
 }

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -1,0 +1,40 @@
+#include <stdlib.h>
+#include <check.h>
+#include "smm-asset.h"
+
+START_TEST(test_placeholder)
+{
+    ck_assert_int_eq(1, 1);
+}
+END_TEST
+
+Suite * smm_suite(void)
+{
+    Suite *s;
+    TCase *tc_core;
+
+    s = suite_create("SMM");
+
+    /* Core test case */
+    tc_core = tcase_create("Core");
+
+    tcase_add_test(tc_core, test_placeholder);
+    suite_add_tcase(s, tc_core);
+
+    return s;
+}
+
+int main(void)
+{
+    int number_failed;
+    Suite *s;
+    SRunner *sr;
+
+    s = smm_suite();
+    sr = srunner_create(s);
+
+    srunner_run_all(sr, CK_NORMAL);
+    number_failed = srunner_ntests_failed(sr);
+    srunner_free(sr);
+    return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,0 +1,28 @@
+services:
+  smm:
+    image: canterburyairpatrol/search-management-map:latest
+    ports:
+      - "8000:8080"
+    environment:
+      - DB_HOST=db
+      - DB_USER=smm
+      - DB_PASS=smmpass
+      - DB_NAME=smm
+      - DEBUG=True
+      - SECRET_KEY=test-secret-key
+      - ALLOWED_HOSTS=localhost,smm
+    depends_on:
+      db:
+        condition: service_healthy
+
+  db:
+    image: postgis/postgis:18-3.6
+    environment:
+      - POSTGRES_DB=smm
+      - POSTGRES_USER=smm
+      - POSTGRES_PASSWORD=smmpass
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U smm"]
+      interval: 5s
+      timeout: 5s
+      retries: 5

--- a/tests/integration_test.c
+++ b/tests/integration_test.c
@@ -1,0 +1,42 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+#include "smm-asset.h"
+
+int main(void)
+{
+    smm_connection conn;
+    smm_assets assets;
+    size_t count;
+    bool res;
+
+    smm_asset_debugging_set(true);
+    printf("Connecting to local SMM...\n");
+    conn = smm_asset_connect("http://localhost:8000", "testuser", "testpass");
+    if (!conn) {
+        fprintf(stderr, "Failed to create connection object\n");
+        return 1;
+    }
+
+    printf("Retrieving assets...\n");
+    res = smm_asset_get_assets(conn, &assets, &count);
+    if (!res) {
+        fprintf(stderr, "Failed to get assets\n");
+        smm_connection_close(conn);
+        return 1;
+    }
+
+    printf("Found %zu assets\n", count);
+    assert(count > 0);
+
+    for (size_t i = 0; i < count; i++) {
+        printf("Asset: %s (%s)\n", smm_asset_name(assets[i]), smm_asset_type(assets[i]));
+    }
+
+    smm_asset_free_assets(assets, count);
+    smm_connection_close(conn);
+
+    printf("Integration test passed!\n");
+    return 0;
+}

--- a/tests/integration_test.c
+++ b/tests/integration_test.c
@@ -11,10 +11,25 @@ main (void)
 	smm_assets assets;
 	size_t count;
 	bool res;
+	const char *host;
+	const char *user;
+	const char *pass;
+
+	host = getenv ("SMM_HOST");
+	if (!host)
+		host = "http://localhost:8000";
+
+	user = getenv ("SMM_USER");
+	if (!user)
+		user = "testuser";
+
+	pass = getenv ("SMM_PASS");
+	if (!pass)
+		pass = "testpass";
 
 	smm_asset_debugging_set (true);
-	printf ("Connecting to local SMM...\n");
-	conn = smm_asset_connect ("http://localhost:8000", "testuser", "testpass");
+	printf ("Connecting to SMM at %s...\n", host);
+	conn = smm_asset_connect (host, user, pass);
 	if (!conn)
 		{
 			fprintf (stderr, "Failed to create connection object\n");

--- a/tests/integration_test.c
+++ b/tests/integration_test.c
@@ -1,42 +1,46 @@
+#include "smm-asset.h"
+#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <assert.h>
-#include "smm-asset.h"
 
-int main(void)
+int
+main (void)
 {
-    smm_connection conn;
-    smm_assets assets;
-    size_t count;
-    bool res;
+	smm_connection conn;
+	smm_assets assets;
+	size_t count;
+	bool res;
 
-    smm_asset_debugging_set(true);
-    printf("Connecting to local SMM...\n");
-    conn = smm_asset_connect("http://localhost:8000", "testuser", "testpass");
-    if (!conn) {
-        fprintf(stderr, "Failed to create connection object\n");
-        return 1;
-    }
+	smm_asset_debugging_set (true);
+	printf ("Connecting to local SMM...\n");
+	conn = smm_asset_connect ("http://localhost:8000", "testuser", "testpass");
+	if (!conn)
+		{
+			fprintf (stderr, "Failed to create connection object\n");
+			return 1;
+		}
 
-    printf("Retrieving assets...\n");
-    res = smm_asset_get_assets(conn, &assets, &count);
-    if (!res) {
-        fprintf(stderr, "Failed to get assets\n");
-        smm_connection_close(conn);
-        return 1;
-    }
+	printf ("Retrieving assets...\n");
+	res = smm_asset_get_assets (conn, &assets, &count);
+	if (!res)
+		{
+			fprintf (stderr, "Failed to get assets\n");
+			smm_connection_close (conn);
+			return 1;
+		}
 
-    printf("Found %zu assets\n", count);
-    assert(count > 0);
+	printf ("Found %zu assets\n", count);
+	assert (count > 0);
 
-    for (size_t i = 0; i < count; i++) {
-        printf("Asset: %s (%s)\n", smm_asset_name(assets[i]), smm_asset_type(assets[i]));
-    }
+	for (size_t i = 0; i < count; i++)
+		{
+			printf ("Asset: %s (%s)\n", smm_asset_name (assets[i]), smm_asset_type (assets[i]));
+		}
 
-    smm_asset_free_assets(assets, count);
-    smm_connection_close(conn);
+	smm_asset_free_assets (assets, count);
+	smm_connection_close (conn);
 
-    printf("Integration test passed!\n");
-    return 0;
+	printf ("Integration test passed!\n");
+	return 0;
 }

--- a/tests/provision.sh
+++ b/tests/provision.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+echo "Waiting for SMM to be ready..."
+until curl -s http://localhost:8000/accounts/login/ > /dev/null; do
+  sleep 2
+done
+
+echo "Provisioning test data..."
+docker compose -f tests/docker-compose.yml exec -T smm /code/venv/bin/python manage.py shell <<EOF
+from django.contrib.auth.models import User
+from assets.models import Asset, AssetType
+if not User.objects.filter(username='testuser').exists():
+    User.objects.create_superuser('testuser', 'test@example.com', 'testpass')
+
+# Create a test asset type and asset
+at, _ = AssetType.objects.get_or_create(name='Test Drone')
+Asset.objects.get_or_create(name='Test Asset', asset_type=at, owner=User.objects.get(username='testuser'))
+EOF
+
+echo "Provisioning complete."


### PR DESCRIPTION
## Summary by Sourcery

Add parsing utilities and tests for SMM asset client and wire them into CI and the build.

New Features:
- Introduce reusable parsing helpers for assets, commands, waypoints, and CSRF tokens to decouple data processing from HTTP calls.
- Add a new connection status to represent protocol errors from the SMM host.
- Provide an integration test that exercises the library against a real SMM instance via Docker.

Bug Fixes:
- Make asset, waypoint, and command parsing more robust to malformed or missing JSON fields and ensure buffers are always freed on error paths.
- Harden CSRF token extraction with length and character validation to avoid accepting invalid tokens.
- Ensure HTTP buffer ownership is consistently cleaned up across error and early-return paths in curl-related functions.

Enhancements:
- Refine connection/login flow to better handle redirects, HTTPS upgrades, and authentication failures, updating connection state accordingly.
- Improve logging and internal debugging macros for clearer diagnostics.
- Apply consistent code formatting and minor header order cleanups across curl and asset modules.

Build:
- Extend the Autotools setup to build and run tests, adding Check as a required dependency and a tests Makefile.
- Update the GitHub Actions workflow to install test dependencies, spin up Dockerized SMM services, and run `make check` and `make distcheck`.

CI:
- Start Docker Compose services and provision test data in CI before executing the integration tests.

Tests:
- Add unit tests for CSRF token extraction, asset parsing, command parsing, and waypoint parsing using the Check framework.
- Add a Docker-backed integration test that connects to a live SMM instance, authenticates, and verifies assets can be listed.