### PR TITLE
Add null checks

### DIFF
--- a/src/smm-asset-curl.c
+++ b/src/smm-asset-curl.c
@@ -299,6 +299,11 @@ extract_csrfmiddlewaretoken (TidyDoc tdoc, TidyNode tnod, char **token)
 													*token
 													    = strdup (
 														value);
+													if (*token
+													    == NULL)
+														{
+															return false;
+														}
 													return true;
 												}
 											else

--- a/src/smm-asset-curl.c
+++ b/src/smm-asset-curl.c
@@ -177,9 +177,13 @@ smm_connection_curl_retrieve_url_r (smm_connection conn, const char *path, const
 			case HTTP_SUCCESS:
 				{
 					char *ct = NULL;
-					if (curl_easy_getinfo (curl, CURLINFO_CONTENT_TYPE, &ct) == CURLE_OK)
+					if (curl_easy_getinfo (curl, CURLINFO_CONTENT_TYPE, &ct) == CURLE_OK && ct)
 						{
 							res->content_type = strdup (ct);
+							if (!res->content_type)
+								{
+									res->success = false;
+								}
 						}
 				}
 				break;
@@ -188,9 +192,14 @@ smm_connection_curl_retrieve_url_r (smm_connection conn, const char *path, const
 			case HTTP_SEE_OTHER:
 				{
 					char *redirect_url = NULL;
-					if (curl_easy_getinfo (curl, CURLINFO_REDIRECT_URL, &redirect_url) == CURLE_OK)
+					if (curl_easy_getinfo (curl, CURLINFO_REDIRECT_URL, &redirect_url) == CURLE_OK
+					    && redirect_url)
 						{
 							res->redirect_url = strdup (redirect_url);
+							if (!res->redirect_url)
+								{
+									res->success = false;
+								}
 						}
 				}
 				break;

--- a/src/smm-asset-curl.c
+++ b/src/smm-asset-curl.c
@@ -108,6 +108,11 @@ smm_connection_curl_retrieve_url_r (smm_connection conn, const char *path, const
 		}
 
 	res = (struct smm_curl_res_s *)calloc (1, sizeof (struct smm_curl_res_s));
+	if (res == NULL)
+		{
+			pthread_mutex_unlock (&conn->lock);
+			return NULL;
+		}
 
 	if (asprintf (&res->full_uri, "%s%s", conn->host, path) < 0)
 		{

--- a/src/smm-asset-curl.c
+++ b/src/smm-asset-curl.c
@@ -389,28 +389,32 @@ smm_asset_connection_login (smm_connection connection)
 					char *esc_user = curl_easy_escape (connection->curl, connection->user, 0);
 					char *esc_pass = curl_easy_escape (connection->curl, connection->pass, 0);
 
-					if (esc_csrf && esc_user && esc_pass
-					    && asprintf (&post_data, "csrfmiddlewaretoken=%s&username=%s&password=%s",
-							 esc_csrf, esc_user, esc_pass)
-						   >= 0)
+					if (esc_csrf && esc_user && esc_pass)
 						{
-							struct smm_curl_res_s *res_post
-							    = smm_connection_curl_retrieve_url (
-								connection, "/accounts/login/", post_data, NULL, NULL,
-								false);
-							if (res_post && res_post->success
-							    && res_post->httpcode == HTTP_FOUND)
+							if (asprintf (&post_data,
+								      "csrfmiddlewaretoken=%s&username=%s&password=%s",
+								      esc_csrf, esc_user, esc_pass)
+							    >= 0)
 								{
-									res = true;
-									connection->state = SMM_CONNECTION_CONNECTED;
+									struct smm_curl_res_s *res_post
+									    = smm_connection_curl_retrieve_url (
+										connection, "/accounts/login/",
+										post_data, NULL, NULL, false);
+									if (res_post && res_post->success
+									    && res_post->httpcode == HTTP_FOUND)
+										{
+											res = true;
+											connection->state
+											    = SMM_CONNECTION_CONNECTED;
+										}
+									else
+										{
+											connection->state
+											    = SMM_CONNECTION_AUTHENTICATION_FAILURE;
+										}
+									smm_curl_res_free (res_post);
+									free (post_data);
 								}
-							else
-								{
-									connection->state
-									    = SMM_CONNECTION_AUTHENTICATION_FAILURE;
-								}
-							smm_curl_res_free (res_post);
-							free (post_data);
 						}
 					curl_free (esc_csrf);
 					curl_free (esc_user);

--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -509,6 +509,10 @@ static smm_waypoint
 smm_waypoint_create (double lat, double lon)
 {
 	smm_waypoint wp = calloc (1, sizeof (struct smm_waypoint_s));
+	if (wp == NULL)
+		{
+			return NULL;
+		}
 	wp->lat = lat;
 	wp->lon = lon;
 	return wp;

--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -110,9 +110,23 @@ smm_asset
 smm_asset_create (smm_connection conn, const char *name, const char *type, long long asset_id, long long asset_type_id)
 {
 	smm_asset asset = calloc (1, sizeof (struct smm_asset_s));
+	if (asset == NULL)
+		{
+			return NULL;
+		}
+
 	asset->conn = conn;
 	asset->name = name ? strdup (name) : NULL;
 	asset->type = type ? strdup (type) : NULL;
+
+	if ((name && !asset->name) || (type && !asset->type))
+		{
+			free (asset->name);
+			free (asset->type);
+			free (asset);
+			return NULL;
+		}
+
 	asset->asset_id = asset_id;
 	asset->asset_type_id = asset_type_id;
 

--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -444,8 +444,20 @@ static smm_search
 smm_search_create (smm_asset asset, const char *url, uint64_t length, uint64_t distance, uint64_t sweep_width)
 {
 	smm_search search = calloc (1, sizeof (struct smm_search_s));
+	if (search == NULL)
+		{
+			return NULL;
+		}
+
 	search->asset = asset;
 	search->url = url ? strdup (url) : NULL;
+
+	if (url && !search->url)
+		{
+			free (search);
+			return NULL;
+		}
+
 	search->length = length;
 	search->distance = distance;
 	search->sweep_width = sweep_width;

--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -55,6 +55,16 @@ smm_asset_connect (const char *host, const char *user, const char *pass)
 	conn->user = strdup (user);
 	conn->pass = strdup (pass);
 	conn->verify_tls = true;
+
+	if (!conn->host || !conn->user || !conn->pass)
+		{
+			free (conn->host);
+			free (conn->user);
+			free (conn->pass);
+			free (conn);
+			return NULL;
+		}
+
 	pthread_mutex_init (&conn->lock, NULL);
 
 	return conn;


### PR DESCRIPTION
## Summary by Sourcery

Improve robustness of asset connection, retrieval, and login flows by handling allocation and CURL metadata failures more safely.

Bug Fixes:
- Return early when memory allocation for CURL result, assets, searches, and waypoints fails instead of proceeding with null pointers.
- Guard uses of CURL-derived strings (content type and redirect URL) with null checks and mark operations as unsuccessful if string duplication fails.
- Ensure strdup failures for connection credentials, asset names/types, search URLs, and CSRF token abort the operation and clean up allocated resources to avoid inconsistent state and leaks.
- Avoid using a POST buffer or login response result when their allocations fail, and ensure they are freed after use in the login flow.