### PR TITLE
fix: lock asset mutex when updating last_command from plaintext

### DIFF
--- a/src/smm-asset-internal.h
+++ b/src/smm-asset-internal.h
@@ -116,3 +116,5 @@ void smm_asset_free_asset (smm_asset assets);
 
 char *smm_asset_build_position_url (long long asset_id, double lat, double lon, unsigned int alt, uint16_t heading,
 				    uint8_t fix);
+
+void smm_asset_set_command_from_plaintext (smm_asset asset, const char *data, size_t len);

--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -449,6 +449,21 @@ smm_asset_last_goto_pos (smm_asset asset, double *lat, double *lon)
 	return res;
 }
 
+void
+smm_asset_set_command_from_plaintext (smm_asset asset, const char *data, size_t len)
+{
+	pthread_mutex_lock (&asset->lock);
+	if (data && strncmp (data, "Continue", len) == 0)
+		{
+			asset->last_command = SMM_COMMAND_CONTINUE;
+		}
+	else
+		{
+			asset->last_command = SMM_COMMAND_NONE;
+		}
+	pthread_mutex_unlock (&asset->lock);
+}
+
 char *
 smm_asset_build_position_url (long long asset_id, double lat, double lon, unsigned int alt, uint16_t heading,
 			      uint8_t fix)
@@ -497,14 +512,7 @@ smm_asset_report_position (smm_asset asset, double latitude, double longitude, u
 		}
 	else
 		{
-			if (buf.data && strncmp (buf.data, "Continue", buf.bytes) == 0)
-				{
-					asset->last_command = SMM_COMMAND_CONTINUE;
-				}
-			else
-				{
-					asset->last_command = SMM_COMMAND_NONE;
-				}
+			smm_asset_set_command_from_plaintext (asset, buf.data, buf.bytes);
 		}
 
 	free (buf.data);

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -148,6 +148,26 @@ START_TEST (test_waypoint_parsing)
 }
 END_TEST
 
+START_TEST (test_set_command_from_plaintext_continue)
+{
+	smm_asset asset = smm_asset_create (NULL, "A", "T", 1, 1);
+	ck_assert_ptr_nonnull (asset);
+	smm_asset_set_command_from_plaintext (asset, "Continue", 8);
+	ck_assert_int_eq (smm_asset_last_command (asset), SMM_COMMAND_CONTINUE);
+	smm_asset_free_asset (asset);
+}
+END_TEST
+
+START_TEST (test_set_command_from_plaintext_other)
+{
+	smm_asset asset = smm_asset_create (NULL, "A", "T", 1, 1);
+	ck_assert_ptr_nonnull (asset);
+	smm_asset_set_command_from_plaintext (asset, "Other", 5);
+	ck_assert_int_eq (smm_asset_last_command (asset), SMM_COMMAND_NONE);
+	smm_asset_free_asset (asset);
+}
+END_TEST
+
 START_TEST (test_build_position_url_heading)
 {
 	char *url = smm_asset_build_position_url (42, -43.5, 172.6, 100, 270, 3);
@@ -182,6 +202,8 @@ smm_suite (void)
 
 	TCase *tc_position = tcase_create ("Position");
 	tcase_add_test (tc_position, test_build_position_url_heading);
+	tcase_add_test (tc_position, test_set_command_from_plaintext_continue);
+	tcase_add_test (tc_position, test_set_command_from_plaintext_other);
 	suite_add_tcase (s, tc_position);
 
 	tc_csrf = tcase_create ("CSRF");


### PR DESCRIPTION
## Description

The non-JSON branch of smm_asset_report_position wrote to asset->last_command without holding asset->lock, racing with concurrent readers via smm_asset_last_command. This branch is hit on every successful position report when the asset is not in a mission (the server returns the plaintext "Continue").

Extracts the logic into smm_asset_set_command_from_plaintext, which acquires asset->lock for the duration of the read/write.

## Summary by Sourcery

Guard updates to an asset's last_command when handling plaintext position responses and cover the new behavior with unit tests.

Bug Fixes:
- Prevent data races by locking the asset mutex when updating last_command from plaintext position responses.

Enhancements:
- Extract the plaintext command parsing into a dedicated helper for reuse and clearer locking semantics.

Tests:
- Add unit tests verifying that plaintext commands set last_command to CONTINUE or NONE as expected.