### PR TITLE
fix: reject absolute object_url responses defensively

### DIFF
--- a/src/smm-asset-internal.h
+++ b/src/smm-asset-internal.h
@@ -120,3 +120,5 @@ char *smm_asset_build_position_url (long long asset_id, double lat, double lon, 
 				    uint8_t fix);
 
 void smm_asset_set_command_from_plaintext (smm_asset asset, const char *data, size_t len);
+
+smm_search smm_parse_search_json (smm_asset asset, const char *data, size_t len);

--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -839,6 +839,62 @@ smm_waypoints_free (smm_waypoints waypoints, size_t waypoints_count)
 }
 
 smm_search
+smm_parse_search_json (smm_asset asset, const char *data, size_t len)
+{
+	smm_search search = NULL;
+	json_t *json_root = NULL;
+	json_error_t json_error;
+
+	json_root = json_loadb (data, len, 0, &json_error);
+	if (json_root)
+		{
+			const char *url = NULL;
+			uint64_t distance = 0;
+			uint64_t length = 0;
+			uint64_t sweep_width = 0;
+			json_t *tmp = json_object_get (json_root, "object_url");
+			if (tmp)
+				{
+					url = json_string_value (tmp);
+				}
+			/* The server contract emits object_url as a relative path
+			 * (e.g. "/search/42/"). Reject absolute URLs defensively in
+			 * case the contract ever changes — accepting them blindly
+			 * here would let the server steer us at an arbitrary host. */
+			if (url && (strncmp (url, "http://", 7) == 0 || strncmp (url, "https://", 8) == 0))
+				{
+					DEBUG ("object_url is absolute; ignoring\n");
+					url = NULL;
+				}
+			tmp = json_object_get (json_root, "distance");
+			if (tmp)
+				{
+					distance = json_integer_value (tmp);
+				}
+			tmp = json_object_get (json_root, "length");
+			if (tmp)
+				{
+					length = json_integer_value (tmp);
+				}
+			tmp = json_object_get (json_root, "sweep_width");
+			if (tmp)
+				{
+					sweep_width = json_integer_value (tmp);
+				}
+			if (url)
+				{
+					search = smm_search_create (asset, url, length, distance, sweep_width);
+				}
+			json_decref (json_root);
+		}
+	else
+		{
+			DEBUG ("JSON Parse Error on line %i: %s\n", json_error.line, json_error.text);
+		}
+	return search;
+}
+
+smm_search
 smm_asset_get_search (smm_asset asset, double latitude, double longitude)
 {
 	smm_search search = NULL;
@@ -870,43 +926,7 @@ smm_asset_get_search (smm_asset asset, double latitude, double longitude)
 
 	if (res->content_type != NULL && strcmp (res->content_type, "application/json") == 0)
 		{
-			json_t *json_root = NULL;
-			json_error_t json_error;
-
-			json_root = json_loadb (buf.data, buf.bytes, 0, &json_error);
-			if (json_root)
-				{
-					const char *url = NULL;
-					uint64_t distance = 0;
-					uint64_t length = 0;
-					uint64_t sweep_width = 0;
-					json_t *tmp = json_object_get (json_root, "object_url");
-					if (tmp)
-						{
-							url = json_string_value (tmp);
-						}
-					tmp = json_object_get (json_root, "distance");
-					if (tmp)
-						{
-							distance = json_integer_value (tmp);
-						}
-					tmp = json_object_get (json_root, "length");
-					if (tmp)
-						{
-							length = json_integer_value (tmp);
-						}
-					tmp = json_object_get (json_root, "sweep_width");
-					if (tmp)
-						{
-							sweep_width = json_integer_value (tmp);
-						}
-					search = smm_search_create (asset, url, length, distance, sweep_width);
-					json_decref (json_root);
-				}
-			else
-				{
-					DEBUG ("JSON Parse Error on line %i: %s\n", json_error.line, json_error.text);
-				}
+			search = smm_parse_search_json (asset, buf.data, buf.bytes);
 		}
 	smm_curl_res_free (res);
 	free (buf.data);

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -162,6 +162,28 @@ START_TEST (test_waypoint_parsing)
 }
 END_TEST
 
+START_TEST (test_get_search_absolute_url_ignored)
+{
+	const char *json = "{\"object_url\": \"https://example.com/search/1/\", \"distance\": 10, \"length\": 100, "
+			   "\"sweep_width\": 50}";
+	smm_search search = smm_parse_search_json (NULL, json, strlen (json));
+	ck_assert_ptr_null (search);
+}
+END_TEST
+
+START_TEST (test_get_search_relative_url_accepted)
+{
+	const char *json
+	    = "{\"object_url\": \"/search/1/\", \"distance\": 10, \"length\": 100, \"sweep_width\": 50}";
+	smm_search search = smm_parse_search_json (NULL, json, strlen (json));
+	ck_assert_ptr_nonnull (search);
+	ck_assert_uint_eq (smm_search_distance (search), 10);
+	ck_assert_uint_eq (smm_search_length (search), 100);
+	ck_assert_uint_eq (smm_search_sweep_width (search), 50);
+	smm_search_destroy (search);
+}
+END_TEST
+
 START_TEST (test_search_accept_null_conn)
 {
 	struct smm_asset_s asset_s;
@@ -319,6 +341,8 @@ smm_suite (void)
 
 	TCase *tc_search = tcase_create ("Search");
 	tcase_add_test (tc_search, test_search_accept_null_conn);
+	tcase_add_test (tc_search, test_get_search_absolute_url_ignored);
+	tcase_add_test (tc_search, test_get_search_relative_url_accepted);
 	suite_add_tcase (s, tc_search);
 
 	return s;


### PR DESCRIPTION
## Description

The SMM server emits object_url as a relative path (e.g. "/search/42/"). The library would happily strdup an absolute URL and pass it through to curl as a path, which is wrong; if the server contract ever changed it would also let the server redirect us to an arbitrary host.

Extracts the search-response JSON parsing into smm_parse_search_json so it can be tested directly. If object_url begins with http:// or https://, the url is treated as absent and no search is returned.

## Summary by Sourcery

Reject absolute search object URLs and factor JSON parsing into a reusable helper.

Bug Fixes:
- Ignore absolute object_url values in search responses to prevent misuse as arbitrary paths.

Enhancements:
- Extract search response JSON parsing into smm_parse_search_json for reuse and direct testing.

Tests:
- Add tests covering acceptance of relative object_url values and rejection of absolute URLs in search parsing.