### PR TITLE
fix: add NULL checks in all asset and search action functions

### DIFF
--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -491,6 +491,10 @@ smm_asset_update_command (smm_asset asset, struct buffer_s *buf)
 smm_asset_command
 smm_asset_last_command (smm_asset asset)
 {
+    if (!asset)
+    {
+        return SMM_COMMAND_UNKNOWN;
+    }
     smm_asset_command cmd;
     pthread_mutex_lock (&asset->lock);
     cmd = asset->last_command;
@@ -501,6 +505,10 @@ smm_asset_last_command (smm_asset asset)
 bool
 smm_asset_last_goto_pos (smm_asset asset, double *lat, double *lon)
 {
+    if (!asset)
+    {
+        return false;
+    }
     bool res = false;
     pthread_mutex_lock (&asset->lock);
     if (asset->last_command == SMM_COMMAND_GOTO)
@@ -522,6 +530,10 @@ smm_asset_last_goto_pos (smm_asset asset, double *lat, double *lon)
 void
 smm_asset_set_command_from_plaintext (smm_asset asset, const char *data, size_t len)
 {
+    if (!asset)
+    {
+        return;
+    }
     pthread_mutex_lock (&asset->lock);
     if (data && len >= CONTINUE_LEN && strncmp (data, CONTINUE_STR, CONTINUE_LEN) == 0)
     {
@@ -552,6 +564,10 @@ bool
 smm_asset_report_position (smm_asset asset, double latitude, double longitude, unsigned int altitude, uint16_t heading,
                            uint8_t fix)
 {
+    if (!asset)
+    {
+        return false;
+    }
     struct buffer_s buf = { NULL, 0 };
 
     char *page = smm_asset_build_position_url (asset->asset_id, latitude, longitude, altitude, heading, fix);
@@ -780,6 +796,10 @@ smm_search_get_waypoints (smm_search search, smm_waypoints *waypoints, size_t *w
 {
     struct buffer_s buf = { NULL, 0 };
 
+    if (!search)
+    {
+        return false;
+    }
     if (waypoints == NULL || waypoints_count == NULL)
     {
         return false;
@@ -821,6 +841,10 @@ smm_search_get_waypoints (smm_search search, smm_waypoints *waypoints, size_t *w
 static bool
 smm_search_action (smm_search search, const char *action)
 {
+    if (!search)
+    {
+        return false;
+    }
     char *action_page = NULL;
     struct buffer_s buf = { NULL, 0 };
 
@@ -938,6 +962,10 @@ smm_parse_search_json (smm_asset asset, const char *data, size_t len)
 smm_search
 smm_asset_get_search (smm_asset asset, double latitude, double longitude)
 {
+    if (!asset)
+    {
+        return NULL;
+    }
     smm_search search = NULL;
     struct buffer_s buf = { NULL, 0 };
 

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -285,6 +285,65 @@ START_TEST (test_search_accept_null_conn)
 }
 END_TEST
 
+START_TEST (test_search_accept_null_search)
+{
+    bool r = smm_search_accept (NULL);
+    ck_assert_int_eq (r, false);
+}
+END_TEST
+
+START_TEST (test_search_complete_null_search)
+{
+    bool r = smm_search_complete (NULL);
+    ck_assert_int_eq (r, false);
+}
+END_TEST
+
+START_TEST (test_search_get_waypoints_null_search)
+{
+    smm_waypoints waypoints = NULL;
+    size_t count = 0;
+    bool r = smm_search_get_waypoints (NULL, &waypoints, &count);
+    ck_assert_int_eq (r, false);
+}
+END_TEST
+
+START_TEST (test_report_position_null_asset)
+{
+    bool r = smm_asset_report_position (NULL, -43.5, 172.6, 100, 270, 3);
+    ck_assert_int_eq (r, false);
+}
+END_TEST
+
+START_TEST (test_get_search_null_asset)
+{
+    smm_search s = smm_asset_get_search (NULL, -43.5, 172.6);
+    ck_assert_ptr_null (s);
+}
+END_TEST
+
+START_TEST (test_last_command_null_asset)
+{
+    smm_asset_command cmd = smm_asset_last_command (NULL);
+    ck_assert_int_eq (cmd, SMM_COMMAND_UNKNOWN);
+}
+END_TEST
+
+START_TEST (test_last_goto_pos_null_asset)
+{
+    double lat = 1.0, lon = 2.0;
+    bool r = smm_asset_last_goto_pos (NULL, &lat, &lon);
+    ck_assert_int_eq (r, false);
+}
+END_TEST
+
+START_TEST (test_set_command_null_asset)
+{
+    /* must not crash */
+    smm_asset_set_command_from_plaintext (NULL, "Continue", 8);
+}
+END_TEST
+
 START_TEST (test_asset_outlives_connection)
 {
     smm_connection conn = smm_asset_connect ("http://localhost/", "user", "pass");
@@ -692,7 +751,12 @@ smm_suite (void)
     tcase_add_test (tc_position, test_set_command_from_plaintext_null);
     tcase_add_test (tc_position, test_set_command_from_plaintext_zero_length);
     tcase_add_test (tc_position, test_set_command_from_plaintext_with_trailing);
+    tcase_add_test (tc_position, test_set_command_null_asset);
     tcase_add_test (tc_position, test_report_position_null_conn);
+    tcase_add_test (tc_position, test_report_position_null_asset);
+    tcase_add_test (tc_position, test_last_command_null_asset);
+    tcase_add_test (tc_position, test_last_goto_pos_null_asset);
+    tcase_add_test (tc_position, test_get_search_null_asset);
     suite_add_tcase (s, tc_position);
 
     tc_csrf = tcase_create ("CSRF");
@@ -736,6 +800,9 @@ smm_suite (void)
 
     TCase *tc_search = tcase_create ("Search");
     tcase_add_test (tc_search, test_search_accept_null_conn);
+    tcase_add_test (tc_search, test_search_accept_null_search);
+    tcase_add_test (tc_search, test_search_complete_null_search);
+    tcase_add_test (tc_search, test_search_get_waypoints_null_search);
     tcase_add_test (tc_search, test_asset_outlives_connection);
     tcase_add_test (tc_search, test_search_sweep_width);
     tcase_add_test (tc_search, test_search_distance_and_length);


### PR DESCRIPTION
## Description

smm_asset_last_command, smm_asset_last_goto_pos,
smm_asset_set_command_from_plaintext, smm_asset_report_position, smm_asset_get_search, smm_search_get_waypoints, and smm_search_action all dereferenced their primary argument unconditionally. SMM_ERROR_INVALID_ARG was defined but never used; these functions now return the appropriate null/false/UNKNOWN value on NULL input.

## Summary by Sourcery

Add NULL argument handling to asset and search operations and extend tests to cover these cases.

Bug Fixes:
- Return SMM_COMMAND_UNKNOWN instead of dereferencing a NULL asset in smm_asset_last_command.
- Avoid NULL asset dereferences in smm_asset_last_goto_pos by returning false when asset is NULL.
- Prevent NULL asset dereferences in smm_asset_set_command_from_plaintext by early returning on NULL asset.
- Avoid NULL asset dereferences in smm_asset_report_position by returning false when asset is NULL.
- Return NULL instead of dereferencing a NULL asset in smm_asset_get_search.
- Return false instead of dereferencing a NULL search in smm_search_get_waypoints.
- Return false instead of dereferencing a NULL search in smm_search_action.

Tests:
- Add unit tests verifying asset functions safely handle NULL assets without crashing and return appropriate default values.
- Add unit tests verifying search functions safely handle NULL search objects and return false.