### PR TITLE
fix: free buf.data on HTTP failure in smm_asset_report_position

### DIFF
--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -500,6 +500,7 @@ smm_asset_report_position (smm_asset asset, double latitude, double longitude, u
 		{
 			smm_curl_res_free (res);
 			free (page);
+			free (buf.data);
 			return false;
 		}
 

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -165,6 +165,16 @@ START_TEST (test_search_accept_null_conn)
 }
 END_TEST
 
+START_TEST (test_report_position_null_conn)
+{
+	smm_asset asset = smm_asset_create (NULL, "A", "T", 1, 1);
+	ck_assert_ptr_nonnull (asset);
+	bool r = smm_asset_report_position (asset, -43.5, 172.6, 100, 270, 3);
+	ck_assert_int_eq (r, false);
+	smm_asset_free_asset (asset);
+}
+END_TEST
+
 START_TEST (test_set_command_from_plaintext_continue)
 {
 	smm_asset asset = smm_asset_create (NULL, "A", "T", 1, 1);
@@ -221,6 +231,7 @@ smm_suite (void)
 	tcase_add_test (tc_position, test_build_position_url_heading);
 	tcase_add_test (tc_position, test_set_command_from_plaintext_continue);
 	tcase_add_test (tc_position, test_set_command_from_plaintext_other);
+	tcase_add_test (tc_position, test_report_position_null_conn);
 	suite_add_tcase (s, tc_position);
 
 	tc_csrf = tcase_create ("CSRF");


### PR DESCRIPTION
## Description

The early-return path on HTTP failure leaked buf.data. The leak is reachable on any HTTP error response.

Adds a regression test that exercises the failure path via a NULL connection.

## Summary by Sourcery

Fix memory leak in smm_asset_report_position on HTTP failure and add a regression test for the null-connection failure path.

Bug Fixes:
- Free allocated HTTP response buffer when smm_asset_report_position returns early on failure to avoid a memory leak.

Tests:
- Add regression test that exercises smm_asset_report_position with a NULL connection to ensure the failure path is handled correctly.