### PR TITLE
fix: accept integer JSON numbers for GOTO coordinates

### DIFF
--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -363,16 +363,19 @@ smm_parse_command (const char *data, size_t len, smm_asset_command *command, dou
 							res = true;
 							if (strcmp (cmd_str, "GOTO") == 0)
 								{
-									/* Get lat and long as well */
+									/* Get lat and long as well. Accept any
+									 * JSON number (real or integer); the
+									 * server normally emits floats but the
+									 * contract does not guarantee it. */
 									tmp = json_object_get (json_root, "latitude");
-									if (json_is_real (tmp))
+									if (json_is_number (tmp))
 										{
-											*lat = json_real_value (tmp);
+											*lat = json_number_value (tmp);
 										}
 									tmp = json_object_get (json_root, "longitude");
-									if (json_is_real (tmp))
+									if (json_is_number (tmp))
 										{
-											*lon = json_real_value (tmp);
+											*lon = json_number_value (tmp);
 										}
 									*command = SMM_COMMAND_GOTO;
 								}

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -106,6 +106,20 @@ START_TEST (test_command_parsing_goto)
 }
 END_TEST
 
+START_TEST (test_command_parsing_goto_integer_coords)
+{
+	const char *json = "{\"action\": \"GOTO\", \"latitude\": -43, \"longitude\": 172}";
+	smm_asset_command cmd;
+	double lat = 0, lon = 0;
+	bool res = smm_parse_command (json, strlen (json), &cmd, &lat, &lon);
+
+	ck_assert_uint_eq (res, true);
+	ck_assert_int_eq (cmd, SMM_COMMAND_GOTO);
+	ck_assert_ldouble_eq_tol (lat, -43.0, 0.0001);
+	ck_assert_ldouble_eq_tol (lon, 172.0, 0.0001);
+}
+END_TEST
+
 START_TEST (test_command_parsing_rtl)
 {
 	const char *json = "{\"action\": \"RTL\"}";
@@ -261,6 +275,7 @@ smm_suite (void)
 
 	TCase *tc_commands = tcase_create ("Commands");
 	tcase_add_test (tc_commands, test_command_parsing_goto);
+	tcase_add_test (tc_commands, test_command_parsing_goto_integer_coords);
 	tcase_add_test (tc_commands, test_command_parsing_rtl);
 	tcase_add_test (tc_commands, test_command_parsing_unknown);
 	suite_add_tcase (s, tc_commands);


### PR DESCRIPTION
## Description

json_is_real and json_real_value reject JSON integers, even though jansson's json_number_* family accepts both. The server contract does not promise a trailing decimal, so use json_is_number / json_number_value to accept either.

## Summary by Sourcery

Allow GOTO command parsing to accept both integer and floating-point JSON coordinates and add coverage for integer inputs.

Bug Fixes:
- Fix GOTO command parsing to accept JSON integer values for latitude and longitude, not just real numbers.

Tests:
- Add a test case ensuring GOTO commands with integer latitude/longitude values are parsed correctly.