### PR TITLE
Improve concurrency handling

### DIFF
--- a/src/smm-asset-curl.c
+++ b/src/smm-asset-curl.c
@@ -83,6 +83,31 @@ smm_connection_share_configure (CURLSH *share, pthread_mutex_t *lock)
 	return true;
 }
 
+static bool
+smm_build_login_post_data (const char *csrf, const char *user, const char *pass, char **out_post)
+{
+	bool ok = false;
+	CURL *curl = curl_easy_init ();
+	if (!curl)
+		return false;
+
+	char *esc_csrf = curl_easy_escape (curl, csrf, 0);
+	char *esc_user = curl_easy_escape (curl, user, 0);
+	char *esc_pass = curl_easy_escape (curl, pass, 0);
+
+	if (esc_csrf && esc_user && esc_pass
+	    && asprintf (out_post, "csrfmiddlewaretoken=%s&username=%s&password=%s", esc_csrf, esc_user, esc_pass) >= 0)
+		{
+			ok = true;
+		}
+
+	curl_free (esc_csrf);
+	curl_free (esc_user);
+	curl_free (esc_pass);
+	curl_easy_cleanup (curl);
+	return ok;
+}
+
 void
 smm_connection_share_init (smm_connection conn)
 {
@@ -188,14 +213,14 @@ smm_connection_curl_retrieve_url_r (smm_connection conn, const char *path, const
 		{
 			pthread_mutex_unlock (&conn->lock);
 			DEBUG ("failed to allocate full_uri");
-			goto error;
+			goto out;
 		}
 	pthread_mutex_unlock (&conn->lock);
 
 	curl = curl_easy_init ();
 	if (curl == NULL)
 		{
-			goto error;
+			goto out;
 		}
 
 	curl_easy_setopt (curl, CURLOPT_SHARE, share);
@@ -276,15 +301,7 @@ smm_connection_curl_retrieve_url_r (smm_connection conn, const char *path, const
 				break;
 		}
 
-	curl_slist_free_all (headers);
-	curl_easy_cleanup (curl);
-	smm_connection_unref (conn);
-
-	DEBUG ("Done\n");
-
-	return res;
-
-error:
+out:
 	if (headers)
 		{
 			curl_slist_free_all (headers);
@@ -297,12 +314,16 @@ error:
 		{
 			smm_connection_unref (conn);
 		}
-	if (res)
+	if (res && !res->success && res->httpcode == 0)
 		{
 			free (res->full_uri);
 			free (res);
+			res = NULL;
 		}
-	return NULL;
+
+	DEBUG ("Done\n");
+
+	return res;
 }
 
 static size_t
@@ -469,46 +490,31 @@ smm_asset_connection_login (smm_connection connection)
 			if (connection->csrfmiddlewaretoken)
 				{
 					char *post_data = NULL;
-					CURL *esc_curl = curl_easy_init ();
-					if (esc_curl == NULL)
+					if (smm_build_login_post_data (connection->csrfmiddlewaretoken,
+								       connection->user, connection->pass, &post_data))
 						{
-							return false;
-						}
-					char *esc_csrf = curl_easy_escape (esc_curl, connection->csrfmiddlewaretoken, 0);
-					char *esc_user = curl_easy_escape (esc_curl, connection->user, 0);
-					char *esc_pass = curl_easy_escape (esc_curl, connection->pass, 0);
-
-					if (esc_csrf && esc_user && esc_pass)
-						{
-							if (asprintf (&post_data,
-								      "csrfmiddlewaretoken=%s&username=%s&password=%s",
-								      esc_csrf, esc_user, esc_pass)
-							    >= 0)
+							struct smm_curl_res_s *res_post
+							    = smm_connection_curl_retrieve_url (
+								connection, "/accounts/login/", post_data, NULL, NULL,
+								false);
+							if (res_post && res_post->success
+							    && res_post->httpcode == HTTP_FOUND)
 								{
-									struct smm_curl_res_s *res_post
-									    = smm_connection_curl_retrieve_url (
-										connection, "/accounts/login/",
-										post_data, NULL, NULL, false);
-									if (res_post && res_post->success
-									    && res_post->httpcode == HTTP_FOUND)
-										{
-											res = true;
-											connection->state
-											    = SMM_CONNECTION_CONNECTED;
-										}
-									else
-										{
-											connection->state
-											    = SMM_CONNECTION_AUTHENTICATION_FAILURE;
-										}
-									smm_curl_res_free (res_post);
-									free (post_data);
+									res = true;
+									connection->state = SMM_CONNECTION_CONNECTED;
 								}
+							else
+								{
+									connection->state
+									    = SMM_CONNECTION_AUTHENTICATION_FAILURE;
+								}
+							smm_curl_res_free (res_post);
+							free (post_data);
 						}
-					curl_free (esc_csrf);
-					curl_free (esc_user);
-					curl_free (esc_pass);
-					curl_easy_cleanup (esc_curl);
+					else
+						{
+							connection->state = SMM_CONNECTION_AUTHENTICATION_FAILURE;
+						}
 				}
 			else
 				{

--- a/src/smm-asset-curl.c
+++ b/src/smm-asset-curl.c
@@ -65,28 +65,45 @@ smm_curl_unlock (CURL *handle, curl_lock_data data, void *userptr)
 	pthread_mutex_unlock (lock);
 }
 
+static bool
+smm_connection_share_configure (CURLSH *share, pthread_mutex_t *lock)
+{
+	if (curl_share_setopt (share, CURLSHOPT_LOCKFUNC, smm_curl_lock) != CURLSHE_OK)
+		return false;
+	if (curl_share_setopt (share, CURLSHOPT_UNLOCKFUNC, smm_curl_unlock) != CURLSHE_OK)
+		return false;
+	if (curl_share_setopt (share, CURLSHOPT_USERDATA, lock) != CURLSHE_OK)
+		return false;
+	if (curl_share_setopt (share, CURLSHOPT_SHARE, CURL_LOCK_DATA_COOKIE) != CURLSHE_OK)
+		return false;
+	if (curl_share_setopt (share, CURLSHOPT_SHARE, CURL_LOCK_DATA_DNS) != CURLSHE_OK)
+		return false;
+	if (curl_share_setopt (share, CURLSHOPT_SHARE, CURL_LOCK_DATA_SSL_SESSION) != CURLSHE_OK)
+		return false;
+	return true;
+}
+
 void
 smm_connection_share_init (smm_connection conn)
 {
-	if (conn->share == NULL)
+	if (conn->share != NULL)
 		{
-			CURLSH *share = curl_share_init ();
-			if (share == NULL)
-				{
-					return;
-				}
-			if (curl_share_setopt (share, CURLSHOPT_LOCKFUNC, smm_curl_lock) != CURLSHE_OK ||
-			    curl_share_setopt (share, CURLSHOPT_UNLOCKFUNC, smm_curl_unlock) != CURLSHE_OK ||
-			    curl_share_setopt (share, CURLSHOPT_USERDATA, &conn->lock) != CURLSHE_OK ||
-			    curl_share_setopt (share, CURLSHOPT_SHARE, CURL_LOCK_DATA_COOKIE) != CURLSHE_OK ||
-			    curl_share_setopt (share, CURLSHOPT_SHARE, CURL_LOCK_DATA_DNS) != CURLSHE_OK ||
-			    curl_share_setopt (share, CURLSHOPT_SHARE, CURL_LOCK_DATA_SSL_SESSION) != CURLSHE_OK)
-				{
-					curl_share_cleanup (share);
-					return;
-				}
-			conn->share = share;
+			return;
 		}
+
+	CURLSH *share = curl_share_init ();
+	if (share == NULL)
+		{
+			return;
+		}
+
+	if (!smm_connection_share_configure (share, &conn->lock))
+		{
+			curl_share_cleanup (share);
+			return;
+		}
+
+	conn->share = share;
 }
 
 void
@@ -142,9 +159,10 @@ smm_connection_curl_retrieve_url_r (smm_connection conn, const char *path, const
 {
 	struct smm_curl_res_s *res = NULL;
 	CURL *curl = NULL;
-	char *host = NULL;
 	bool verify_tls = true;
 	CURLSH *share = NULL;
+	struct curl_slist *headers = NULL;
+	bool have_ref = false;
 
 	DEBUG ("(%p, %s, %s, %p)\n", (void *)conn, path, post_data, write_data);
 
@@ -154,47 +172,30 @@ smm_connection_curl_retrieve_url_r (smm_connection conn, const char *path, const
 			return NULL;
 		}
 
-	pthread_mutex_lock (&conn->lock);
-	if (conn->host)
-		{
-			host = strdup (conn->host);
-		}
-	verify_tls = conn->verify_tls;
-	share = conn->share;
-	conn->refcount++;
-	pthread_mutex_unlock (&conn->lock);
-
-	if (host == NULL)
-		{
-			smm_connection_unref (conn);
-			return NULL;
-		}
-
 	res = (struct smm_curl_res_s *)calloc (1, sizeof (struct smm_curl_res_s));
 	if (res == NULL)
 		{
-			free (host);
-			smm_connection_unref (conn);
 			return NULL;
 		}
 
-	if (asprintf (&res->full_uri, "%s%s", host, path) < 0)
+	pthread_mutex_lock (&conn->lock);
+	verify_tls = conn->verify_tls;
+	share = conn->share;
+	conn->refcount++;
+	have_ref = true;
+
+	if (asprintf (&res->full_uri, "%s%s", conn->host, path) < 0)
 		{
-			free (host);
-			free (res);
+			pthread_mutex_unlock (&conn->lock);
 			DEBUG ("failed to allocate full_uri");
-			smm_connection_unref (conn);
-			return NULL;
+			goto error;
 		}
-	free (host);
+	pthread_mutex_unlock (&conn->lock);
 
 	curl = curl_easy_init ();
 	if (curl == NULL)
 		{
-			free (res->full_uri);
-			free (res);
-			smm_connection_unref (conn);
-			return NULL;
+			goto error;
 		}
 
 	curl_easy_setopt (curl, CURLOPT_SHARE, share);
@@ -228,8 +229,6 @@ smm_connection_curl_retrieve_url_r (smm_connection conn, const char *path, const
 			curl_easy_setopt (curl, CURLOPT_WRITEFUNCTION, eat_data);
 			curl_easy_setopt (curl, CURLOPT_WRITEDATA, NULL);
 		}
-
-	struct curl_slist *headers = NULL;
 
 	if (json)
 		{
@@ -279,12 +278,31 @@ smm_connection_curl_retrieve_url_r (smm_connection conn, const char *path, const
 
 	curl_slist_free_all (headers);
 	curl_easy_cleanup (curl);
-
 	smm_connection_unref (conn);
 
 	DEBUG ("Done\n");
 
 	return res;
+
+error:
+	if (headers)
+		{
+			curl_slist_free_all (headers);
+		}
+	if (curl)
+		{
+			curl_easy_cleanup (curl);
+		}
+	if (have_ref)
+		{
+			smm_connection_unref (conn);
+		}
+	if (res)
+		{
+			free (res->full_uri);
+			free (res);
+		}
+	return NULL;
 }
 
 static size_t
@@ -452,6 +470,10 @@ smm_asset_connection_login (smm_connection connection)
 				{
 					char *post_data = NULL;
 					CURL *esc_curl = curl_easy_init ();
+					if (esc_curl == NULL)
+						{
+							return false;
+						}
 					char *esc_csrf = curl_easy_escape (esc_curl, connection->csrfmiddlewaretoken, 0);
 					char *esc_user = curl_easy_escape (esc_curl, connection->user, 0);
 					char *esc_pass = curl_easy_escape (esc_curl, connection->pass, 0);

--- a/src/smm-asset-curl.c
+++ b/src/smm-asset-curl.c
@@ -46,6 +46,51 @@ enum http_return_codes
 	HTTP_SEE_OTHER = 303,
 };
 
+static void
+smm_curl_lock (CURL *handle, curl_lock_data data, curl_lock_access access, void *userptr)
+{
+	(void)handle;
+	(void)data;
+	(void)access;
+	pthread_mutex_t *lock = (pthread_mutex_t *)userptr;
+	pthread_mutex_lock (lock);
+}
+
+static void
+smm_curl_unlock (CURL *handle, curl_lock_data data, void *userptr)
+{
+	(void)handle;
+	(void)data;
+	pthread_mutex_t *lock = (pthread_mutex_t *)userptr;
+	pthread_mutex_unlock (lock);
+}
+
+void
+smm_connection_share_init (smm_connection conn)
+{
+	if (conn->share == NULL)
+		{
+			CURLSH *share = curl_share_init ();
+			curl_share_setopt (share, CURLSHOPT_LOCKFUNC, smm_curl_lock);
+			curl_share_setopt (share, CURLSHOPT_UNLOCKFUNC, smm_curl_unlock);
+			curl_share_setopt (share, CURLSHOPT_USERDATA, &conn->lock);
+			curl_share_setopt (share, CURLSHOPT_SHARE, CURL_LOCK_DATA_COOKIE);
+			curl_share_setopt (share, CURLSHOPT_SHARE, CURL_LOCK_DATA_DNS);
+			curl_share_setopt (share, CURLSHOPT_SHARE, CURL_LOCK_DATA_SSL_SESSION);
+			conn->share = share;
+		}
+}
+
+void
+smm_connection_share_destroy (smm_connection conn)
+{
+	if (conn->share != NULL)
+		{
+			curl_share_cleanup (conn->share);
+			conn->share = NULL;
+		}
+}
+
 void
 smm_curl_res_free (struct smm_curl_res_s *res)
 {
@@ -88,6 +133,10 @@ smm_connection_curl_retrieve_url_r (smm_connection conn, const char *path, const
 				    void *write_data, bool json)
 {
 	struct smm_curl_res_s *res = NULL;
+	CURL *curl = NULL;
+	char *host = NULL;
+	bool verify_tls = true;
+	CURLSH *share = NULL;
 
 	DEBUG ("(%p, %s, %s, %p)\n", (void *)conn, path, post_data, write_data);
 
@@ -98,30 +147,44 @@ smm_connection_curl_retrieve_url_r (smm_connection conn, const char *path, const
 		}
 
 	pthread_mutex_lock (&conn->lock);
-	CURL *curl = conn->curl;
-	bool verify_tls = conn->verify_tls;
-	if (curl == NULL)
+	if (conn->host)
 		{
-			DEBUG ("creating curl object\n");
-			curl = curl_easy_init ();
-			conn->curl = curl;
+			host = strdup (conn->host);
+		}
+	verify_tls = conn->verify_tls;
+	share = conn->share;
+	pthread_mutex_unlock (&conn->lock);
+
+	if (host == NULL)
+		{
+			return NULL;
 		}
 
 	res = (struct smm_curl_res_s *)calloc (1, sizeof (struct smm_curl_res_s));
 	if (res == NULL)
 		{
-			pthread_mutex_unlock (&conn->lock);
+			free (host);
 			return NULL;
 		}
 
-	if (asprintf (&res->full_uri, "%s%s", conn->host, path) < 0)
+	if (asprintf (&res->full_uri, "%s%s", host, path) < 0)
 		{
+			free (host);
 			free (res);
 			DEBUG ("failed to allocate full_uri");
-			pthread_mutex_unlock (&conn->lock);
+			return NULL;
+		}
+	free (host);
+
+	curl = curl_easy_init ();
+	if (curl == NULL)
+		{
+			free (res->full_uri);
+			free (res);
 			return NULL;
 		}
 
+	curl_easy_setopt (curl, CURLOPT_SHARE, share);
 	curl_easy_setopt (curl, CURLOPT_FAILONERROR, true);
 	curl_easy_setopt (curl, CURLOPT_SSL_VERIFYPEER, verify_tls ? 1L : 0L);
 	curl_easy_setopt (curl, CURLOPT_SSL_VERIFYHOST, verify_tls ? 2L : 0L);
@@ -166,10 +229,6 @@ smm_connection_curl_retrieve_url_r (smm_connection conn, const char *path, const
 	DEBUG ("curl returned %i\n", cres);
 	res->success = (cres == CURLE_OK);
 
-	curl_easy_setopt (curl, CURLOPT_HTTPHEADER, NULL);
-	curl_slist_free_all (headers);
-	headers = NULL;
-
 	curl_easy_getinfo (curl, CURLINFO_RESPONSE_CODE, &res->httpcode);
 	DEBUG ("httpcode = %li\n", res->httpcode);
 	switch (res->httpcode)
@@ -205,15 +264,8 @@ smm_connection_curl_retrieve_url_r (smm_connection conn, const char *path, const
 				break;
 		}
 
-	/* Clear anything we set in the curl object */
-	curl_easy_setopt (curl, CURLOPT_URL, NULL);
-	curl_easy_setopt (curl, CURLOPT_REFERER, NULL);
-	curl_easy_setopt (curl, CURLOPT_POSTFIELDS, NULL);
-	curl_easy_setopt (curl, CURLOPT_POST, 0);
-	curl_easy_setopt (curl, CURLOPT_WRITEFUNCTION, NULL);
-	curl_easy_setopt (curl, CURLOPT_WRITEDATA, NULL);
-
-	pthread_mutex_unlock (&conn->lock);
+	curl_slist_free_all (headers);
+	curl_easy_cleanup (curl);
 
 	DEBUG ("Done\n");
 
@@ -384,10 +436,9 @@ smm_asset_connection_login (smm_connection connection)
 			if (connection->csrfmiddlewaretoken)
 				{
 					char *post_data = NULL;
-					char *esc_csrf
-					    = curl_easy_escape (connection->curl, connection->csrfmiddlewaretoken, 0);
-					char *esc_user = curl_easy_escape (connection->curl, connection->user, 0);
-					char *esc_pass = curl_easy_escape (connection->curl, connection->pass, 0);
+					char *esc_csrf = curl_easy_escape (NULL, connection->csrfmiddlewaretoken, 0);
+					char *esc_user = curl_easy_escape (NULL, connection->user, 0);
+					char *esc_pass = curl_easy_escape (NULL, connection->pass, 0);
 
 					if (esc_csrf && esc_user && esc_pass)
 						{

--- a/src/smm-asset-curl.c
+++ b/src/smm-asset-curl.c
@@ -71,12 +71,20 @@ smm_connection_share_init (smm_connection conn)
 	if (conn->share == NULL)
 		{
 			CURLSH *share = curl_share_init ();
-			curl_share_setopt (share, CURLSHOPT_LOCKFUNC, smm_curl_lock);
-			curl_share_setopt (share, CURLSHOPT_UNLOCKFUNC, smm_curl_unlock);
-			curl_share_setopt (share, CURLSHOPT_USERDATA, &conn->lock);
-			curl_share_setopt (share, CURLSHOPT_SHARE, CURL_LOCK_DATA_COOKIE);
-			curl_share_setopt (share, CURLSHOPT_SHARE, CURL_LOCK_DATA_DNS);
-			curl_share_setopt (share, CURLSHOPT_SHARE, CURL_LOCK_DATA_SSL_SESSION);
+			if (share == NULL)
+				{
+					return;
+				}
+			if (curl_share_setopt (share, CURLSHOPT_LOCKFUNC, smm_curl_lock) != CURLSHE_OK ||
+			    curl_share_setopt (share, CURLSHOPT_UNLOCKFUNC, smm_curl_unlock) != CURLSHE_OK ||
+			    curl_share_setopt (share, CURLSHOPT_USERDATA, &conn->lock) != CURLSHE_OK ||
+			    curl_share_setopt (share, CURLSHOPT_SHARE, CURL_LOCK_DATA_COOKIE) != CURLSHE_OK ||
+			    curl_share_setopt (share, CURLSHOPT_SHARE, CURL_LOCK_DATA_DNS) != CURLSHE_OK ||
+			    curl_share_setopt (share, CURLSHOPT_SHARE, CURL_LOCK_DATA_SSL_SESSION) != CURLSHE_OK)
+				{
+					curl_share_cleanup (share);
+					return;
+				}
 			conn->share = share;
 		}
 }
@@ -153,10 +161,12 @@ smm_connection_curl_retrieve_url_r (smm_connection conn, const char *path, const
 		}
 	verify_tls = conn->verify_tls;
 	share = conn->share;
+	conn->refcount++;
 	pthread_mutex_unlock (&conn->lock);
 
 	if (host == NULL)
 		{
+			smm_connection_unref (conn);
 			return NULL;
 		}
 
@@ -164,6 +174,7 @@ smm_connection_curl_retrieve_url_r (smm_connection conn, const char *path, const
 	if (res == NULL)
 		{
 			free (host);
+			smm_connection_unref (conn);
 			return NULL;
 		}
 
@@ -172,6 +183,7 @@ smm_connection_curl_retrieve_url_r (smm_connection conn, const char *path, const
 			free (host);
 			free (res);
 			DEBUG ("failed to allocate full_uri");
+			smm_connection_unref (conn);
 			return NULL;
 		}
 	free (host);
@@ -181,6 +193,7 @@ smm_connection_curl_retrieve_url_r (smm_connection conn, const char *path, const
 		{
 			free (res->full_uri);
 			free (res);
+			smm_connection_unref (conn);
 			return NULL;
 		}
 
@@ -266,6 +279,8 @@ smm_connection_curl_retrieve_url_r (smm_connection conn, const char *path, const
 
 	curl_slist_free_all (headers);
 	curl_easy_cleanup (curl);
+
+	smm_connection_unref (conn);
 
 	DEBUG ("Done\n");
 
@@ -436,9 +451,10 @@ smm_asset_connection_login (smm_connection connection)
 			if (connection->csrfmiddlewaretoken)
 				{
 					char *post_data = NULL;
-					char *esc_csrf = curl_easy_escape (NULL, connection->csrfmiddlewaretoken, 0);
-					char *esc_user = curl_easy_escape (NULL, connection->user, 0);
-					char *esc_pass = curl_easy_escape (NULL, connection->pass, 0);
+					CURL *esc_curl = curl_easy_init ();
+					char *esc_csrf = curl_easy_escape (esc_curl, connection->csrfmiddlewaretoken, 0);
+					char *esc_user = curl_easy_escape (esc_curl, connection->user, 0);
+					char *esc_pass = curl_easy_escape (esc_curl, connection->pass, 0);
 
 					if (esc_csrf && esc_user && esc_pass)
 						{
@@ -470,6 +486,7 @@ smm_asset_connection_login (smm_connection connection)
 					curl_free (esc_csrf);
 					curl_free (esc_user);
 					curl_free (esc_pass);
+					curl_easy_cleanup (esc_curl);
 				}
 			else
 				{
@@ -512,6 +529,7 @@ smm_connection_curl_retrieve_url (smm_connection conn, const char *path, const c
 				{
 					DEBUG ("Got redirected to (%s) accessing %s\n", res->redirect_url, path);
 					/* It's possible we need to upgrade to https */
+					pthread_mutex_lock (&conn->lock);
 					if (strncmp (conn->host, "https://", 8) != 0
 					    && strncmp (res->redirect_url, "https://", 8) == 0)
 						{
@@ -545,6 +563,7 @@ smm_connection_curl_retrieve_url (smm_connection conn, const char *path, const c
 									retry = true;
 								}
 						}
+					pthread_mutex_unlock (&conn->lock);
 
 					if (!retry && strstr (res->redirect_url, "accounts/login") != NULL)
 						{

--- a/src/smm-asset-internal.h
+++ b/src/smm-asset-internal.h
@@ -51,6 +51,7 @@ struct smm_connection_s
 	char *csrfmiddlewaretoken;
 	pthread_mutex_t lock;
 	bool verify_tls;
+	int refcount;
 };
 
 struct smm_asset_s
@@ -94,6 +95,8 @@ size_t to_buffer (char *ptr, size_t size, size_t nmemb, void *userdata);
 
 void smm_connection_share_init (smm_connection conn);
 void smm_connection_share_destroy (smm_connection conn);
+
+void smm_connection_unref (smm_connection conn);
 
 void smm_curl_res_free (struct smm_curl_res_s *);
 struct smm_curl_res_s *smm_connection_curl_retrieve_url (smm_connection conn, const char *path, const char *post_data,

--- a/src/smm-asset-internal.h
+++ b/src/smm-asset-internal.h
@@ -47,7 +47,7 @@ struct smm_connection_s
 	char *user;
 	char *pass;
 	smm_connection_status state;
-	CURL *curl;
+	CURLSH *share;
 	char *csrfmiddlewaretoken;
 	pthread_mutex_t lock;
 	bool verify_tls;
@@ -90,6 +90,9 @@ struct buffer_s
 };
 
 size_t to_buffer (char *ptr, size_t size, size_t nmemb, void *userdata);
+
+void smm_connection_share_init (smm_connection conn);
+void smm_connection_share_destroy (smm_connection conn);
 
 void smm_curl_res_free (struct smm_curl_res_s *);
 struct smm_curl_res_s *smm_connection_curl_retrieve_url (smm_connection conn, const char *path, const char *post_data,

--- a/src/smm-asset-internal.h
+++ b/src/smm-asset-internal.h
@@ -63,6 +63,7 @@ struct smm_asset_s
 	smm_asset_command last_command;
 	double last_command_lat;
 	double last_command_lon;
+	pthread_mutex_t lock;
 };
 
 struct smm_search_s

--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -131,6 +131,8 @@ smm_asset_create (smm_connection conn, const char *name, const char *type, long 
 	asset->asset_id = asset_id;
 	asset->asset_type_id = asset_type_id;
 
+	pthread_mutex_init (&asset->lock, NULL);
+
 	return asset;
 }
 
@@ -256,9 +258,13 @@ smm_asset_get_assets (smm_connection connection, smm_assets *assets, size_t *ass
 void
 smm_asset_free_asset (smm_asset asset)
 {
-	free (asset->name);
-	free (asset->type);
-	free (asset);
+	if (asset)
+		{
+			free (asset->name);
+			free (asset->type);
+			pthread_mutex_destroy (&asset->lock);
+			free (asset);
+		}
 }
 
 void
@@ -370,30 +376,40 @@ smm_parse_command (const char *data, size_t len, smm_asset_command *command, dou
 static bool
 smm_asset_update_command (smm_asset asset, struct buffer_s *buf)
 {
-	return smm_parse_command (buf->data, buf->bytes, &asset->last_command, &asset->last_command_lat,
-				  &asset->last_command_lon);
+	bool res;
+	pthread_mutex_lock (&asset->lock);
+	res = smm_parse_command (buf->data, buf->bytes, &asset->last_command, &asset->last_command_lat,
+				 &asset->last_command_lon);
+	pthread_mutex_unlock (&asset->lock);
+	return res;
 }
 
 smm_asset_command
 smm_asset_last_command (smm_asset asset)
 {
-	return asset->last_command;
+	smm_asset_command cmd;
+	pthread_mutex_lock (&asset->lock);
+	cmd = asset->last_command;
+	pthread_mutex_unlock (&asset->lock);
+	return cmd;
 }
 
 bool
 smm_asset_last_goto_pos (smm_asset asset, double *lat, double *lon)
 {
-	if (asset->last_command != SMM_COMMAND_GOTO)
+	bool res = false;
+	pthread_mutex_lock (&asset->lock);
+	if (asset->last_command == SMM_COMMAND_GOTO)
 		{
-			return false;
+			if (lat != NULL && lon != NULL)
+				{
+					*lat = asset->last_command_lat;
+					*lon = asset->last_command_lon;
+					res = true;
+				}
 		}
-	if (lat == NULL || lon == NULL)
-		{
-			return false;
-		}
-	*lat = asset->last_command_lat;
-	*lon = asset->last_command_lon;
-	return true;
+	pthread_mutex_unlock (&asset->lock);
+	return res;
 }
 
 bool

--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -55,6 +55,7 @@ smm_asset_connect (const char *host, const char *user, const char *pass)
 	conn->user = strdup (user);
 	conn->pass = strdup (pass);
 	conn->verify_tls = true;
+	conn->refcount = 1;
 
 	if (!conn->host || !conn->user || !conn->pass)
 		{
@@ -93,18 +94,36 @@ smm_asset_connection_tls_verify_set (smm_connection connection, bool verify)
 }
 
 void
-smm_connection_close (smm_connection connection)
+smm_connection_unref (smm_connection connection)
 {
-	if (connection != NULL)
+	if (connection == NULL)
 		{
+			return;
+		}
+
+	pthread_mutex_lock (&connection->lock);
+	connection->refcount--;
+	if (connection->refcount == 0)
+		{
+			pthread_mutex_unlock (&connection->lock);
 			free (connection->host);
 			free (connection->user);
 			free (connection->pass);
 			free (connection->csrfmiddlewaretoken);
 			smm_connection_share_destroy (connection);
 			pthread_mutex_destroy (&connection->lock);
+			free (connection);
 		}
-	free (connection);
+	else
+		{
+			pthread_mutex_unlock (&connection->lock);
+		}
+}
+
+void
+smm_connection_close (smm_connection connection)
+{
+	smm_connection_unref (connection);
 }
 
 smm_asset

--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -66,6 +66,7 @@ smm_asset_connect (const char *host, const char *user, const char *pass)
 		}
 
 	pthread_mutex_init (&conn->lock, NULL);
+	smm_connection_share_init (conn);
 
 	return conn;
 }
@@ -100,7 +101,7 @@ smm_connection_close (smm_connection connection)
 			free (connection->user);
 			free (connection->pass);
 			free (connection->csrfmiddlewaretoken);
-			curl_easy_cleanup (connection->curl);
+			smm_connection_share_destroy (connection);
 			pthread_mutex_destroy (&connection->lock);
 		}
 	free (connection);

--- a/src/smm-asset.h
+++ b/src/smm-asset.h
@@ -127,7 +127,11 @@ smm_connection_status smm_asset_connection_get_state (smm_connection connection)
 void smm_asset_connection_tls_verify_set (smm_connection connection, bool verify);
 
 /**
- * Close a connection to smm and free associated resources
+ * Close a connection to smm and free associated resources.
+ *
+ * This function should only be called when no other threads are actively
+ * using the connection. Calling this while network requests are in flight
+ * or being initiated on other threads leads to undefined behavior.
  *
  * @param connection the smm_connection object to close and free
  */

--- a/tests/provision.sh
+++ b/tests/provision.sh
@@ -12,6 +12,10 @@ from django.contrib.auth.models import User
 from assets.models import Asset, AssetType
 if not User.objects.filter(username='testuser').exists():
     User.objects.create_superuser('testuser', 'test@example.com', 'testpass')
+else:
+    u = User.objects.get(username='testuser')
+    u.set_password('testpass')
+    u.save()
 
 # Create a test asset type and asset
 at, _ = AssetType.objects.get_or_create(name='Test Drone')


### PR DESCRIPTION
## Summary by Sourcery

Improve thread-safe use of libcurl connections and asset state while adding reference-counted connection lifecycle management.

New Features:
- Introduce shared libcurl handle configuration with cookie, DNS, and SSL session sharing across requests.
- Add reference-counted connection management API to safely free connection resources when no longer in use.

Bug Fixes:
- Ensure asset last-command data and goto coordinates are accessed and updated under a mutex to prevent data races.
- Rebuild login POST data using a fresh CURL handle to avoid reliance on shared connection state.
- Reset or update the Django test superuser password in provisioning to ensure deterministic credentials.

Enhancements:
- Create and clean up per-request CURL handles instead of reusing a single connection-global handle to improve concurrency robustness.
- Guard connection host/TLS configuration changes during redirects with the connection mutex.
- Add shared-handle initialization and destruction to the connection lifecycle and document threading expectations for smm_connection_close.

Tests:
- Adjust test provisioning script to always set a known password for the test user.