### PR TITLE
fix: make smm_debug an _Atomic bool

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,4 +1,4 @@
-AM_CFLAGS = $(WERROR_CFLAGS) -Wall -Wformat=2 -Wvla -Wextra -Wwrite-strings -Wmissing-prototypes -Wunreachable-code -pedantic -std=c99 -D_DEFAULT_SOURCE -D_GNU_SOURCE
+AM_CFLAGS = $(WERROR_CFLAGS) -Wall -Wformat=2 -Wvla -Wextra -Wwrite-strings -Wmissing-prototypes -Wunreachable-code -pedantic -std=c11 -D_DEFAULT_SOURCE -D_GNU_SOURCE
 AM_CFLAGS += $(TIDY_CFLAGS) $(CURL_CFLAGS) $(JANSSON_CFLAGS)
 
 lib_LTLIBRARIES = libsmmasset.la

--- a/src/smm-asset-internal.h
+++ b/src/smm-asset-internal.h
@@ -38,7 +38,7 @@ enum http_return_codes
 	HTTP_SEE_OTHER = 303,
 };
 
-extern bool smm_debug;
+extern _Atomic bool smm_debug;
 #define DEBUG(...)                                                                                                     \
 	do                                                                                                             \
 		{                                                                                                      \

--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -29,7 +29,7 @@
 
 #include <jansson.h>
 
-bool smm_debug = false;
+_Atomic bool smm_debug = false;
 
 void
 smm_asset_debugging_set (bool debug)

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -289,6 +289,13 @@ START_TEST (test_invalid_host)
 }
 END_TEST
 
+START_TEST (test_debugging_set)
+{
+	smm_asset_debugging_set (true);
+	smm_asset_debugging_set (false);
+}
+END_TEST
+
 START_TEST (test_connection_login_fields_initialised)
 {
 	smm_connection conn = smm_asset_connect ("not a url", "user", "pass");
@@ -312,6 +319,7 @@ smm_suite (void)
 	tc_conn = tcase_create ("Connection");
 	tcase_add_test (tc_conn, test_invalid_host);
 	tcase_add_test (tc_conn, test_connection_login_fields_initialised);
+	tcase_add_test (tc_conn, test_debugging_set);
 	suite_add_tcase (s, tc_conn);
 
 	TCase *tc_position = tcase_create ("Position");


### PR DESCRIPTION
## Description

The global smm_debug flag was read from every DEBUG site and could be written from any thread via smm_asset_debugging_set, racing in both directions. _Atomic bool gives sequentially consistent loads/stores without an explicit memory barrier at each call site.

_Atomic requires C11; bump the standard for the library translation units from c99 to c11 to match. All other code already compiles cleanly under c11.

## Summary by Sourcery

Make the global smm_debug flag atomic and update the build to C11 to ensure thread-safe debug flag access.

Enhancements:
- Change smm_debug to an _Atomic bool to ensure thread-safe reads and writes of the global debug flag.

Build:
- Bump the C standard for library sources from C99 to C11 to support _Atomic usage.

Tests:
- Add a test verifying smm_asset_debugging_set can toggle the debug flag on and off.