### PR TITLE
build: gate integration tests behind --enable-integration-tests configure flag

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -14,6 +14,13 @@ PKG_CHECK_MODULES([CURL],[libcurl])
 PKG_CHECK_MODULES([JANSSON],[jansson])
 PKG_CHECK_MODULES([CHECK], [check >= 0.9.4])
 
+AC_ARG_ENABLE([integration-tests],
+  [AS_HELP_STRING([--enable-integration-tests],
+    [build and run integration tests (requires a live SMM server)])],
+  [enable_integration_tests=$enableval],
+  [enable_integration_tests=no])
+AM_CONDITIONAL([INTEGRATION_TESTS], [test "x$enable_integration_tests" = "xyes"])
+
 AC_CHECK_HEADERS([tidy.h],[],[
 AC_CHECK_HEADERS([tidy/tidy.h])])
 

--- a/tests/Dockerfile.tester
+++ b/tests/Dockerfile.tester
@@ -16,6 +16,6 @@ RUN apt-get update && apt-get install -y \
 WORKDIR /app
 COPY . .
 
-RUN ./autogen.sh && ./configure && make
+RUN ./autogen.sh && ./configure --enable-integration-tests && make
 
 CMD ["make", "check"]

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,11 +1,15 @@
 TESTS = check_smm
-check_PROGRAMS = check_smm integration_test
+check_PROGRAMS = check_smm
 check_smm_SOURCES = check_smm.c $(top_builddir)/src/smm-asset.h
 check_smm_CFLAGS = @CHECK_CFLAGS@ -I$(top_srcdir)/src
 check_smm_LDADD = $(top_builddir)/src/libsmmasset.la @CHECK_LIBS@
 
+if INTEGRATION_TESTS
+TESTS += integration_test
+check_PROGRAMS += integration_test
 integration_test_SOURCES = integration_test.c $(top_builddir)/src/smm-asset.h
 integration_test_CFLAGS = -I$(top_srcdir)/src
 integration_test_LDADD = $(top_builddir)/src/libsmmasset.la
+endif
 
 EXTRA_DIST = docker-compose.yml provision.sh


### PR DESCRIPTION
## Description

Prevents integration_test from being built during make distcheck, and fixes the docker tester to actually run it via make check.

## Summary by Sourcery

Gate integration tests behind an optional configure flag and ensure they are only built and run when explicitly enabled.

New Features:
- Introduce a configure-time --enable-integration-tests option to control building and running integration tests.

Enhancements:
- Conditionally include the integration_test binary in the test suite based on the integration tests flag so it is skipped by default, including during make distcheck.