### PR TITLE
fix: return NULL from smm_asset_connect when share_init fails

### DIFF
--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -71,7 +71,8 @@ smm_asset_connect (const char *host, const char *user, const char *pass)
     pthread_cond_init (&conn->login_cond, NULL);
     if (!smm_connection_share_init (conn))
     {
-        conn->state = SMM_CONNECTION_FAILURE;
+        smm_connection_unref (conn);
+        return NULL;
     }
 
     /* Early host validation */


### PR DESCRIPTION
## Description

Callers guard with `if (!conn)` so returning a non-NULL broken connection caused them to proceed with a connection stuck in SMM_CONNECTION_FAILURE state.

## Summary by Sourcery

Bug Fixes:
- Fix smm_asset_connect to avoid returning a broken connection object when share initialization fails, allowing callers that check for NULL to correctly detect the failure.