### PR TITLE
fix: serialise concurrent login attempts

### DIFF
--- a/src/smm-asset-curl.c
+++ b/src/smm-asset-curl.c
@@ -495,6 +495,24 @@ smm_asset_connection_login (smm_connection connection)
 {
 	bool res = false;
 	TidyBuffer docbuf = { 0 };
+	char *csrf_token = NULL;
+	smm_connection_status new_state = SMM_CONNECTION_FAILURE;
+
+	/* Serialise concurrent login attempts. If another thread is already
+	 * logging in, wait for it to finish. When it does, if the connection is
+	 * now CONNECTED, return success without making another login attempt. */
+	pthread_mutex_lock (&connection->lock);
+	while (connection->login_in_progress)
+		{
+			pthread_cond_wait (&connection->login_cond, &connection->lock);
+		}
+	if (connection->state == SMM_CONNECTION_CONNECTED)
+		{
+			pthread_mutex_unlock (&connection->lock);
+			return true;
+		}
+	connection->login_in_progress = true;
+	pthread_mutex_unlock (&connection->lock);
 
 	tidyBufInit (&docbuf);
 
@@ -505,13 +523,13 @@ smm_asset_connection_login (smm_connection connection)
 	if (res_get && res_get->success && res_get->httpcode == HTTP_SUCCESS)
 		{
 			/* find the input token with the csrfmiddlewaretoken */
-			connection->csrfmiddlewaretoken = smm_parse_csrf_token ((const char *)docbuf.bp, docbuf.size);
+			csrf_token = smm_parse_csrf_token ((const char *)docbuf.bp, docbuf.size);
 
-			if (connection->csrfmiddlewaretoken)
+			if (csrf_token)
 				{
 					char *post_data = NULL;
-					if (smm_build_login_post_data (connection->csrfmiddlewaretoken,
-								       connection->user, connection->pass, &post_data))
+					if (smm_build_login_post_data (csrf_token, connection->user, connection->pass,
+								       &post_data))
 						{
 							struct smm_curl_res_s *res_post
 							    = smm_connection_curl_retrieve_url (
@@ -521,31 +539,30 @@ smm_asset_connection_login (smm_connection connection)
 							    && res_post->httpcode == HTTP_FOUND)
 								{
 									res = true;
-									connection->state = SMM_CONNECTION_CONNECTED;
+									new_state = SMM_CONNECTION_CONNECTED;
 								}
 							else
 								{
-									connection->state
-									    = SMM_CONNECTION_AUTHENTICATION_FAILURE;
+									new_state = SMM_CONNECTION_AUTHENTICATION_FAILURE;
 								}
 							smm_curl_res_free (res_post);
 							free (post_data);
 						}
 					else
 						{
-							connection->state = SMM_CONNECTION_FAILURE;
+							new_state = SMM_CONNECTION_FAILURE;
 						}
 				}
 			else
 				{
 					DEBUG ("Failed to find CSRF token in login page\n");
-					connection->state = SMM_CONNECTION_PROTOCOL_ERROR;
+					new_state = SMM_CONNECTION_PROTOCOL_ERROR;
 				}
 		}
 	else if (!res_get)
 		{
 			DEBUG ("No res object returned\n");
-			connection->state = SMM_CONNECTION_NO_HOST_CONNECTION;
+			new_state = SMM_CONNECTION_NO_HOST_CONNECTION;
 		}
 	else
 		{
@@ -555,6 +572,19 @@ smm_asset_connection_login (smm_connection connection)
 	smm_curl_res_free (res_get);
 
 	tidyBufFree (&docbuf);
+
+	/* Publish the CSRF token and state under the lock, then release the
+	 * login flag and wake any waiters. */
+	pthread_mutex_lock (&connection->lock);
+	if (csrf_token)
+		{
+			free (connection->csrfmiddlewaretoken);
+			connection->csrfmiddlewaretoken = csrf_token;
+		}
+	connection->state = new_state;
+	connection->login_in_progress = false;
+	pthread_cond_broadcast (&connection->login_cond);
+	pthread_mutex_unlock (&connection->lock);
 
 	return res;
 }

--- a/src/smm-asset-internal.h
+++ b/src/smm-asset-internal.h
@@ -52,6 +52,8 @@ struct smm_connection_s
 	pthread_mutex_t lock;
 	bool verify_tls;
 	int refcount;
+	bool login_in_progress;
+	pthread_cond_t login_cond;
 };
 
 struct smm_asset_s

--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -67,6 +67,8 @@ smm_asset_connect (const char *host, const char *user, const char *pass)
 		}
 
 	pthread_mutex_init (&conn->lock, NULL);
+	conn->login_in_progress = false;
+	pthread_cond_init (&conn->login_cond, NULL);
 	if (!smm_connection_share_init (conn))
 		{
 			conn->state = SMM_CONNECTION_FAILURE;
@@ -129,6 +131,7 @@ smm_connection_unref (smm_connection connection)
 			free (connection->pass);
 			free (connection->csrfmiddlewaretoken);
 			smm_connection_share_destroy (connection);
+			pthread_cond_destroy (&connection->login_cond);
 			pthread_mutex_destroy (&connection->lock);
 			free (connection);
 		}

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -214,6 +214,17 @@ START_TEST (test_invalid_host)
 }
 END_TEST
 
+START_TEST (test_connection_login_fields_initialised)
+{
+	smm_connection conn = smm_asset_connect ("not a url", "user", "pass");
+	ck_assert_ptr_nonnull (conn);
+	/* login_in_progress must be false after smm_asset_connect; if not, a
+	 * subsequent caller would deadlock waiting on the condition variable. */
+	ck_assert_int_eq (conn->login_in_progress, false);
+	smm_connection_close (conn);
+}
+END_TEST
+
 Suite *
 smm_suite (void)
 {
@@ -225,6 +236,7 @@ smm_suite (void)
 
 	tc_conn = tcase_create ("Connection");
 	tcase_add_test (tc_conn, test_invalid_host);
+	tcase_add_test (tc_conn, test_connection_login_fields_initialised);
 	suite_add_tcase (s, tc_conn);
 
 	TCase *tc_position = tcase_create ("Position");


### PR DESCRIPTION
## Description

Two threads that both received a 302 redirect to /accounts/login/ could enter smm_asset_connection_login simultaneously, both write connection->csrfmiddlewaretoken and connection->state without holding the connection lock, and race against each other and against unrelated readers.

Adds login_in_progress and login_cond fields to smm_connection_s. On entry, smm_asset_connection_login now waits while another login is in flight and, once the previous attempt finishes, short-circuits if the connection is already CONNECTED. The slow path remains unlocked across the network calls (only the in-progress flag and the published CSRF token / state are guarded).

## Summary by Sourcery

Serialise concurrent login attempts on a connection to avoid races when multiple threads log in simultaneously.

Bug Fixes:
- Prevent concurrent login attempts from racing when updating connection state and CSRF token.

Enhancements:
- Track login progress with a condition variable and short-circuit redundant login attempts when the connection is already established.

Tests:
- Add a regression test to ensure new login synchronisation fields are correctly initialised on connection creation.