### PR TITLE
tests: replace curl-based readiness check with Python healthcheck

### DIFF
--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -12,6 +12,12 @@ services:
     depends_on:
       db:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:8080/accounts/login/')\""]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+      start_period: 10s
 
   tester:
     build:
@@ -22,7 +28,8 @@ services:
       - SMM_USER=testuser
       - SMM_PASS=testpass
     depends_on:
-      - smm
+      smm:
+        condition: service_healthy
 
   db:
     image: postgis/postgis:18-3.6

--- a/tests/provision.sh
+++ b/tests/provision.sh
@@ -2,7 +2,7 @@
 set -e
 
 echo "Waiting for SMM to be ready..."
-until docker compose -f tests/docker-compose.yml exec -T smm curl -s http://localhost:8080/accounts/login/ > /dev/null; do
+until docker compose -f tests/docker-compose.yml ps smm | grep -q "healthy"; do
   sleep 2
 done
 


### PR DESCRIPTION
## Description

curl is no longer available in the smm container; use Python's urllib (guaranteed present in a Django image) as the healthcheck instead. provision.sh now polls docker compose health status rather than exec-ing into the container, and the tester service waits for smm to be healthy.

## Summary by Sourcery

Replace curl-based SMM readiness check with a Docker healthcheck using Python and make the tester depend on the service's healthy state.

Tests:
- Add a Python-based HTTP healthcheck for the smm service in tests/docker-compose.yml and gate the tester service on smm being healthy.
- Update tests/provision.sh to wait for the smm container's Docker health status instead of running curl inside the container.