### PR TITLE
fix: send heading= instead of bearing= in position URL

### DIFF
--- a/src/smm-asset-internal.h
+++ b/src/smm-asset-internal.h
@@ -113,3 +113,6 @@ bool smm_parse_waypoints (const char *data, size_t len, smm_waypoints *waypoints
 smm_asset smm_asset_create (smm_connection connection, const char *name, const char *type, long long asset_id,
 			    long long asset_type_id);
 void smm_asset_free_asset (smm_asset assets);
+
+char *smm_asset_build_position_url (long long asset_id, double lat, double lon, unsigned int alt, uint16_t heading,
+				    uint8_t fix);

--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -449,16 +449,28 @@ smm_asset_last_goto_pos (smm_asset asset, double *lat, double *lon)
 	return res;
 }
 
+char *
+smm_asset_build_position_url (long long asset_id, double lat, double lon, unsigned int alt, uint16_t heading,
+			      uint8_t fix)
+{
+	char *page = NULL;
+	if (asprintf (&page, "/data/assets/%lld/position/add/?lat=%lf&lon=%lf&alt=%u&heading=%u&fix=%u", asset_id, lat,
+		      lon, alt, heading, fix)
+	    < 0)
+		{
+			return NULL;
+		}
+	return page;
+}
+
 bool
 smm_asset_report_position (smm_asset asset, double latitude, double longitude, unsigned int altitude, uint16_t bearing,
 			   uint8_t fix)
 {
 	struct buffer_s buf = { NULL, 0 };
 
-	char *page = NULL;
-	if (asprintf (&page, "/data/assets/%lld/position/add/?lat=%lf&lon=%lf&alt=%u&bearing=%u&fix=%u",
-		      asset->asset_id, latitude, longitude, altitude, bearing, fix)
-	    < 0)
+	char *page = smm_asset_build_position_url (asset->asset_id, latitude, longitude, altitude, bearing, fix);
+	if (page == NULL)
 		{
 			return false;
 		}

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -148,6 +148,16 @@ START_TEST (test_waypoint_parsing)
 }
 END_TEST
 
+START_TEST (test_build_position_url_heading)
+{
+	char *url = smm_asset_build_position_url (42, -43.5, 172.6, 100, 270, 3);
+	ck_assert_ptr_nonnull (url);
+	ck_assert_ptr_nonnull (strstr (url, "heading="));
+	ck_assert_ptr_null (strstr (url, "bearing="));
+	free (url);
+}
+END_TEST
+
 START_TEST (test_invalid_host)
 {
 	smm_connection conn = smm_asset_connect ("not a url", "user", "pass");
@@ -169,6 +179,10 @@ smm_suite (void)
 	tc_conn = tcase_create ("Connection");
 	tcase_add_test (tc_conn, test_invalid_host);
 	suite_add_tcase (s, tc_conn);
+
+	TCase *tc_position = tcase_create ("Position");
+	tcase_add_test (tc_position, test_build_position_url_heading);
+	suite_add_tcase (s, tc_position);
 
 	tc_csrf = tcase_create ("CSRF");
 	tcase_add_test (tc_csrf, test_csrf_extraction);


### PR DESCRIPTION
## Description

The server reads the URL parameter as 'heading', not 'bearing'. The previous code silently caused the server to save every position with no heading value, resulting in persistent data loss.

Extracts a new internal helper, smm_asset_build_position_url, so the wire format can be tested in isolation. Adds a regression test that asserts the produced URL contains 'heading=' and does not contain 'bearing='.

## Summary by Sourcery

Fix position reporting to send heading parameter and add coverage for the URL format.

Bug Fixes:
- Correct position URL query parameter from bearing to heading so the server records heading values.

Enhancements:
- Extract helper smm_asset_build_position_url to construct position URLs for reuse and isolation.

Tests:
- Add unit test to verify the position URL uses heading and not bearing, and register it in the test suite.