### PR TITLE
refactor: remove dead NULL check after asprintf in smm_search_action

### DIFF
--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -782,10 +782,6 @@ smm_search_action (smm_search search, const char *action)
 		{
 			return false;
 		}
-	if (action_page == NULL)
-		{
-			return false;
-		}
 
 	struct smm_curl_res_s *res
 	    = smm_connection_curl_retrieve_url (search->asset->conn, action_page, NULL, to_buffer, &buf, false);


### PR DESCRIPTION
## Description

asprintf is documented to return -1 on failure and leave the output pointer unspecified; we already guard on the return value, so the subsequent NULL check is unreachable.

## Summary by Sourcery

Enhancements:
- Simplify smm_search_action by relying on asprintf's return value instead of an additional NULL pointer check.