### PR TITLE
docs: fix README examples and header documentation drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Search Management Map Asset API
 
-A C library for accessing the asset side of the API for [Search Management Map](https://github.com/canterburyairpatrol/search-management-map)
+A C library for accessing the asset side of the API for [Search Management Map](https://github.com/canterbury-air-patrol/search-management-map)
 
 ## Getting started
 ### Prerequisites
@@ -15,7 +15,7 @@ A C library for accessing the asset side of the API for [Search Management Map](
 git clone https://github.com/canterbury-air-patrol/smm-asset-api.git
 cd smm-asset-api
 ./autogen.sh
-./configure -prefix=/usr
+./configure --prefix=/usr
 make
 make install
 ```
@@ -25,21 +25,23 @@ make install
 Link your program against -lsmmasset or use pkg-config with the installed smm-asset.pc.
 
 Basic API usage example
-```
+```c
 #include <smm-asset.h>
+#include <stdio.h>
+#include <string.h>
 
 int main(int argc, char *argv[])
 {
-	smm_asset *assets;
+	smm_assets assets;
 	size_t assets_count;
 	smm_asset asset = NULL;
 
 	smm_connection conn = smm_asset_connect ("http://localhost/", "asset", "assetpassword");
-	if (smm_asset_get_assets (conn, &assets, assets_count))
+	if (smm_asset_get_assets (conn, &assets, &assets_count))
 	{
 		for (size_t i = 0; i < assets_count; i++)
 		{
-			if (strcmp (smm_asset_get_name (assets[i]), "my-asset") == 0)
+			if (strcmp (smm_asset_name (assets[i]), "my-asset") == 0)
 			{
 				asset = assets[i];
 			}
@@ -54,16 +56,22 @@ int main(int argc, char *argv[])
 		smm_search search;
 		do {
 			search = smm_asset_get_search (asset, -43, 172);
-		} while (!smm_search_accept (search));
-		/* All the waypoints for the search are accessible with */
-		smm_waypoints waypoints;
-		size_t waypoints_count;
-		smm_search_waypoints_get (search, &waypoints, &waypoints_count);
-		/* Iterate them the same as assets, then free with */
-		smm_waypoints_free (waypoints, waypoints_count);
-		/* Once the search is completed then */
-		smm_search_completed (search);
-		smm_search_destroy (search);
+		} while (search != NULL && !smm_search_accept (search));
+
+		if (search != NULL)
+		{
+			/* All the waypoints for the search are accessible with */
+			smm_waypoints waypoints;
+			size_t waypoints_count;
+			if (smm_search_get_waypoints (search, &waypoints, &waypoints_count))
+			{
+				/* Iterate them the same as assets, then free with */
+				smm_waypoints_free (waypoints, waypoints_count);
+			}
+			/* Once the search is completed then */
+			smm_search_complete (search);
+			smm_search_destroy (search);
+		}
 	}
 
 	smm_asset_free_assets (assets, assets_count);
@@ -76,4 +84,3 @@ See the list of [contributors](https://github.com/canterbury-air-patrol/smm-asse
 
 ## License
 This project is licensed under GNU LGPLv2.1 see the [LICENSE.md](LICENSE.md) file for details.
-

--- a/src/smm-asset.h
+++ b/src/smm-asset.h
@@ -269,7 +269,7 @@ bool smm_search_get_waypoints (smm_search search, smm_waypoints *waypoints, size
  *
  * @param search the search to accept
  *
- * @return true if the server accepted this search begining, otherwise @ref smm_search_destory the search and @ref
+ * @return true if the server accepted this search begining, otherwise @ref smm_search_destroy the search and @ref
  * smm_asset_get_search again
  */
 bool smm_search_accept (smm_search search);

--- a/src/smm-asset.pc.in
+++ b/src/smm-asset.pc.in
@@ -5,7 +5,7 @@ includedir=@includedir@
 
 Name: @PACKAGE_NAME@
 Description: Library to act as an Asset for Search Management Map
-URL: https://github.com/canterbury-air-patrol/smm-asset
+URL: https://github.com/canterbury-air-patrol/smm-asset-api
 Version: @VERSION@
 Libs: -lsmmasset
 Cflags: -I${includedir}


### PR DESCRIPTION
## Description

- Update README.md examples to match current public API and types.
- Fix typo smm_search_destory -> smm_search_destroy in header doc comments.
- Normalize GitHub organization name to canterbury-air-patrol across README and pc file.
- Fix upstream search-management-map link in README.

## Summary by Sourcery

Align documentation and examples with the current public API and naming conventions.

Build:
- Normalize the GitHub organization name in the pkg-config template file to match the canonical repository location.

Documentation:
- Update README usage example to reflect the current C API types, function signatures, and error handling.
- Correct the upstream project link and GitHub organization naming in README.
- Fix a typo in the smm_search_destroy reference within header documentation comments.