### PR TITLE
Add extra tests

### DIFF
--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -119,6 +119,20 @@ START_TEST (test_command_parsing_goto_integer_coords)
 }
 END_TEST
 
+START_TEST (test_command_parsing_goto_mixed_lat_int_lon_real)
+{
+    const char *json = "{\"action\": \"GOTO\", \"latitude\": -43, \"longitude\": 172.5}";
+    smm_asset_command cmd;
+    double lat = 0, lon = 0;
+    bool res = smm_parse_command (json, strlen (json), &cmd, &lat, &lon);
+
+    ck_assert_uint_eq (res, true);
+    ck_assert_int_eq (cmd, SMM_COMMAND_GOTO);
+    ck_assert_ldouble_eq_tol (lat, -43.0, 0.0001);
+    ck_assert_ldouble_eq_tol (lon, 172.5, 0.0001);
+}
+END_TEST
+
 START_TEST (test_command_parsing_rtl)
 {
     const char *json = "{\"action\": \"RTL\"}";
@@ -593,6 +607,7 @@ smm_suite (void)
     TCase *tc_commands = tcase_create ("Commands");
     tcase_add_test (tc_commands, test_command_parsing_goto);
     tcase_add_test (tc_commands, test_command_parsing_goto_integer_coords);
+    tcase_add_test (tc_commands, test_command_parsing_goto_mixed_lat_int_lon_real);
     tcase_add_test (tc_commands, test_command_parsing_rtl);
     tcase_add_test (tc_commands, test_command_parsing_circle);
     tcase_add_test (tc_commands, test_command_parsing_abandon_search);

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -179,6 +179,15 @@ START_TEST (test_get_search_absolute_url_ignored)
 }
 END_TEST
 
+START_TEST (test_get_search_http_absolute_url_ignored)
+{
+    const char *json
+        = "{\"object_url\": \"http://example.com/search/1/\", \"distance\": 10, \"length\": 100, \"sweep_width\": 50}";
+    smm_search search = smm_parse_search_json (NULL, json, strlen (json));
+    ck_assert_ptr_null (search);
+}
+END_TEST
+
 START_TEST (test_get_search_relative_url_accepted)
 {
     const char *json = "{\"object_url\": \"/search/1/\", \"distance\": 10, \"length\": 100, \"sweep_width\": 50}";
@@ -589,6 +598,7 @@ smm_suite (void)
     tcase_add_test (tc_search, test_search_sweep_width);
     tcase_add_test (tc_search, test_search_distance_and_length);
     tcase_add_test (tc_search, test_get_search_absolute_url_ignored);
+    tcase_add_test (tc_search, test_get_search_http_absolute_url_ignored);
     tcase_add_test (tc_search, test_get_search_relative_url_accepted);
     suite_add_tcase (s, tc_search);
 

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -179,6 +179,14 @@ START_TEST (test_get_search_absolute_url_ignored)
 }
 END_TEST
 
+START_TEST (test_get_search_missing_object_url_returns_null)
+{
+    const char *json = "{\"distance\": 10, \"length\": 100, \"sweep_width\": 50}";
+    smm_search search = smm_parse_search_json (NULL, json, strlen (json));
+    ck_assert_ptr_null (search);
+}
+END_TEST
+
 START_TEST (test_get_search_http_absolute_url_ignored)
 {
     const char *json
@@ -599,6 +607,7 @@ smm_suite (void)
     tcase_add_test (tc_search, test_search_distance_and_length);
     tcase_add_test (tc_search, test_get_search_absolute_url_ignored);
     tcase_add_test (tc_search, test_get_search_http_absolute_url_ignored);
+    tcase_add_test (tc_search, test_get_search_missing_object_url_returns_null);
     tcase_add_test (tc_search, test_get_search_relative_url_accepted);
     suite_add_tcase (s, tc_search);
 

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -91,6 +91,20 @@ START_TEST (test_assets_parsing_invalid)
 }
 END_TEST
 
+START_TEST (test_assets_parsing_missing_id)
+{
+    const char *json = "{\"assets\": [{\"type_id\": 2, \"name\": \"Asset 1\", \"type_name\": \"Type 1\"}]}";
+    smm_assets assets;
+    size_t count;
+    bool res = smm_parse_assets (NULL, json, strlen (json), &assets, &count);
+
+    ck_assert_uint_eq (res, true);
+    ck_assert_uint_eq (count, 1);
+    ck_assert_str_eq (smm_asset_name (assets[0]), "Asset 1");
+    smm_asset_free_assets (assets, count);
+}
+END_TEST
+
 START_TEST (test_command_parsing_goto)
 {
     const char *json = "{\"action\": \"GOTO\", \"latitude\": -43.5, \"longitude\": 172.6}";
@@ -616,6 +630,7 @@ smm_suite (void)
     tcase_add_test (tc_assets, test_assets_parsing);
     tcase_add_test (tc_assets, test_assets_parsing_empty);
     tcase_add_test (tc_assets, test_assets_parsing_invalid);
+    tcase_add_test (tc_assets, test_assets_parsing_missing_id);
     suite_add_tcase (s, tc_assets);
 
     TCase *tc_commands = tcase_create ("Commands");

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -119,6 +119,20 @@ START_TEST (test_command_parsing_goto_integer_coords)
 }
 END_TEST
 
+START_TEST (test_command_parsing_goto_mixed_lat_real_lon_int)
+{
+    const char *json = "{\"action\": \"GOTO\", \"latitude\": -43.75, \"longitude\": 172}";
+    smm_asset_command cmd;
+    double lat = 0, lon = 0;
+    bool res = smm_parse_command (json, strlen (json), &cmd, &lat, &lon);
+
+    ck_assert_uint_eq (res, true);
+    ck_assert_int_eq (cmd, SMM_COMMAND_GOTO);
+    ck_assert_ldouble_eq_tol (lat, -43.75, 0.0001);
+    ck_assert_ldouble_eq_tol (lon, 172.0, 0.0001);
+}
+END_TEST
+
 START_TEST (test_command_parsing_goto_mixed_lat_int_lon_real)
 {
     const char *json = "{\"action\": \"GOTO\", \"latitude\": -43, \"longitude\": 172.5}";
@@ -607,6 +621,7 @@ smm_suite (void)
     TCase *tc_commands = tcase_create ("Commands");
     tcase_add_test (tc_commands, test_command_parsing_goto);
     tcase_add_test (tc_commands, test_command_parsing_goto_integer_coords);
+    tcase_add_test (tc_commands, test_command_parsing_goto_mixed_lat_real_lon_int);
     tcase_add_test (tc_commands, test_command_parsing_goto_mixed_lat_int_lon_real);
     tcase_add_test (tc_commands, test_command_parsing_rtl);
     tcase_add_test (tc_commands, test_command_parsing_circle);

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -91,6 +91,20 @@ START_TEST (test_assets_parsing_invalid)
 }
 END_TEST
 
+START_TEST (test_assets_parsing_missing_type_id)
+{
+    const char *json = "{\"assets\": [{\"id\": 1, \"name\": \"Asset 1\", \"type_name\": \"Type 1\"}]}";
+    smm_assets assets;
+    size_t count;
+    bool res = smm_parse_assets (NULL, json, strlen (json), &assets, &count);
+
+    ck_assert_uint_eq (res, true);
+    ck_assert_uint_eq (count, 1);
+    ck_assert_str_eq (smm_asset_name (assets[0]), "Asset 1");
+    smm_asset_free_assets (assets, count);
+}
+END_TEST
+
 START_TEST (test_assets_parsing_missing_id)
 {
     const char *json = "{\"assets\": [{\"type_id\": 2, \"name\": \"Asset 1\", \"type_name\": \"Type 1\"}]}";
@@ -631,6 +645,7 @@ smm_suite (void)
     tcase_add_test (tc_assets, test_assets_parsing_empty);
     tcase_add_test (tc_assets, test_assets_parsing_invalid);
     tcase_add_test (tc_assets, test_assets_parsing_missing_id);
+    tcase_add_test (tc_assets, test_assets_parsing_missing_type_id);
     suite_add_tcase (s, tc_assets);
 
     TCase *tc_commands = tcase_create ("Commands");

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -179,6 +179,14 @@ START_TEST (test_get_search_absolute_url_ignored)
 }
 END_TEST
 
+START_TEST (test_get_search_nonstring_object_url_returns_null)
+{
+    const char *json = "{\"object_url\": 123, \"distance\": 10, \"length\": 100, \"sweep_width\": 50}";
+    smm_search search = smm_parse_search_json (NULL, json, strlen (json));
+    ck_assert_ptr_null (search);
+}
+END_TEST
+
 START_TEST (test_get_search_missing_object_url_returns_null)
 {
     const char *json = "{\"distance\": 10, \"length\": 100, \"sweep_width\": 50}";
@@ -607,6 +615,7 @@ smm_suite (void)
     tcase_add_test (tc_search, test_search_distance_and_length);
     tcase_add_test (tc_search, test_get_search_absolute_url_ignored);
     tcase_add_test (tc_search, test_get_search_http_absolute_url_ignored);
+    tcase_add_test (tc_search, test_get_search_nonstring_object_url_returns_null);
     tcase_add_test (tc_search, test_get_search_missing_object_url_returns_null);
     tcase_add_test (tc_search, test_get_search_relative_url_accepted);
     suite_add_tcase (s, tc_search);


### PR DESCRIPTION
## Summary by Sourcery

Expand test coverage for asset, command, and search JSON parsing edge cases.

Tests:
- Add asset parsing tests for inputs missing id or type_id while still accepting valid data.
- Add command parsing tests covering mixed integer and floating-point latitude/longitude values for GOTO actions.
- Add search parsing tests validating object_url requirements, including non-string, missing, and disallowed absolute HTTP URLs.