### PR TITLE
Add connection ref counting

### DIFF
--- a/src/smm-asset-internal.h
+++ b/src/smm-asset-internal.h
@@ -79,7 +79,8 @@ struct smm_asset_s
 
 struct smm_search_s
 {
-    smm_asset asset;
+    smm_connection conn;  /* owns a reference; acquired in smm_search_create */
+    long long asset_id;   /* cached from the creating asset */
     char *url;
     uint64_t distance;
     uint64_t length;
@@ -106,6 +107,7 @@ size_t to_buffer (char *ptr, size_t size, size_t nmemb, void *userdata);
 bool smm_connection_share_init (smm_connection conn);
 void smm_connection_share_destroy (smm_connection conn);
 
+void smm_connection_ref (smm_connection conn);
 void smm_connection_unref (smm_connection conn);
 
 void smm_curl_res_free (struct smm_curl_res_s *);

--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -118,6 +118,18 @@ smm_asset_connection_tls_verify_set (smm_connection connection, bool verify)
 }
 
 void
+smm_connection_ref (smm_connection connection)
+{
+    if (connection == NULL)
+    {
+        return;
+    }
+    pthread_mutex_lock (&connection->lock);
+    connection->refcount++;
+    pthread_mutex_unlock (&connection->lock);
+}
+
+void
 smm_connection_unref (smm_connection connection)
 {
     if (connection == NULL)
@@ -161,6 +173,7 @@ smm_asset_create (smm_connection conn, const char *name, const char *type, long 
     }
 
     asset->conn = conn;
+    smm_connection_ref (conn);
     asset->name = name ? strdup (name) : NULL;
     asset->type = type ? strdup (type) : NULL;
 
@@ -300,6 +313,7 @@ smm_asset_free_asset (smm_asset asset)
 {
     if (asset)
     {
+        smm_connection_unref (asset->conn);
         free (asset->name);
         free (asset->type);
         pthread_mutex_destroy (&asset->lock);
@@ -315,12 +329,6 @@ smm_asset_free_assets (smm_assets assets, size_t assets_count)
         smm_asset_free_asset (assets[i]);
     }
     free (assets);
-}
-
-static long long
-smm_asset_get_asset_id (smm_asset asset)
-{
-    return asset->asset_id;
 }
 
 const char *
@@ -541,11 +549,17 @@ smm_search_create (smm_asset asset, const char *url, uint64_t length, uint64_t d
         return NULL;
     }
 
-    search->asset = asset;
-    search->url = url ? strdup (url) : NULL;
+    if (asset)
+    {
+        search->conn = asset->conn;
+        search->asset_id = asset->asset_id;
+        smm_connection_ref (asset->conn);
+    }
 
+    search->url = url ? strdup (url) : NULL;
     if (url && !search->url)
     {
+        smm_connection_unref (search->conn);
         free (search);
         return NULL;
     }
@@ -592,6 +606,7 @@ smm_search_destroy (smm_search search)
 {
     if (search)
     {
+        smm_connection_unref (search->conn);
         free (search->url);
         free (search);
     }
@@ -717,7 +732,7 @@ smm_search_get_waypoints (smm_search search, smm_waypoints *waypoints, size_t *w
     *waypoints_count = 0;
 
     struct smm_curl_res_s *res
-        = smm_connection_curl_retrieve_url (search->asset->conn, search->url, NULL, to_buffer, &buf, true);
+        = smm_connection_curl_retrieve_url (search->conn, search->url, NULL, to_buffer, &buf, true);
 
     if (res == NULL)
     {
@@ -744,13 +759,13 @@ smm_search_action (smm_search search, const char *action)
     char *action_page = NULL;
     struct buffer_s buf = { NULL, 0 };
 
-    if (asprintf (&action_page, "%s%s/?asset_id=%lli", search->url, action, smm_asset_get_asset_id (search->asset)) < 0)
+    if (asprintf (&action_page, "%s%s/?asset_id=%lli", search->url, action, search->asset_id) < 0)
     {
         return false;
     }
 
     struct smm_curl_res_s *res
-        = smm_connection_curl_retrieve_url (search->asset->conn, action_page, NULL, to_buffer, &buf, false);
+        = smm_connection_curl_retrieve_url (search->conn, action_page, NULL, to_buffer, &buf, false);
     if (res == NULL)
     {
         free (action_page);

--- a/src/smm-asset.h
+++ b/src/smm-asset.h
@@ -27,6 +27,29 @@
 #include <stdint.h>
 
 /**
+ * @section thread_safety Thread-safety guarantees
+ *
+ * - A single smm_connection may be shared across threads.  All functions that
+ *   operate on an smm_connection are internally serialised with a mutex.
+ *
+ * - smm_asset_connect() and smm_connection_close() are safe to call from any
+ *   thread, but smm_connection_close() must not be called while another thread
+ *   is still creating assets or searches from the same connection.
+ *   smm_asset_create() acquires a reference on the connection, so closing the
+ *   connection before freeing all assets is safe.
+ *
+ * - Each smm_asset is owned by a single thread at a time.  Two threads must
+ *   not call functions on the same asset concurrently.
+ *
+ * - Each smm_search is owned by a single thread at a time.  Two threads must
+ *   not call functions on the same search concurrently.
+ *
+ * - smm_asset_debugging_set() must be called before any other threads are
+ *   started; the smm_debug flag is declared _Atomic but toggling it after
+ *   threads are running may produce interleaved debug output.
+ */
+
+/**
  * An opaque object for accessing the smm
  */
 typedef struct smm_connection_s *smm_connection;

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -274,18 +274,28 @@ END_TEST
 
 START_TEST (test_search_accept_null_conn)
 {
-    struct smm_asset_s asset_s;
-    memset (&asset_s, 0, sizeof (asset_s));
-    asset_s.asset_id = 1;
-    pthread_mutex_init (&asset_s.lock, NULL);
     struct smm_search_s search_s;
     memset (&search_s, 0, sizeof (search_s));
-    search_s.asset = &asset_s;
+    search_s.conn = NULL;
+    search_s.asset_id = 1;
     search_s.url = strdup ("/search/1/");
     bool r = smm_search_accept (&search_s);
     ck_assert_int_eq (r, false);
     free (search_s.url);
-    pthread_mutex_destroy (&asset_s.lock);
+}
+END_TEST
+
+START_TEST (test_asset_outlives_connection)
+{
+    smm_connection conn = smm_asset_connect ("http://localhost/", "user", "pass");
+    ck_assert_ptr_nonnull (conn);
+    smm_asset asset = smm_asset_create (conn, "A", "T", 1, 1);
+    ck_assert_ptr_nonnull (asset);
+    smm_connection_close (conn);
+    /* asset holds its own reference; the connection must not be freed yet */
+    ck_assert_str_eq (smm_asset_name (asset), "A");
+    smm_asset_free_asset (asset);
+    /* connection is freed here when asset's ref is dropped — no double-free */
 }
 END_TEST
 
@@ -671,6 +681,7 @@ smm_suite (void)
 
     TCase *tc_search = tcase_create ("Search");
     tcase_add_test (tc_search, test_search_accept_null_conn);
+    tcase_add_test (tc_search, test_asset_outlives_connection);
     tcase_add_test (tc_search, test_search_sweep_width);
     tcase_add_test (tc_search, test_search_distance_and_length);
     tcase_add_test (tc_search, test_get_search_absolute_url_ignored);


### PR DESCRIPTION
## Summary by Sourcery

Introduce reference counting for smm_connection and ensure assets and searches hold their own connection references to prevent premature connection free and enable safe multithreaded use.

Bug Fixes:
- Prevent premature freeing and potential double-free of connections by having smm_asset and smm_search acquire and release their own connection references.
- Fix smm_search usage when created with a null connection by guarding connection-dependent operations.

Enhancements:
- Document thread-safety guarantees for smm_connection, smm_asset, and smm_search in the public header.
- Refactor smm_search to cache the connection and asset_id directly rather than depending on an smm_asset pointer.

Tests:
- Add regression test to ensure assets outliving their creating connection remain valid until explicitly freed.