### PR TITLE
fix: validate redirect host matches original before HTTPS upgrade

### DIFF
--- a/src/smm-asset-curl.c
+++ b/src/smm-asset-curl.c
@@ -577,6 +577,26 @@ smm_asset_connection_login (smm_connection connection)
     return res;
 }
 
+bool
+smm_https_upgrade_is_same_host (const char *http_host, const char *https_redirect)
+{
+    if (http_host == NULL || https_redirect == NULL)
+        return false;
+    if (strncmp (http_host, "http://", 7) != 0)
+        return false;
+    if (strncmp (https_redirect, "https://", 8) != 0)
+        return false;
+
+    const char *orig_host = http_host + 7;
+    const char *redir_host = https_redirect + 8;
+
+    /* Host ends at '/', '?', '#', or end of string */
+    size_t orig_len = strcspn (orig_host, "/?#");
+    size_t redir_len = strcspn (redir_host, "/?#");
+
+    return orig_len == redir_len && strncmp (orig_host, redir_host, orig_len) == 0;
+}
+
 struct smm_curl_res_s *
 smm_connection_curl_retrieve_url (smm_connection conn, const char *path, const char *post_data,
                                   size_t (*write_func) (char *ptr, size_t size, size_t nmemb, void *userdata),
@@ -596,32 +616,20 @@ smm_connection_curl_retrieve_url (smm_connection conn, const char *path, const c
             DEBUG ("Got redirected to (%s) accessing %s\n", res->redirect_url, path);
             /* It's possible we need to upgrade to https */
             pthread_mutex_lock (&conn->lock);
-            if (strncmp (conn->host, "https://", 8) != 0 && strncmp (res->redirect_url, "https://", 8) == 0)
+            if (smm_https_upgrade_is_same_host (conn->host, res->redirect_url))
             {
-                /* Upgrade to https */
+                /* Upgrade to https — same host, just switch the scheme */
                 DEBUG ("Upgrading to https\n");
                 char *new_host = NULL;
-                if (strncmp (conn->host, "http://", 7) == 0)
-                {
-                    if (asprintf (&new_host, "https://%s", &conn->host[7]) < 0)
-                    {
-                        DEBUG ("Failed to create new "
-                               "host\n");
-                    }
-                }
-                else
-                {
-                    if (asprintf (&new_host, "https://%s", conn->host) < 0)
-                    {
-                        DEBUG ("Failed to create new "
-                               "host\n");
-                    }
-                }
-                if (new_host)
+                if (asprintf (&new_host, "https://%s", conn->host + 7) >= 0)
                 {
                     free (conn->host);
                     conn->host = new_host;
                     retry = true;
+                }
+                else
+                {
+                    DEBUG ("Failed to create new host\n");
                 }
             }
             pthread_mutex_unlock (&conn->lock);

--- a/src/smm-asset-internal.h
+++ b/src/smm-asset-internal.h
@@ -142,3 +142,7 @@ char *smm_asset_build_position_url (long long asset_id, double lat, double lon, 
 void smm_asset_set_command_from_plaintext (smm_asset asset, const char *data, size_t len);
 
 smm_search smm_parse_search_json (smm_asset asset, const char *data, size_t len);
+
+/* Returns true if https_redirect is an HTTPS upgrade of http_host to the
+ * same host:port — used to guard against redirect-based downgrade attacks. */
+bool smm_https_upgrade_is_same_host (const char *http_host, const char *https_redirect);

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -428,6 +428,53 @@ START_TEST (test_build_position_url_heading)
 }
 END_TEST
 
+START_TEST (test_https_upgrade_same_host)
+{
+    ck_assert_int_eq (smm_https_upgrade_is_same_host ("http://example.com", "https://example.com/login/"), true);
+}
+END_TEST
+
+START_TEST (test_https_upgrade_same_host_with_port)
+{
+    ck_assert_int_eq (smm_https_upgrade_is_same_host ("http://example.com:8080", "https://example.com:8080/login/"),
+                      true);
+}
+END_TEST
+
+START_TEST (test_https_upgrade_different_host)
+{
+    ck_assert_int_eq (smm_https_upgrade_is_same_host ("http://example.com", "https://evil.com/login/"), false);
+}
+END_TEST
+
+START_TEST (test_https_upgrade_subdomain)
+{
+    ck_assert_int_eq (smm_https_upgrade_is_same_host ("http://example.com", "https://evil.example.com/login/"), false);
+}
+END_TEST
+
+START_TEST (test_https_upgrade_different_port)
+{
+    ck_assert_int_eq (smm_https_upgrade_is_same_host ("http://example.com:80", "https://example.com:443/login/"),
+                      false);
+}
+END_TEST
+
+START_TEST (test_https_upgrade_null_args)
+{
+    ck_assert_int_eq (smm_https_upgrade_is_same_host (NULL, "https://example.com/"), false);
+    ck_assert_int_eq (smm_https_upgrade_is_same_host ("http://example.com", NULL), false);
+}
+END_TEST
+
+START_TEST (test_https_upgrade_already_https)
+{
+    /* conn is already https — smm_https_upgrade_is_same_host must return false
+     * since http_host does not start with "http://" */
+    ck_assert_int_eq (smm_https_upgrade_is_same_host ("https://example.com", "https://example.com/login/"), false);
+}
+END_TEST
+
 START_TEST (test_curl_retrieve_url_r_returns_null_on_no_response)
 {
     /* Exercises the httpcode==0 cleanup path in smm_connection_curl_retrieve_url_r.
@@ -747,6 +794,13 @@ smm_suite (void)
     tc_conn = tcase_create ("Connection");
     tcase_add_test (tc_conn, test_curl_retrieve_url_r_returns_null_on_no_response);
     tcase_add_test (tc_conn, test_login_in_progress_reset_on_failure);
+    tcase_add_test (tc_conn, test_https_upgrade_same_host);
+    tcase_add_test (tc_conn, test_https_upgrade_same_host_with_port);
+    tcase_add_test (tc_conn, test_https_upgrade_different_host);
+    tcase_add_test (tc_conn, test_https_upgrade_subdomain);
+    tcase_add_test (tc_conn, test_https_upgrade_different_port);
+    tcase_add_test (tc_conn, test_https_upgrade_null_args);
+    tcase_add_test (tc_conn, test_https_upgrade_already_https);
     tcase_add_test (tc_conn, test_invalid_host);
     tcase_add_test (tc_conn, test_connect_null_host);
     tcase_add_test (tc_conn, test_connect_null_user);

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -467,6 +467,14 @@ START_TEST (test_https_upgrade_null_args)
 }
 END_TEST
 
+START_TEST (test_https_upgrade_non_http_http_host)
+{
+    ck_assert_int_eq (smm_https_upgrade_is_same_host ("ftp://example.com", "https://example.com/"), false);
+    ck_assert_int_eq (smm_https_upgrade_is_same_host ("example.com", "https://example.com/"), false);
+    ck_assert_int_eq (smm_https_upgrade_is_same_host ("", "https://example.com/"), false);
+}
+END_TEST
+
 START_TEST (test_https_upgrade_already_https)
 {
     /* conn is already https — smm_https_upgrade_is_same_host must return false
@@ -800,6 +808,7 @@ smm_suite (void)
     tcase_add_test (tc_conn, test_https_upgrade_subdomain);
     tcase_add_test (tc_conn, test_https_upgrade_different_port);
     tcase_add_test (tc_conn, test_https_upgrade_null_args);
+    tcase_add_test (tc_conn, test_https_upgrade_non_http_http_host);
     tcase_add_test (tc_conn, test_https_upgrade_already_https);
     tcase_add_test (tc_conn, test_invalid_host);
     tcase_add_test (tc_conn, test_connect_null_host);


### PR DESCRIPTION
## Description

The old upgrade check only verified the redirect URL started with "https://", allowing an active network attacker to redirect the client to any HTTPS host and receive the POST credentials.

Add smm_https_upgrade_is_same_host() which compares the host:port of the current http:// connection against the redirect URL. Only identical host:port is accepted. Also simplifies the upgrade path: since the helper guarantees conn->host starts with "http://", the non-http:// branch was dead code and is removed.

## Summary by Sourcery

Guard HTTPS upgrade redirects by ensuring the redirect target matches the original connection host and port, and simplify the HTTPS upgrade logic accordingly.

Bug Fixes:
- Prevent redirect-based credential theft by only upgrading to HTTPS when the redirect points to the same host and port as the original HTTP connection.

Enhancements:
- Introduce a helper to validate HTTPS upgrade redirects against the original host:port and streamline the host upgrade path.

Tests:
- Add unit tests covering valid and invalid HTTPS upgrade scenarios, including host/port mismatches, subdomains, null arguments, and already-HTTPS connections.