### PR TITLE
fix: free action_page and buf.data on failure in smm_search_action

### DIFF
--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -786,11 +786,14 @@ smm_search_action (smm_search search, const char *action)
 	    = smm_connection_curl_retrieve_url (search->asset->conn, action_page, NULL, to_buffer, &buf, false);
 	if (res == NULL)
 		{
+			free (action_page);
 			return false;
 		}
 	else if (!(res->success && res->httpcode == HTTP_SUCCESS))
 		{
 			smm_curl_res_free (res);
+			free (action_page);
+			free (buf.data);
 			return false;
 		}
 

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -148,6 +148,23 @@ START_TEST (test_waypoint_parsing)
 }
 END_TEST
 
+START_TEST (test_search_accept_null_conn)
+{
+	struct smm_asset_s asset_s;
+	memset (&asset_s, 0, sizeof (asset_s));
+	asset_s.asset_id = 1;
+	pthread_mutex_init (&asset_s.lock, NULL);
+	struct smm_search_s search_s;
+	memset (&search_s, 0, sizeof (search_s));
+	search_s.asset = &asset_s;
+	search_s.url = strdup ("/search/1/");
+	bool r = smm_search_accept (&search_s);
+	ck_assert_int_eq (r, false);
+	free (search_s.url);
+	pthread_mutex_destroy (&asset_s.lock);
+}
+END_TEST
+
 START_TEST (test_set_command_from_plaintext_continue)
 {
 	smm_asset asset = smm_asset_create (NULL, "A", "T", 1, 1);
@@ -228,6 +245,10 @@ smm_suite (void)
 	TCase *tc_waypoints = tcase_create ("Waypoints");
 	tcase_add_test (tc_waypoints, test_waypoint_parsing);
 	suite_add_tcase (s, tc_waypoints);
+
+	TCase *tc_search = tcase_create ("Search");
+	tcase_add_test (tc_search, test_search_accept_null_conn);
+	suite_add_tcase (s, tc_search);
 
 	return s;
 }


### PR DESCRIPTION
## Description

Both early-return paths in smm_search_action leaked allocations: the res==NULL path leaked action_page, and the HTTP-failure path leaked both action_page and buf.data. The leaks are reachable on any HTTP error (e.g. 403/404), which can occur on every search begin/finished call.

Adds a regression test that exercises the res==NULL branch via a connection of NULL.

## Summary by Sourcery

Fix memory leaks in smm_search_action on failure paths and add regression coverage for null-connection search acceptance.

Bug Fixes:
- Ensure action_page is freed when smm_search_action returns early due to a NULL curl result.
- Ensure both action_page and the response buffer are freed when smm_search_action fails due to an unsuccessful HTTP response.

Tests:
- Add a regression test verifying smm_search_accept handles a NULL connection without leaking resources and wire it into the Search test case suite.