### PR TITLE
fix: acquire connection lock in smm_asset_connection_get_state

### DIFF
--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -99,7 +99,10 @@ smm_asset_connection_get_state (smm_connection connection)
 		{
 			return SMM_CONNECTION_UNKNOWN;
 		}
-	return connection->state;
+	pthread_mutex_lock (&connection->lock);
+	smm_connection_status state = connection->state;
+	pthread_mutex_unlock (&connection->lock);
+	return state;
 }
 
 void

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -475,6 +475,21 @@ START_TEST (test_connection_login_fields_initialised)
 }
 END_TEST
 
+START_TEST (test_get_state_null_connection)
+{
+	ck_assert_int_eq (smm_asset_connection_get_state (NULL), SMM_CONNECTION_UNKNOWN);
+}
+END_TEST
+
+START_TEST (test_get_state_initial)
+{
+	smm_connection conn = smm_asset_connect ("http://localhost/", "user", "pass");
+	ck_assert_ptr_nonnull (conn);
+	ck_assert_int_eq (smm_asset_connection_get_state (conn), SMM_CONNECTION_UNKNOWN);
+	smm_connection_close (conn);
+}
+END_TEST
+
 Suite *
 smm_suite (void)
 {
@@ -491,6 +506,8 @@ smm_suite (void)
 	tcase_add_test (tc_conn, test_connect_null_user);
 	tcase_add_test (tc_conn, test_connect_null_pass);
 	tcase_add_test (tc_conn, test_connection_login_fields_initialised);
+	tcase_add_test (tc_conn, test_get_state_null_connection);
+	tcase_add_test (tc_conn, test_get_state_initial);
 	tcase_add_test (tc_conn, test_debugging_set);
 	suite_add_tcase (s, tc_conn);
 


### PR DESCRIPTION
## Description

The state field was being read without holding the mutex, creating a data race with writers (login, connect) that always held the lock.

## Summary by Sourcery

Protect connection state reads with the connection mutex to avoid data races and add tests around the initial and null-connection state handling.

Bug Fixes:
- Fix a data race by acquiring the connection lock before reading the connection state.

Tests:
- Add tests verifying smm_asset_connection_get_state returns UNKNOWN for null and newly created connections.