### PR TITLE
build: include <stdio.h> for printf in DEBUG macro

### DIFF
--- a/src/smm-asset-internal.h
+++ b/src/smm-asset-internal.h
@@ -26,6 +26,7 @@
 
 #include <pthread.h>
 #include <stdbool.h>
+#include <stdio.h>
 
 #include <curl/curl.h>
 


### PR DESCRIPTION
## Description

The DEBUG macro defined in smm-asset-internal.h uses printf, but the header did not include <stdio.h>. Translation units that pull this header in worked only by transitive luck.

## Summary by Sourcery

Build:
- Add <stdio.h> include to smm-asset-internal.h so translation units using the DEBUG macro have a correct printf declaration.