### PR TITLE
api: rename bearing to heading in smm_asset_report_position

### DIFF
--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -491,12 +491,12 @@ smm_asset_build_position_url (long long asset_id, double lat, double lon, unsign
 }
 
 bool
-smm_asset_report_position (smm_asset asset, double latitude, double longitude, unsigned int altitude, uint16_t bearing,
+smm_asset_report_position (smm_asset asset, double latitude, double longitude, unsigned int altitude, uint16_t heading,
 			   uint8_t fix)
 {
 	struct buffer_s buf = { NULL, 0 };
 
-	char *page = smm_asset_build_position_url (asset->asset_id, latitude, longitude, altitude, bearing, fix);
+	char *page = smm_asset_build_position_url (asset->asset_id, latitude, longitude, altitude, heading, fix);
 	if (page == NULL)
 		{
 			return false;

--- a/src/smm-asset.h
+++ b/src/smm-asset.h
@@ -181,13 +181,13 @@ const char *smm_asset_type (smm_asset asset);
  * @param latitude The current latitude in degrees
  * @param longitude The current longitude in degrees
  * @param altitude The current altitude in meters
- * @param bearing the current course over ground in degrees true
+ * @param heading the current course over ground in degrees true
  * @param fix the accurancy of the current fix (0=unknown, 2=2d only, 3 = 3d fix)
  *
  * @return true if the position was reported to the server
  */
 bool smm_asset_report_position (smm_asset asset, double latitude, double longitude, unsigned int altitude,
-				uint16_t bearing, uint8_t fix);
+				uint16_t heading, uint8_t fix);
 
 /**
  * Get the last command we saw from the server

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -477,6 +477,20 @@ START_TEST (test_build_position_url_values)
 }
 END_TEST
 
+START_TEST (test_build_position_url_heading_boundary)
+{
+	char *url0 = smm_asset_build_position_url (1, 0.0, 0.0, 0, 0, 0);
+	ck_assert_ptr_nonnull (url0);
+	ck_assert_ptr_nonnull (strstr (url0, "heading=0"));
+	free (url0);
+
+	char *url359 = smm_asset_build_position_url (1, 0.0, 0.0, 0, 359, 0);
+	ck_assert_ptr_nonnull (url359);
+	ck_assert_ptr_nonnull (strstr (url359, "heading=359"));
+	free (url359);
+}
+END_TEST
+
 START_TEST (test_debugging_set)
 {
 	smm_asset_debugging_set (true);
@@ -583,6 +597,7 @@ smm_suite (void)
 
 	TCase *tc_position_ext = tcase_create ("PositionExt");
 	tcase_add_test (tc_position_ext, test_build_position_url_values);
+	tcase_add_test (tc_position_ext, test_build_position_url_heading_boundary);
 	tcase_add_test (tc_position_ext, test_asset_last_goto_pos_not_goto);
 	tcase_add_test (tc_position_ext, test_asset_last_goto_pos_goto);
 	suite_add_tcase (s, tc_position_ext);


### PR DESCRIPTION
## Description

The wire-level parameter has always been sent as heading= since the position URL builder was updated. Align the public API parameter name and its doc comment to match.

## Summary by Sourcery

Rename the position reporting API parameter from bearing to heading and add coverage for heading values in position URL generation.

Bug Fixes:
- Align the public API parameter name and documentation with the underlying wire-level heading field used in position URL construction.

Documentation:
- Update smm_asset_report_position documentation to describe heading instead of bearing.

Tests:
- Add boundary tests to verify that position URLs encode heading values from 0 to 359 degrees.