### PR TITLE
fix: use json_number_value for waypoint coordinates

### DIFF
--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -675,9 +675,13 @@ smm_parse_waypoints (const char *data, size_t len, smm_waypoints *waypoints, siz
 														    = json_array_get (
 															value,
 															0);
-														lat = json_real_value (
+														if (!json_is_number (json_lat) || !json_is_number (json_lon))
+															{
+															    continue;
+															}
+														lat = json_number_value (
 														    json_lat);
-														lon = json_real_value (
+														lon = json_number_value (
 														    json_lon);
 														smm_waypoint
 														    new_wp

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -402,6 +402,26 @@ START_TEST (test_waypoints_parsing_multiple_features)
 }
 END_TEST
 
+START_TEST (test_waypoint_parsing_integer_coords)
+{
+	/* GeoJSON coordinates may be integers; json_real_value returns 0 for
+	 * integer JSON nodes, so we must use json_number_value instead. */
+	const char *json = "{\"features\": [{\"geometry\": {\"coordinates\": [[173, -44], [172, -43]]}}]}";
+	smm_waypoints waypoints;
+	size_t count;
+	bool res = smm_parse_waypoints (json, strlen (json), &waypoints, &count);
+
+	ck_assert_uint_eq (res, true);
+	ck_assert_uint_eq (count, 2);
+	ck_assert_ldouble_eq_tol (waypoints[0]->lat, -44.0, 0.0001);
+	ck_assert_ldouble_eq_tol (waypoints[0]->lon, 173.0, 0.0001);
+	ck_assert_ldouble_eq_tol (waypoints[1]->lat, -43.0, 0.0001);
+	ck_assert_ldouble_eq_tol (waypoints[1]->lon, 172.0, 0.0001);
+
+	smm_waypoints_free (waypoints, count);
+}
+END_TEST
+
 START_TEST (test_asset_last_goto_pos_not_goto)
 {
 	smm_asset asset = smm_asset_create (NULL, "A", "T", 1, 1);
@@ -550,6 +570,7 @@ smm_suite (void)
 	tcase_add_test (tc_waypoints, test_waypoint_parsing);
 	tcase_add_test (tc_waypoints, test_waypoints_parsing_empty_features);
 	tcase_add_test (tc_waypoints, test_waypoints_parsing_multiple_features);
+	tcase_add_test (tc_waypoints, test_waypoint_parsing_integer_coords);
 	suite_add_tcase (s, tc_waypoints);
 
 	TCase *tc_search = tcase_create ("Search");


### PR DESCRIPTION
## Description

json_real_value returns 0.0 for integer JSON nodes, silently zeroing any whole-number lat/lon coordinate. json_number_value handles both real and integer nodes, matching the same fix already applied to the GOTO command parser.

## Summary by Sourcery

Handle numeric waypoint coordinates correctly and add regression coverage for integer-based GeoJSON waypoints.

Bug Fixes:
- Fix waypoint parsing to correctly read both integer and real JSON coordinate values instead of zeroing integer lat/lon.
- Skip waypoint entries whose latitude or longitude JSON nodes are not numeric.

Tests:
- Add a waypoint parsing test that verifies integer GeoJSON coordinates are parsed into correct latitude and longitude values.