### PR TITLE
fix: use smm_curl_res_free in httpcode==0 cleanup path

### DIFF
--- a/src/smm-asset-curl.c
+++ b/src/smm-asset-curl.c
@@ -327,8 +327,7 @@ out:
     }
     if (res && !res->success && res->httpcode == 0)
     {
-        free (res->full_uri);
-        free (res);
+        smm_curl_res_free (res);
         res = NULL;
     }
 

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -428,6 +428,20 @@ START_TEST (test_build_position_url_heading)
 }
 END_TEST
 
+START_TEST (test_curl_retrieve_url_r_returns_null_on_no_response)
+{
+    /* Exercises the httpcode==0 cleanup path in smm_connection_curl_retrieve_url_r.
+     * Port 19999 is chosen to be connection-refused (fast) rather than a
+     * timeout. The function must return NULL and free all internal state
+     * (ASAN/Valgrind will catch any leak of content_type or redirect_url). */
+    smm_connection conn = smm_asset_connect ("http://127.0.0.1:19999/", "user", "pass");
+    ck_assert_ptr_nonnull (conn);
+    struct smm_curl_res_s *res = smm_connection_curl_retrieve_url_r (conn, "/test/", NULL, NULL, NULL, false);
+    ck_assert_ptr_null (res);
+    smm_connection_close (conn);
+}
+END_TEST
+
 START_TEST (test_login_in_progress_reset_on_failure)
 {
     /* login_in_progress must be false after a failed attempt so no caller
@@ -731,6 +745,7 @@ smm_suite (void)
     s = suite_create ("SMM");
 
     tc_conn = tcase_create ("Connection");
+    tcase_add_test (tc_conn, test_curl_retrieve_url_r_returns_null_on_no_response);
     tcase_add_test (tc_conn, test_login_in_progress_reset_on_failure);
     tcase_add_test (tc_conn, test_invalid_host);
     tcase_add_test (tc_conn, test_connect_null_host);


### PR DESCRIPTION
## Description

The partial-free on network failure (free full_uri + free res) bypassed smm_curl_res_free and would leak content_type and redirect_url if either were ever non-NULL at that point. Replace with the dedicated destructor so all fields are always freed through a single code path.

## Summary by Sourcery

Ensure curl result structures are fully cleaned up on network failures and add a regression test for the no-response path.

Bug Fixes:
- Fix a memory leak by routing the httpcode==0 cleanup path through smm_curl_res_free so all curl result fields are freed.

Tests:
- Add a regression test verifying smm_connection_curl_retrieve_url_r returns NULL and frees internal state when no HTTP response is received.