### PR TITLE
fix: validate server-supplied object_url before use in request paths

### DIFF
--- a/src/smm-asset-internal.h
+++ b/src/smm-asset-internal.h
@@ -149,3 +149,8 @@ smm_search smm_parse_search_json (smm_asset asset, const char *data, size_t len)
 /* Returns true if https_redirect is an HTTPS upgrade of http_host to the
  * same host:port — used to guard against redirect-based downgrade attacks. */
 bool smm_https_upgrade_is_same_host (const char *http_host, const char *https_redirect);
+
+/* Returns true if url is a safe relative path: starts with '/', contains
+ * no '..' segments, no query ('?'), no fragment ('#'), and no percent-
+ * encoded characters ('%'). */
+bool smm_url_path_is_safe (const char *url);

--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -546,6 +546,22 @@ smm_asset_set_command_from_plaintext (smm_asset asset, const char *data, size_t 
     pthread_mutex_unlock (&asset->lock);
 }
 
+bool
+smm_url_path_is_safe (const char *url)
+{
+    if (url == NULL || url[0] != '/')
+        return false;
+    if (strstr (url, "..") != NULL)
+        return false;
+    if (strchr (url, '?') != NULL)
+        return false;
+    if (strchr (url, '#') != NULL)
+        return false;
+    if (strchr (url, '%') != NULL)
+        return false;
+    return true;
+}
+
 char *
 smm_asset_build_position_url (long long asset_id, double lat, double lon, unsigned int alt, uint16_t heading,
                               uint8_t fix)
@@ -922,13 +938,13 @@ smm_parse_search_json (smm_asset asset, const char *data, size_t len)
         {
             url = json_string_value (tmp);
         }
-        /* The server contract emits object_url as a relative path
-         * (e.g. "/search/42/"). Reject absolute URLs defensively in
-         * case the contract ever changes — accepting them blindly
-         * here would let the server steer us at an arbitrary host. */
-        if (url && (strncmp (url, "http://", 7) == 0 || strncmp (url, "https://", 8) == 0))
+        /* Validate the server-supplied path: must be a safe relative path
+         * with no '..' segments, query strings, fragments, or percent-
+         * encoded characters that could redirect requests at an arbitrary
+         * endpoint. */
+        if (url && !smm_url_path_is_safe (url))
         {
-            DEBUG ("object_url is absolute; ignoring\n");
+            DEBUG ("object_url is not a safe relative path; ignoring\n");
             url = NULL;
         }
         tmp = json_object_get (json_root, "distance");

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -428,6 +428,79 @@ START_TEST (test_build_position_url_heading)
 }
 END_TEST
 
+START_TEST (test_url_path_safe_valid)
+{
+    ck_assert_int_eq (smm_url_path_is_safe ("/search/1/"), true);
+    ck_assert_int_eq (smm_url_path_is_safe ("/search/42/begin/"), true);
+    ck_assert_int_eq (smm_url_path_is_safe ("/"), true);
+}
+END_TEST
+
+START_TEST (test_url_path_safe_dotdot)
+{
+    ck_assert_int_eq (smm_url_path_is_safe ("/search/1/../../admin/"), false);
+    ck_assert_int_eq (smm_url_path_is_safe ("/.."), false);
+}
+END_TEST
+
+START_TEST (test_url_path_safe_query)
+{
+    ck_assert_int_eq (smm_url_path_is_safe ("/search/1/?injected=evil"), false);
+}
+END_TEST
+
+START_TEST (test_url_path_safe_fragment)
+{
+    ck_assert_int_eq (smm_url_path_is_safe ("/search/1/#frag"), false);
+}
+END_TEST
+
+START_TEST (test_url_path_safe_encoded)
+{
+    ck_assert_int_eq (smm_url_path_is_safe ("/search/%2e%2e/admin/"), false);
+}
+END_TEST
+
+START_TEST (test_url_path_safe_absolute)
+{
+    ck_assert_int_eq (smm_url_path_is_safe ("http://example.com/search/1/"), false);
+    ck_assert_int_eq (smm_url_path_is_safe ("https://example.com/search/1/"), false);
+}
+END_TEST
+
+START_TEST (test_url_path_safe_null)
+{
+    ck_assert_int_eq (smm_url_path_is_safe (NULL), false);
+}
+END_TEST
+
+START_TEST (test_get_search_dotdot_url_rejected)
+{
+    const char *json = "{\"object_url\": \"/search/1/../../admin/\", \"distance\": 10, \"length\": 100, "
+                       "\"sweep_width\": 50}";
+    smm_search search = smm_parse_search_json (NULL, json, strlen (json));
+    ck_assert_ptr_null (search);
+}
+END_TEST
+
+START_TEST (test_get_search_query_url_rejected)
+{
+    const char *json
+        = "{\"object_url\": \"/search/1/?injected=x\", \"distance\": 10, \"length\": 100, \"sweep_width\": 50}";
+    smm_search search = smm_parse_search_json (NULL, json, strlen (json));
+    ck_assert_ptr_null (search);
+}
+END_TEST
+
+START_TEST (test_get_search_encoded_url_rejected)
+{
+    const char *json = "{\"object_url\": \"/search/%2e%2e/admin/\", \"distance\": 10, \"length\": 100, "
+                       "\"sweep_width\": 50}";
+    smm_search search = smm_parse_search_json (NULL, json, strlen (json));
+    ck_assert_ptr_null (search);
+}
+END_TEST
+
 START_TEST (test_curl_timeout_constants)
 {
     /* Verify timeout macros are positive and connect <= transfer */
@@ -899,7 +972,20 @@ smm_suite (void)
     tcase_add_test (tc_search, test_get_search_nonstring_object_url_returns_null);
     tcase_add_test (tc_search, test_get_search_missing_object_url_returns_null);
     tcase_add_test (tc_search, test_get_search_relative_url_accepted);
+    tcase_add_test (tc_search, test_get_search_dotdot_url_rejected);
+    tcase_add_test (tc_search, test_get_search_query_url_rejected);
+    tcase_add_test (tc_search, test_get_search_encoded_url_rejected);
     suite_add_tcase (s, tc_search);
+
+    TCase *tc_url = tcase_create ("URL");
+    tcase_add_test (tc_url, test_url_path_safe_valid);
+    tcase_add_test (tc_url, test_url_path_safe_dotdot);
+    tcase_add_test (tc_url, test_url_path_safe_query);
+    tcase_add_test (tc_url, test_url_path_safe_fragment);
+    tcase_add_test (tc_url, test_url_path_safe_encoded);
+    tcase_add_test (tc_url, test_url_path_safe_absolute);
+    tcase_add_test (tc_url, test_url_path_safe_null);
+    suite_add_tcase (s, tc_url);
 
     TCase *tc_position_ext = tcase_create ("PositionExt");
     tcase_add_test (tc_position_ext, test_build_position_url_values);


### PR DESCRIPTION
## Description

smm_search_action appended search->url (from the server's object_url) into request URLs verbatim. A malicious or compromised server could supply a path containing '..' segments, query strings, fragments, or percent-encoded traversals to redirect requests at an arbitrary endpoint.

Add smm_url_path_is_safe() which requires the path start with '/' and contain none of '..', '?', '#', or '%'. Replace the previous absolute-URL-only check in smm_parse_search_json with this stricter validation so all of those cases are rejected at parse time.

## Summary by Sourcery

Validate server-supplied search object URLs using a stricter path safety check to prevent unsafe paths from being used in requests.

Bug Fixes:
- Reject search object_url values that contain directory traversal, query, fragment, or percent-encoded components instead of only blocking absolute URLs.

Enhancements:
- Introduce a reusable smm_url_path_is_safe helper for validating server-supplied URL paths.

Tests:
- Add unit tests covering smm_url_path_is_safe behavior and ensuring unsafe search object_url paths are rejected during JSON parsing.