### PR TITLE
fix: prevent self-deadlock in smm_asset_connection_login on redirect loop

### DIFF
--- a/src/smm-asset-curl.c
+++ b/src/smm-asset-curl.c
@@ -170,7 +170,7 @@ to_buffer (char *ptr, size_t size, size_t nmemb, void *userdata)
 	return new_bytes;
 }
 
-static struct smm_curl_res_s *
+struct smm_curl_res_s *
 smm_connection_curl_retrieve_url_r (smm_connection conn, const char *path, const char *post_data,
 				    size_t (*write_func) (char *ptr, size_t size, size_t nmemb, void *userdata),
 				    void *write_data, bool json)
@@ -508,9 +508,10 @@ smm_asset_connection_login (smm_connection connection)
 
 	tidyBufInit (&docbuf);
 
-	/* Get the login page, so we can get the csrf cookie + token */
+	/* Use the raw (non-retrying) fetch so that a redirect on the login page
+	 * itself does not recurse back into smm_asset_connection_login. */
 	struct smm_curl_res_s *res_get
-	    = smm_connection_curl_retrieve_url (connection, "/accounts/login/", NULL, populate_tidy, &docbuf, false);
+	    = smm_connection_curl_retrieve_url_r (connection, "/accounts/login/", NULL, populate_tidy, &docbuf, false);
 
 	if (res_get && res_get->success && res_get->httpcode == HTTP_SUCCESS)
 		{
@@ -524,7 +525,7 @@ smm_asset_connection_login (smm_connection connection)
 								       &post_data))
 						{
 							struct smm_curl_res_s *res_post
-							    = smm_connection_curl_retrieve_url (
+							    = smm_connection_curl_retrieve_url_r (
 								connection, "/accounts/login/", post_data, NULL, NULL,
 								false);
 							if (res_post && res_post->success

--- a/src/smm-asset-internal.h
+++ b/src/smm-asset-internal.h
@@ -110,6 +110,13 @@ void smm_connection_share_destroy (smm_connection conn);
 void smm_connection_unref (smm_connection conn);
 
 void smm_curl_res_free (struct smm_curl_res_s *);
+/* Raw single-shot fetch: no retry, no login redirect, no HTTPS upgrade.
+ * Use this inside login itself to avoid re-entrant login attempts. */
+struct smm_curl_res_s *smm_connection_curl_retrieve_url_r (smm_connection conn, const char *path,
+							   const char *post_data,
+							   size_t (*write_func) (char *ptr, size_t size,
+										 size_t nmemb, void *userdata),
+							   void *write_data, bool json);
 struct smm_curl_res_s *smm_connection_curl_retrieve_url (smm_connection conn, const char *path, const char *post_data,
 							 size_t (*write_func) (char *ptr, size_t size, size_t nmemb,
 									       void *userdata),

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -280,6 +280,20 @@ START_TEST (test_build_position_url_heading)
 }
 END_TEST
 
+START_TEST (test_login_in_progress_reset_on_failure)
+{
+	/* login_in_progress must be false after a failed attempt so no caller
+	 * waiting on login_cond is ever stranded. Port 19999 is chosen to be
+	 * unreachable without blocking for long (connect-refused, not timeout). */
+	smm_connection conn = smm_asset_connect ("http://127.0.0.1:19999/", "user", "pass");
+	ck_assert_ptr_nonnull (conn);
+	bool res = smm_asset_connection_login (conn);
+	ck_assert_int_eq (res, false);
+	ck_assert_int_eq (conn->login_in_progress, false);
+	smm_connection_close (conn);
+}
+END_TEST
+
 START_TEST (test_invalid_host)
 {
 	smm_connection conn = smm_asset_connect ("not a url", "user", "pass");
@@ -471,6 +485,7 @@ smm_suite (void)
 	s = suite_create ("SMM");
 
 	tc_conn = tcase_create ("Connection");
+	tcase_add_test (tc_conn, test_login_in_progress_reset_on_failure);
 	tcase_add_test (tc_conn, test_invalid_host);
 	tcase_add_test (tc_conn, test_connect_null_host);
 	tcase_add_test (tc_conn, test_connect_null_user);


### PR DESCRIPTION
## Description

The retry wrapper (smm_connection_curl_retrieve_url) calls smm_asset_connection_login when it sees a 302 to accounts/login.  If the login page itself returns a redirect, the wrapper would recurse back into smm_asset_connection_login on the same thread.  With login_in_progress already true, the thread would block on pthread_cond_wait indefinitely.

Fix: expose smm_connection_curl_retrieve_url_r (the raw single-shot fetch) and use it for both the GET and POST inside smm_asset_connection_login, bypassing the retry/re-login loop entirely for those calls.

Test: verify login_in_progress is reset to false after a failed login so no waiter can be stranded.

## Summary by Sourcery

Prevent re-entrant login attempts from causing self-deadlocks during asset connection login redirects.

Bug Fixes:
- Ensure login_in_progress is reset to false after failed login attempts to avoid stranded waiters.
- Bypass the retry/re-login wrapper when fetching the login page and posting credentials to prevent recursive login calls on redirect loops.

Enhancements:
- Expose the raw single-shot CURL retrieval helper for internal use in login flows.

Tests:
- Add a connection test verifying login_in_progress is cleared after a failed login attempt on an unreachable endpoint.