### PR TITLE
fix: return NULL from smm_asset_connect when any argument is NULL

### DIFF
--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -40,6 +40,11 @@ smm_asset_debugging_set (bool debug)
 smm_connection
 smm_asset_connect (const char *host, const char *user, const char *pass)
 {
+	if (host == NULL || user == NULL || pass == NULL)
+		{
+			return NULL;
+		}
+
 	smm_connection conn = calloc (1, sizeof (struct smm_connection_s));
 	if (conn == NULL)
 		{


### PR DESCRIPTION
## Description

Previously passing NULL for host, user, or pass would cause strdup(NULL), which is undefined behaviour on most platforms.

## Summary by Sourcery

Bug Fixes:
- Return NULL from smm_asset_connect when any of host, user, or pass is NULL instead of calling strdup on a NULL pointer.