### PR TITLE
fix: add curl connect and transfer timeouts to all requests

### DIFF
--- a/src/smm-asset-curl.c
+++ b/src/smm-asset-curl.c
@@ -222,6 +222,8 @@ smm_connection_curl_retrieve_url_r (smm_connection conn, const char *path, const
     curl_easy_setopt (curl, CURLOPT_SSL_VERIFYHOST, verify_tls ? 2L : 0L);
     curl_easy_setopt (curl, CURLOPT_COOKIEFILE, "");
     curl_easy_setopt (curl, CURLOPT_FOLLOWLOCATION, 0L);
+    curl_easy_setopt (curl, CURLOPT_CONNECTTIMEOUT, SMM_CURL_CONNECT_TIMEOUT_SECS);
+    curl_easy_setopt (curl, CURLOPT_TIMEOUT, SMM_CURL_TRANSFER_TIMEOUT_SECS);
     curl_easy_setopt (curl, CURLOPT_URL, res->full_uri);
 
     if (post_data)

--- a/src/smm-asset-internal.h
+++ b/src/smm-asset-internal.h
@@ -38,6 +38,9 @@ enum http_return_codes
     HTTP_SEE_OTHER = 303,
 };
 
+#define SMM_CURL_CONNECT_TIMEOUT_SECS 30L
+#define SMM_CURL_TRANSFER_TIMEOUT_SECS 60L
+
 extern _Atomic bool smm_debug;
 #define DEBUG(...)                                                                                                     \
     do                                                                                                                 \

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -428,6 +428,15 @@ START_TEST (test_build_position_url_heading)
 }
 END_TEST
 
+START_TEST (test_curl_timeout_constants)
+{
+    /* Verify timeout macros are positive and connect <= transfer */
+    ck_assert_int_gt (SMM_CURL_CONNECT_TIMEOUT_SECS, 0);
+    ck_assert_int_gt (SMM_CURL_TRANSFER_TIMEOUT_SECS, 0);
+    ck_assert_int_le (SMM_CURL_CONNECT_TIMEOUT_SECS, SMM_CURL_TRANSFER_TIMEOUT_SECS);
+}
+END_TEST
+
 START_TEST (test_https_upgrade_same_host)
 {
     ck_assert_int_eq (smm_https_upgrade_is_same_host ("http://example.com", "https://example.com/login/"), true);
@@ -800,6 +809,7 @@ smm_suite (void)
     s = suite_create ("SMM");
 
     tc_conn = tcase_create ("Connection");
+    tcase_add_test (tc_conn, test_curl_timeout_constants);
     tcase_add_test (tc_conn, test_curl_retrieve_url_r_returns_null_on_no_response);
     tcase_add_test (tc_conn, test_login_in_progress_reset_on_failure);
     tcase_add_test (tc_conn, test_https_upgrade_same_host);


### PR DESCRIPTION
## Description

Without timeouts a hung server would block the calling thread indefinitely — a serious operational hazard for a library used by vehicles in the field.

Add SMM_CURL_CONNECT_TIMEOUT_SECS (30 s) and
SMM_CURL_TRANSFER_TIMEOUT_SECS (60 s) as named constants in the internal header, and set CURLOPT_CONNECTTIMEOUT / CURLOPT_TIMEOUT on every curl handle created in smm_connection_curl_retrieve_url_r.

## Summary by Sourcery

Add global curl timeout configuration and cover it with a basic sanity test.

Enhancements:
- Define shared curl connect and transfer timeout constants and apply them to all curl requests to prevent indefinite hangs.

Tests:
- Add a unit test to validate curl timeout constants are positive and that connect timeout does not exceed transfer timeout.