### PR TITLE
build: move -Werror behind a configure flag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     - name: autogen
       run: ./autogen.sh
     - name: configure
-      run: ./configure
+      run: ./configure --enable-werror
     - name: make
       run: make
     - name: Start Docker SMM

--- a/configure.ac
+++ b/configure.ac
@@ -9,6 +9,12 @@ AM_PROG_AR
 
 LT_INIT([disable-static pic-only])
 
+AC_ARG_ENABLE([werror],
+  AS_HELP_STRING([--enable-werror], [treat warnings as errors]),
+  [werror=$enableval], [werror=no])
+AS_IF([test "x$werror" = "xyes"], [WERROR_CFLAGS="-Werror"])
+AC_SUBST([WERROR_CFLAGS])
+
 PKG_CHECK_MODULES([TIDY],[tidy])
 PKG_CHECK_MODULES([CURL],[libcurl])
 PKG_CHECK_MODULES([JANSSON],[jansson])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,4 +1,4 @@
-AM_CFLAGS = -Werror -Wall -Wformat=2 -Wvla -Wextra -Wwrite-strings -Wmissing-prototypes -Wunreachable-code -pedantic -std=c99 -D_DEFAULT_SOURCE -D_GNU_SOURCE
+AM_CFLAGS = $(WERROR_CFLAGS) -Wall -Wformat=2 -Wvla -Wextra -Wwrite-strings -Wmissing-prototypes -Wunreachable-code -pedantic -std=c99 -D_DEFAULT_SOURCE -D_GNU_SOURCE
 AM_CFLAGS += $(TIDY_CFLAGS) $(CURL_CFLAGS) $(JANSSON_CFLAGS)
 
 lib_LTLIBRARIES = libsmmasset.la


### PR DESCRIPTION
## Description

This removes the hardcoded -Werror from the main build system, which can cause unnecessary failures for downstream packagers using newer compilers. Strict warning-as-error checks are now opt-in via --enable-werror and are enabled by default in GitHub CI.

## Summary by Sourcery

Make treating compiler warnings as errors configurable via a new build flag while keeping it enabled in CI.

Build:
- Introduce a --enable-werror configure option that conditionally adds -Werror to compiler flags instead of hardcoding it in the main build.
- Update the GitHub Actions build workflow to configure the project with --enable-werror so CI still treats warnings as errors.