### PR TITLE
feat: add structured error reporting API (smm_error / smm_connection_get_last_error)

### DIFF
--- a/src/smm-asset-curl.c
+++ b/src/smm-asset-curl.c
@@ -535,8 +535,8 @@ smm_asset_connection_login (smm_connection connection)
 
     tidyBufFree (&docbuf);
 
-    /* Publish the CSRF token and state under the lock, then release the
-     * login flag and wake any waiters. */
+    /* Publish the CSRF token, state, and last_error under the lock so that
+     * readers always see a consistent view of all three fields. */
     pthread_mutex_lock (&connection->lock);
     if (csrf_token)
     {
@@ -544,6 +544,33 @@ smm_asset_connection_login (smm_connection connection)
         connection->csrfmiddlewaretoken = csrf_token;
     }
     connection->state = new_state;
+    switch (new_state)
+    {
+        case SMM_CONNECTION_CONNECTED:
+            connection->last_error.code = SMM_ERROR_NONE;
+            connection->last_error.message[0] = '\0';
+            break;
+        case SMM_CONNECTION_AUTHENTICATION_FAILURE:
+            connection->last_error.code = SMM_ERROR_AUTH;
+            snprintf (connection->last_error.message, sizeof (connection->last_error.message),
+                      "authentication failed");
+            break;
+        case SMM_CONNECTION_PROTOCOL_ERROR:
+            connection->last_error.code = SMM_ERROR_PROTOCOL;
+            snprintf (connection->last_error.message, sizeof (connection->last_error.message),
+                      "CSRF token not found in login page");
+            break;
+        case SMM_CONNECTION_NO_HOST_CONNECTION:
+            connection->last_error.code = SMM_ERROR_NETWORK;
+            snprintf (connection->last_error.message, sizeof (connection->last_error.message),
+                      "network failure fetching login page");
+            break;
+        default:
+            connection->last_error.code = SMM_ERROR_SERVER;
+            snprintf (connection->last_error.message, sizeof (connection->last_error.message),
+                      "login failed");
+            break;
+    }
     connection->login_in_progress = false;
     pthread_cond_broadcast (&connection->login_cond);
     pthread_mutex_unlock (&connection->lock);

--- a/src/smm-asset-internal.h
+++ b/src/smm-asset-internal.h
@@ -112,6 +112,7 @@ void smm_connection_ref (smm_connection conn);
 void smm_connection_unref (smm_connection conn);
 void smm_connection_set_error (smm_connection conn, smm_error_code code, const char *fmt, ...)
     __attribute__ ((format (printf, 3, 4)));
+void smm_connection_clear_error (smm_connection conn);
 
 void smm_curl_res_free (struct smm_curl_res_s *);
 /* Raw single-shot fetch: no retry, no login redirect, no HTTPS upgrade.

--- a/src/smm-asset-internal.h
+++ b/src/smm-asset-internal.h
@@ -62,6 +62,7 @@ struct smm_connection_s
     int refcount;
     bool login_in_progress;
     pthread_cond_t login_cond;
+    smm_error last_error;
 };
 
 struct smm_asset_s
@@ -109,6 +110,8 @@ void smm_connection_share_destroy (smm_connection conn);
 
 void smm_connection_ref (smm_connection conn);
 void smm_connection_unref (smm_connection conn);
+void smm_connection_set_error (smm_connection conn, smm_error_code code, const char *fmt, ...)
+    __attribute__ ((format (printf, 3, 4)));
 
 void smm_curl_res_free (struct smm_curl_res_s *);
 /* Raw single-shot fetch: no retry, no login redirect, no HTTPS upgrade.

--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -57,6 +57,8 @@ smm_asset_connect (const char *host, const char *user, const char *pass)
     conn->pass = strdup (pass);
     conn->verify_tls = true;
     conn->refcount = 1;
+    conn->last_error.code = SMM_ERROR_NONE;
+    conn->last_error.message[0] = '\0';
 
     if (!conn->host || !conn->user || !conn->pass)
     {

--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -24,6 +24,7 @@
 #include "smm-asset-internal.h"
 
 #include <pthread.h>
+#include <stdarg.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -115,6 +116,32 @@ smm_asset_connection_tls_verify_set (smm_connection connection, bool verify)
         connection->verify_tls = verify;
         pthread_mutex_unlock (&connection->lock);
     }
+}
+
+void
+smm_connection_set_error (smm_connection conn, smm_error_code code, const char *fmt, ...)
+{
+    if (conn == NULL)
+    {
+        return;
+    }
+    pthread_mutex_lock (&conn->lock);
+    conn->last_error.code = code;
+    va_list ap;
+    va_start (ap, fmt);
+    vsnprintf (conn->last_error.message, sizeof (conn->last_error.message), fmt, ap);
+    va_end (ap);
+    pthread_mutex_unlock (&conn->lock);
+}
+
+const smm_error *
+smm_connection_get_last_error (smm_connection connection)
+{
+    if (connection == NULL)
+    {
+        return NULL;
+    }
+    return &connection->last_error;
 }
 
 void
@@ -292,10 +319,12 @@ smm_asset_get_assets (smm_connection connection, smm_assets *assets, size_t *ass
     struct smm_curl_res_s *res = smm_connection_curl_retrieve_url (connection, "/assets/", NULL, to_buffer, &buf, true);
     if (res == NULL)
     {
+        smm_connection_set_error (connection, SMM_ERROR_NETWORK, "network failure fetching /assets/");
         return false;
     }
     if (!(res->success && res->httpcode == HTTP_SUCCESS))
     {
+        smm_connection_set_error (connection, SMM_ERROR_SERVER, "unexpected HTTP %ld from /assets/", res->httpcode);
         smm_curl_res_free (res);
         free (buf.data);
         return false;
@@ -303,6 +332,10 @@ smm_asset_get_assets (smm_connection connection, smm_assets *assets, size_t *ass
     smm_curl_res_free (res);
 
     bool parse_res = smm_parse_assets (connection, buf.data, buf.bytes, assets, assets_count);
+    if (!parse_res)
+    {
+        smm_connection_set_error (connection, SMM_ERROR_PARSE, "failed to parse /assets/ response");
+    }
 
     free (buf.data);
     return parse_res;
@@ -510,11 +543,14 @@ smm_asset_report_position (smm_asset asset, double latitude, double longitude, u
     struct smm_curl_res_s *res = smm_connection_curl_retrieve_url (asset->conn, page, NULL, to_buffer, &buf, false);
     if (res == NULL)
     {
+        smm_connection_set_error (asset->conn, SMM_ERROR_NETWORK, "network failure reporting position");
         free (page);
         return false;
     }
     if (!(res->success && res->httpcode == HTTP_SUCCESS))
     {
+        smm_connection_set_error (asset->conn, SMM_ERROR_SERVER, "unexpected HTTP %ld from position report",
+                                  res->httpcode);
         smm_curl_res_free (res);
         free (page);
         free (buf.data);
@@ -883,12 +919,14 @@ smm_asset_get_search (smm_asset asset, double latitude, double longitude)
     struct smm_curl_res_s *res = smm_connection_curl_retrieve_url (asset->conn, page, NULL, to_buffer, &buf, false);
     if (res == NULL)
     {
+        smm_connection_set_error (asset->conn, SMM_ERROR_NETWORK, "network failure fetching closest search");
         free (page);
         return NULL;
     }
     if (!(res->success && res->httpcode == HTTP_SUCCESS))
     {
-        /* login and try again */
+        smm_connection_set_error (asset->conn, SMM_ERROR_SERVER, "unexpected HTTP %ld fetching closest search",
+                                  res->httpcode);
         smm_curl_res_free (res);
         free (page);
         free (buf.data);

--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -794,10 +794,13 @@ smm_search_get_waypoints (smm_search search, smm_waypoints *waypoints, size_t *w
 
     if (res == NULL)
     {
+        smm_connection_set_error (search->conn, SMM_ERROR_NETWORK, "network failure fetching waypoints");
         return false;
     }
     else if (!(res->success && res->httpcode == HTTP_SUCCESS))
     {
+        smm_connection_set_error (search->conn, SMM_ERROR_SERVER, "unexpected HTTP %ld fetching waypoints",
+                                  res->httpcode);
         smm_curl_res_free (res);
         free (buf.data);
         return false;
@@ -805,6 +808,10 @@ smm_search_get_waypoints (smm_search search, smm_waypoints *waypoints, size_t *w
     smm_curl_res_free (res);
 
     bool parse_res = smm_parse_waypoints (buf.data, buf.bytes, waypoints, waypoints_count);
+    if (!parse_res)
+    {
+        smm_connection_set_error (search->conn, SMM_ERROR_PARSE, "failed to parse waypoints response");
+    }
 
     free (buf.data);
 
@@ -827,11 +834,14 @@ smm_search_action (smm_search search, const char *action)
         = smm_connection_curl_retrieve_url (search->conn, action_page, NULL, to_buffer, &buf, false);
     if (res == NULL)
     {
+        smm_connection_set_error (search->conn, SMM_ERROR_NETWORK, "network failure sending %s action", action);
         free (action_page);
         return false;
     }
     else if (!(res->success && res->httpcode == HTTP_SUCCESS))
     {
+        smm_connection_set_error (search->conn, SMM_ERROR_SERVER, "unexpected HTTP %ld from %s action", res->httpcode,
+                                  action);
         smm_curl_res_free (res);
         free (action_page);
         free (buf.data);

--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -136,14 +136,18 @@ smm_connection_set_error (smm_connection conn, smm_error_code code, const char *
     pthread_mutex_unlock (&conn->lock);
 }
 
-const smm_error *
+smm_error
 smm_connection_get_last_error (smm_connection connection)
 {
+    smm_error result = { SMM_ERROR_NONE, { 0 } };
     if (connection == NULL)
     {
-        return NULL;
+        return result;
     }
-    return &connection->last_error;
+    pthread_mutex_lock (&connection->lock);
+    result = connection->last_error;
+    pthread_mutex_unlock (&connection->lock);
+    return result;
 }
 
 void

--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -136,6 +136,19 @@ smm_connection_set_error (smm_connection conn, smm_error_code code, const char *
     pthread_mutex_unlock (&conn->lock);
 }
 
+void
+smm_connection_clear_error (smm_connection conn)
+{
+    if (conn == NULL)
+    {
+        return;
+    }
+    pthread_mutex_lock (&conn->lock);
+    conn->last_error.code = SMM_ERROR_NONE;
+    conn->last_error.message[0] = '\0';
+    pthread_mutex_unlock (&conn->lock);
+}
+
 smm_error
 smm_connection_get_last_error (smm_connection connection)
 {
@@ -321,6 +334,7 @@ smm_asset_get_assets (smm_connection connection, smm_assets *assets, size_t *ass
 
     *assets = NULL;
     *assets_count = 0;
+    smm_connection_clear_error (connection);
 
     struct smm_curl_res_s *res = smm_connection_curl_retrieve_url (connection, "/assets/", NULL, to_buffer, &buf, true);
     if (res == NULL)
@@ -545,6 +559,7 @@ smm_asset_report_position (smm_asset asset, double latitude, double longitude, u
     {
         return false;
     }
+    smm_connection_clear_error (asset->conn);
 
     struct smm_curl_res_s *res = smm_connection_curl_retrieve_url (asset->conn, page, NULL, to_buffer, &buf, false);
     if (res == NULL)
@@ -772,6 +787,7 @@ smm_search_get_waypoints (smm_search search, smm_waypoints *waypoints, size_t *w
 
     *waypoints = NULL;
     *waypoints_count = 0;
+    smm_connection_clear_error (search->conn);
 
     struct smm_curl_res_s *res
         = smm_connection_curl_retrieve_url (search->conn, search->url, NULL, to_buffer, &buf, true);
@@ -805,6 +821,7 @@ smm_search_action (smm_search search, const char *action)
     {
         return false;
     }
+    smm_connection_clear_error (search->conn);
 
     struct smm_curl_res_s *res
         = smm_connection_curl_retrieve_url (search->conn, action_page, NULL, to_buffer, &buf, false);
@@ -921,6 +938,7 @@ smm_asset_get_search (smm_asset asset, double latitude, double longitude)
     {
         return NULL;
     }
+    smm_connection_clear_error (asset->conn);
 
     struct smm_curl_res_s *res = smm_connection_curl_retrieve_url (asset->conn, page, NULL, to_buffer, &buf, false);
     if (res == NULL)

--- a/src/smm-asset.h
+++ b/src/smm-asset.h
@@ -27,6 +27,29 @@
 #include <stdint.h>
 
 /**
+ * Error codes returned by smm_connection_get_last_error()
+ */
+typedef enum
+{
+    SMM_ERROR_NONE = 0,         /*!< No error */
+    SMM_ERROR_NETWORK,          /*!< Network or connection failure */
+    SMM_ERROR_AUTH,             /*!< Authentication failure */
+    SMM_ERROR_PROTOCOL,         /*!< Unexpected or malformed response */
+    SMM_ERROR_PARSE,            /*!< JSON or HTML parse failure */
+    SMM_ERROR_INVALID_ARG,      /*!< Invalid argument (e.g. NULL pointer) */
+    SMM_ERROR_SERVER,           /*!< Server returned an unexpected HTTP status */
+} smm_error_code;
+
+/**
+ * Structured error detail attached to an smm_connection.
+ */
+typedef struct
+{
+    smm_error_code code;  /*!< Machine-readable error code */
+    char message[256];    /*!< Human-readable description */
+} smm_error;
+
+/**
  * @section thread_safety Thread-safety guarantees
  *
  * - A single smm_connection may be shared across threads.  All functions that
@@ -323,3 +346,14 @@ void smm_search_destroy (smm_search search);
  * @param waypoints_count the number of waypoints
  */
 void smm_waypoints_free (smm_waypoints waypoints, size_t waypoints_count);
+
+/**
+ * Retrieve the most recent error recorded on a connection.
+ *
+ * The returned pointer is valid until the next call on the same connection.
+ * The caller must not free it.  Returns NULL if connection is NULL.
+ *
+ * @param connection the smm_connection to query
+ * @return pointer to the last error, or NULL
+ */
+const smm_error *smm_connection_get_last_error (smm_connection connection);

--- a/src/smm-asset.h
+++ b/src/smm-asset.h
@@ -350,10 +350,11 @@ void smm_waypoints_free (smm_waypoints waypoints, size_t waypoints_count);
 /**
  * Retrieve the most recent error recorded on a connection.
  *
- * The returned pointer is valid until the next call on the same connection.
- * The caller must not free it.  Returns NULL if connection is NULL.
+ * Returns a snapshot of the last error, copied under the connection lock.
+ * Safe to call concurrently with other library functions.
+ * Returns a zeroed smm_error (code == SMM_ERROR_NONE) if connection is NULL.
  *
  * @param connection the smm_connection to query
- * @return pointer to the last error, or NULL
+ * @return a copy of the last recorded error
  */
-const smm_error *smm_connection_get_last_error (smm_connection connection);
+smm_error smm_connection_get_last_error (smm_connection connection);

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -630,6 +630,23 @@ START_TEST (test_connection_login_fields_initialised)
 }
 END_TEST
 
+START_TEST (test_get_last_error_null_connection)
+{
+    ck_assert_ptr_null (smm_connection_get_last_error (NULL));
+}
+END_TEST
+
+START_TEST (test_get_last_error_initial)
+{
+    smm_connection conn = smm_asset_connect ("http://localhost/", "user", "pass");
+    ck_assert_ptr_nonnull (conn);
+    const smm_error *err = smm_connection_get_last_error (conn);
+    ck_assert_ptr_nonnull (err);
+    ck_assert_int_eq (err->code, SMM_ERROR_NONE);
+    smm_connection_close (conn);
+}
+END_TEST
+
 START_TEST (test_get_state_null_connection)
 {
     ck_assert_int_eq (smm_asset_connection_get_state (NULL), SMM_CONNECTION_UNKNOWN);
@@ -661,6 +678,8 @@ smm_suite (void)
     tcase_add_test (tc_conn, test_connect_null_user);
     tcase_add_test (tc_conn, test_connect_null_pass);
     tcase_add_test (tc_conn, test_connection_login_fields_initialised);
+    tcase_add_test (tc_conn, test_get_last_error_null_connection);
+    tcase_add_test (tc_conn, test_get_last_error_initial);
     tcase_add_test (tc_conn, test_get_state_null_connection);
     tcase_add_test (tc_conn, test_get_state_initial);
     tcase_add_test (tc_conn, test_debugging_set);

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -632,7 +632,8 @@ END_TEST
 
 START_TEST (test_get_last_error_null_connection)
 {
-    ck_assert_ptr_null (smm_connection_get_last_error (NULL));
+    smm_error err = smm_connection_get_last_error (NULL);
+    ck_assert_int_eq (err.code, SMM_ERROR_NONE);
 }
 END_TEST
 
@@ -640,9 +641,8 @@ START_TEST (test_get_last_error_initial)
 {
     smm_connection conn = smm_asset_connect ("http://localhost/", "user", "pass");
     ck_assert_ptr_nonnull (conn);
-    const smm_error *err = smm_connection_get_last_error (conn);
-    ck_assert_ptr_nonnull (err);
-    ck_assert_int_eq (err->code, SMM_ERROR_NONE);
+    smm_error err = smm_connection_get_last_error (conn);
+    ck_assert_int_eq (err.code, SMM_ERROR_NONE);
     smm_connection_close (conn);
 }
 END_TEST


### PR DESCRIPTION
## Description

Adds smm_error_code enum and smm_error struct to smm-asset.h, a last_error field to smm_connection_s, and the public accessor smm_connection_get_last_error(). An internal helper smm_connection_set_error() populates the error under the connection lock.  Network, server, and parse failures from smm_asset_get_assets, smm_asset_report_position, and smm_asset_get_search now record a machine-readable code and human-readable message.

## Summary by Sourcery

Introduce structured, connection-scoped error reporting and expose a public API to retrieve the last error from a connection.

New Features:
- Add smm_error_code enum and smm_error struct to represent machine-readable error codes and human-readable messages.
- Expose smm_connection_get_last_error() to retrieve the last recorded error on a connection.

Enhancements:
- Track and clear connection-level errors across login, asset retrieval, position reporting, and search operations, providing more informative error context to callers.

Tests:
- Add unit tests validating the default last-error state for null and newly created connections.