### PR TITLE
api: wire up all connection states and improve error classification

### DIFF
--- a/src/smm-asset-curl.c
+++ b/src/smm-asset-curl.c
@@ -108,27 +108,28 @@ smm_build_login_post_data (const char *csrf, const char *user, const char *pass,
 	return ok;
 }
 
-void
+bool
 smm_connection_share_init (smm_connection conn)
 {
 	if (conn->share != NULL)
 		{
-			return;
+			return true;
 		}
 
 	CURLSH *share = curl_share_init ();
 	if (share == NULL)
 		{
-			return;
+			return false;
 		}
 
 	if (!smm_connection_share_configure (share, &conn->lock))
 		{
 			curl_share_cleanup (share);
-			return;
+			return false;
 		}
 
 	conn->share = share;
+	return true;
 }
 
 void
@@ -265,6 +266,25 @@ smm_connection_curl_retrieve_url_r (smm_connection conn, const char *path, const
 	CURLcode cres = curl_easy_perform (curl);
 	DEBUG ("curl returned %i\n", cres);
 	res->success = (cres == CURLE_OK);
+
+	if (cres != CURLE_OK)
+		{
+			pthread_mutex_lock (&conn->lock);
+			switch (cres)
+				{
+					case CURLE_URL_MALFORMAT:
+						conn->state = SMM_CONNECTION_HOST_INVALID;
+						break;
+					case CURLE_COULDNT_RESOLVE_HOST:
+					case CURLE_COULDNT_CONNECT:
+						conn->state = SMM_CONNECTION_NO_HOST_CONNECTION;
+						break;
+					default:
+						conn->state = SMM_CONNECTION_FAILURE;
+						break;
+				}
+			pthread_mutex_unlock (&conn->lock);
+		}
 
 	curl_easy_getinfo (curl, CURLINFO_RESPONSE_CODE, &res->httpcode);
 	DEBUG ("httpcode = %li\n", res->httpcode);
@@ -513,7 +533,7 @@ smm_asset_connection_login (smm_connection connection)
 						}
 					else
 						{
-							connection->state = SMM_CONNECTION_AUTHENTICATION_FAILURE;
+							connection->state = SMM_CONNECTION_FAILURE;
 						}
 				}
 			else

--- a/src/smm-asset-internal.h
+++ b/src/smm-asset-internal.h
@@ -93,7 +93,7 @@ struct buffer_s
 
 size_t to_buffer (char *ptr, size_t size, size_t nmemb, void *userdata);
 
-void smm_connection_share_init (smm_connection conn);
+bool smm_connection_share_init (smm_connection conn);
 void smm_connection_share_destroy (smm_connection conn);
 
 void smm_connection_unref (smm_connection conn);

--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -67,7 +67,25 @@ smm_asset_connect (const char *host, const char *user, const char *pass)
 		}
 
 	pthread_mutex_init (&conn->lock, NULL);
-	smm_connection_share_init (conn);
+	if (!smm_connection_share_init (conn))
+		{
+			conn->state = SMM_CONNECTION_FAILURE;
+		}
+
+	/* Early host validation */
+	CURLU *curlu = curl_url ();
+	if (curlu)
+		{
+			if (curl_url_set (curlu, CURLUPART_URL, host, 0) != CURLUE_OK)
+				{
+					conn->state = SMM_CONNECTION_HOST_INVALID;
+				}
+			curl_url_cleanup (curlu);
+		}
+	else
+		{
+			conn->state = SMM_CONNECTION_FAILURE;
+		}
 
 	return conn;
 }

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -148,13 +148,27 @@ START_TEST (test_waypoint_parsing)
 }
 END_TEST
 
+START_TEST (test_invalid_host)
+{
+	smm_connection conn = smm_asset_connect ("not a url", "user", "pass");
+	ck_assert_ptr_nonnull (conn);
+	ck_assert_int_eq (smm_asset_connection_get_state (conn), SMM_CONNECTION_HOST_INVALID);
+	smm_connection_close (conn);
+}
+END_TEST
+
 Suite *
 smm_suite (void)
 {
 	Suite *s;
 	TCase *tc_csrf;
+	TCase *tc_conn;
 
 	s = suite_create ("SMM");
+
+	tc_conn = tcase_create ("Connection");
+	tcase_add_test (tc_conn, test_invalid_host);
+	suite_add_tcase (s, tc_conn);
 
 	tc_csrf = tcase_create ("CSRF");
 	tcase_add_test (tc_csrf, test_csrf_extraction);


### PR DESCRIPTION
## Description

- Add early URL validation to smm_asset_connect using curl_url.
- Map CURL error codes to specific connection states (INVALID_HOST, NO_HOST_CONNECTION, FAILURE) during network transfers.
- Update smm_asset_connection_login to use SMM_CONNECTION_FAILURE for internal errors.
- Ensure all smm_connection_status values are assigned and usable by the caller.
- Add unit test for invalid host detection.

## Summary by Sourcery

Improve connection state handling and error classification for asset connections using curl.

New Features:
- Perform early URL validation in smm_asset_connect and classify invalid hosts via SMM_CONNECTION_HOST_INVALID.

Bug Fixes:
- Classify curl transfer failures into specific connection states including invalid host, no host connectivity, and generic failure so callers can reliably interpret errors.
- Treat internal errors during login as a generic connection failure instead of an authentication failure.

Enhancements:
- Make smm_connection_share_init return a boolean to signal initialization success and propagate failures into the connection state.
- Ensure all smm_connection_status values are used consistently and exposed to callers.

Tests:
- Add a unit test to verify invalid host detection and the resulting connection state.
- Extend the test suite with a dedicated connection test case.