### PR TITLE
fix: treat realloc failures as hard errors in waypoint parsing

### DIFF
--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -611,6 +611,16 @@ smm_parse_waypoints (const char *data, size_t len, smm_waypoints *waypoints, siz
 																	{
 																		smm_waypoint_free (
 																		    new_wp);
+																		smm_waypoints_free (
+																		    *waypoints,
+																		    *waypoints_count);
+																		*waypoints
+																		    = NULL;
+																		*waypoints_count
+																		    = 0;
+																		json_decref (
+																		    json_root);
+																		return false;
 																	}
 															}
 													}


### PR DESCRIPTION
## Description

Ensures that memory allocation failures are handled gracefully by freeing previous allocations and returning false.

Addresses part of issue #05 and addresses code review feedback.

## Summary by Sourcery

Bug Fixes:
- Free previously allocated waypoints, reset counters, and release JSON resources when waypoint reallocation fails during parsing.