### PR TITLE
refactor: consolidate http_return_codes into the internal header

### DIFF
--- a/src/smm-asset-curl.c
+++ b/src/smm-asset-curl.c
@@ -38,14 +38,6 @@
 #error No tidy header(s)
 #endif
 
-enum http_return_codes
-{
-	HTTP_SUCCESS = 200,
-	HTTP_MOVED_PERMANENTLY = 301,
-	HTTP_FOUND = 302,
-	HTTP_SEE_OTHER = 303,
-};
-
 static void
 smm_curl_lock (CURL *handle, curl_lock_data data, curl_lock_access access, void *userptr)
 {

--- a/src/smm-asset-internal.h
+++ b/src/smm-asset-internal.h
@@ -29,6 +29,14 @@
 
 #include <curl/curl.h>
 
+enum http_return_codes
+{
+	HTTP_SUCCESS = 200,
+	HTTP_MOVED_PERMANENTLY = 301,
+	HTTP_FOUND = 302,
+	HTTP_SEE_OTHER = 303,
+};
+
 extern bool smm_debug;
 #define DEBUG(...)                                                                                                     \
 	do                                                                                                             \

--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -29,11 +29,6 @@
 
 #include <jansson.h>
 
-enum http_return_codes
-{
-	HTTP_SUCCESS = 200,
-};
-
 bool smm_debug = false;
 
 void


### PR DESCRIPTION
## Description

The enum was defined twice — once in smm-asset.c (only HTTP_SUCCESS) and once in smm-asset-curl.c. Move the single definition into smm-asset-internal.h so both translation units share it.

## Summary by Sourcery

Enhancements:
- Deduplicate HTTP return code definitions by moving the enum into smm-asset-internal.h for shared use.