### PR TITLE
fix: move error state from connection to asset and search objects

### DIFF
--- a/src/smm-asset-internal.h
+++ b/src/smm-asset-internal.h
@@ -79,16 +79,18 @@ struct smm_asset_s
     double last_command_lat;
     double last_command_lon;
     pthread_mutex_t lock;
+    smm_error last_error;  /* guarded by lock */
 };
 
 struct smm_search_s
 {
-    smm_connection conn;  /* owns a reference; acquired in smm_search_create */
-    long long asset_id;   /* cached from the creating asset */
+    smm_connection conn;   /* owns a reference; acquired in smm_search_create */
+    long long asset_id;    /* cached from the creating asset */
     char *url;
     uint64_t distance;
     uint64_t length;
     uint64_t sweep_width;
+    smm_error last_error;  /* not guarded; searches are single-threaded */
 };
 
 struct smm_curl_res_s

--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -120,6 +120,73 @@ smm_asset_connection_tls_verify_set (smm_connection connection, bool verify)
     }
 }
 
+static void
+smm_asset_set_error (smm_asset asset, smm_error_code code, const char *fmt, ...)
+{
+    if (asset == NULL)
+        return;
+    pthread_mutex_lock (&asset->lock);
+    asset->last_error.code = code;
+    va_list ap;
+    va_start (ap, fmt);
+    vsnprintf (asset->last_error.message, sizeof (asset->last_error.message), fmt, ap);
+    va_end (ap);
+    pthread_mutex_unlock (&asset->lock);
+}
+
+static void
+smm_asset_clear_error (smm_asset asset)
+{
+    if (asset == NULL)
+        return;
+    pthread_mutex_lock (&asset->lock);
+    asset->last_error.code = SMM_ERROR_NONE;
+    asset->last_error.message[0] = '\0';
+    pthread_mutex_unlock (&asset->lock);
+}
+
+smm_error
+smm_asset_get_last_error (smm_asset asset)
+{
+    smm_error result = { SMM_ERROR_NONE, { 0 } };
+    if (asset == NULL)
+        return result;
+    pthread_mutex_lock (&asset->lock);
+    result = asset->last_error;
+    pthread_mutex_unlock (&asset->lock);
+    return result;
+}
+
+static void
+smm_search_set_error (smm_search search, smm_error_code code, const char *fmt, ...)
+{
+    if (search == NULL)
+        return;
+    search->last_error.code = code;
+    va_list ap;
+    va_start (ap, fmt);
+    vsnprintf (search->last_error.message, sizeof (search->last_error.message), fmt, ap);
+    va_end (ap);
+}
+
+static void
+smm_search_clear_error (smm_search search)
+{
+    if (search == NULL)
+        return;
+    search->last_error.code = SMM_ERROR_NONE;
+    search->last_error.message[0] = '\0';
+}
+
+smm_error
+smm_search_get_last_error (smm_search search)
+{
+    smm_error result = { SMM_ERROR_NONE, { 0 } };
+    if (search == NULL)
+        return result;
+    return search->last_error;
+}
+
 void
 smm_connection_set_error (smm_connection conn, smm_error_code code, const char *fmt, ...)
 {
@@ -591,19 +658,18 @@ smm_asset_report_position (smm_asset asset, double latitude, double longitude, u
     {
         return false;
     }
-    smm_connection_clear_error (asset->conn);
+    smm_asset_clear_error (asset);
 
     struct smm_curl_res_s *res = smm_connection_curl_retrieve_url (asset->conn, page, NULL, to_buffer, &buf, false);
     if (res == NULL)
     {
-        smm_connection_set_error (asset->conn, SMM_ERROR_NETWORK, "network failure reporting position");
+        smm_asset_set_error (asset, SMM_ERROR_NETWORK, "network failure reporting position");
         free (page);
         return false;
     }
     if (!(res->success && res->httpcode == HTTP_SUCCESS))
     {
-        smm_connection_set_error (asset->conn, SMM_ERROR_SERVER, "unexpected HTTP %ld from position report",
-                                  res->httpcode);
+        smm_asset_set_error (asset, SMM_ERROR_SERVER, "unexpected HTTP %ld from position report", res->httpcode);
         smm_curl_res_free (res);
         free (page);
         free (buf.data);
@@ -823,20 +889,19 @@ smm_search_get_waypoints (smm_search search, smm_waypoints *waypoints, size_t *w
 
     *waypoints = NULL;
     *waypoints_count = 0;
-    smm_connection_clear_error (search->conn);
+    smm_search_clear_error (search);
 
     struct smm_curl_res_s *res
         = smm_connection_curl_retrieve_url (search->conn, search->url, NULL, to_buffer, &buf, true);
 
     if (res == NULL)
     {
-        smm_connection_set_error (search->conn, SMM_ERROR_NETWORK, "network failure fetching waypoints");
+        smm_search_set_error (search, SMM_ERROR_NETWORK, "network failure fetching waypoints");
         return false;
     }
     else if (!(res->success && res->httpcode == HTTP_SUCCESS))
     {
-        smm_connection_set_error (search->conn, SMM_ERROR_SERVER, "unexpected HTTP %ld fetching waypoints",
-                                  res->httpcode);
+        smm_search_set_error (search, SMM_ERROR_SERVER, "unexpected HTTP %ld fetching waypoints", res->httpcode);
         smm_curl_res_free (res);
         free (buf.data);
         return false;
@@ -846,7 +911,7 @@ smm_search_get_waypoints (smm_search search, smm_waypoints *waypoints, size_t *w
     bool parse_res = smm_parse_waypoints (buf.data, buf.bytes, waypoints, waypoints_count);
     if (!parse_res)
     {
-        smm_connection_set_error (search->conn, SMM_ERROR_PARSE, "failed to parse waypoints response");
+        smm_search_set_error (search, SMM_ERROR_PARSE, "failed to parse waypoints response");
     }
 
     free (buf.data);
@@ -868,20 +933,19 @@ smm_search_action (smm_search search, const char *action)
     {
         return false;
     }
-    smm_connection_clear_error (search->conn);
+    smm_search_clear_error (search);
 
     struct smm_curl_res_s *res
         = smm_connection_curl_retrieve_url (search->conn, action_page, NULL, to_buffer, &buf, false);
     if (res == NULL)
     {
-        smm_connection_set_error (search->conn, SMM_ERROR_NETWORK, "network failure sending %s action", action);
+        smm_search_set_error (search, SMM_ERROR_NETWORK, "network failure sending %s action", action);
         free (action_page);
         return false;
     }
     else if (!(res->success && res->httpcode == HTTP_SUCCESS))
     {
-        smm_connection_set_error (search->conn, SMM_ERROR_SERVER, "unexpected HTTP %ld from %s action", res->httpcode,
-                                  action);
+        smm_search_set_error (search, SMM_ERROR_SERVER, "unexpected HTTP %ld from %s action", res->httpcode, action);
         smm_curl_res_free (res);
         free (action_page);
         free (buf.data);
@@ -992,19 +1056,18 @@ smm_asset_get_search (smm_asset asset, double latitude, double longitude)
     {
         return NULL;
     }
-    smm_connection_clear_error (asset->conn);
+    smm_asset_clear_error (asset);
 
     struct smm_curl_res_s *res = smm_connection_curl_retrieve_url (asset->conn, page, NULL, to_buffer, &buf, false);
     if (res == NULL)
     {
-        smm_connection_set_error (asset->conn, SMM_ERROR_NETWORK, "network failure fetching closest search");
+        smm_asset_set_error (asset, SMM_ERROR_NETWORK, "network failure fetching closest search");
         free (page);
         return NULL;
     }
     if (!(res->success && res->httpcode == HTTP_SUCCESS))
     {
-        smm_connection_set_error (asset->conn, SMM_ERROR_SERVER, "unexpected HTTP %ld fetching closest search",
-                                  res->httpcode);
+        smm_asset_set_error (asset, SMM_ERROR_SERVER, "unexpected HTTP %ld fetching closest search", res->httpcode);
         smm_curl_res_free (res);
         free (page);
         free (buf.data);

--- a/src/smm-asset.h
+++ b/src/smm-asset.h
@@ -350,6 +350,11 @@ void smm_waypoints_free (smm_waypoints waypoints, size_t waypoints_count);
 /**
  * Retrieve the most recent error recorded on a connection.
  *
+ * Only reflects errors from connection-level operations: login and
+ * smm_asset_get_assets.  Asset-level and search-level errors are
+ * stored on the respective asset or search object; use
+ * smm_asset_get_last_error() and smm_search_get_last_error() instead.
+ *
  * Returns a snapshot of the last error, copied under the connection lock.
  * Safe to call concurrently with other library functions.
  * Returns a zeroed smm_error (code == SMM_ERROR_NONE) if connection is NULL.
@@ -358,3 +363,33 @@ void smm_waypoints_free (smm_waypoints waypoints, size_t waypoints_count);
  * @return a copy of the last recorded error
  */
 smm_error smm_connection_get_last_error (smm_connection connection);
+
+/**
+ * Retrieve the most recent error recorded on an asset.
+ *
+ * Reflects errors from smm_asset_report_position() and
+ * smm_asset_get_search().  The error is stored per-asset so concurrent
+ * operations on different assets sharing the same connection do not
+ * clobber each other's error state.
+ *
+ * Returns a zeroed smm_error (code == SMM_ERROR_NONE) if asset is NULL.
+ *
+ * @param asset the smm_asset to query
+ * @return a copy of the last recorded error
+ */
+smm_error smm_asset_get_last_error (smm_asset asset);
+
+/**
+ * Retrieve the most recent error recorded on a search.
+ *
+ * Reflects errors from smm_search_get_waypoints(), smm_search_accept(),
+ * and smm_search_complete().  The error is stored per-search so
+ * concurrent operations on different searches sharing the same connection
+ * do not clobber each other's error state.
+ *
+ * Returns a zeroed smm_error (code == SMM_ERROR_NONE) if search is NULL.
+ *
+ * @param search the smm_search to query
+ * @return a copy of the last recorded error
+ */
+smm_error smm_search_get_last_error (smm_search search);

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -428,6 +428,71 @@ START_TEST (test_build_position_url_heading)
 }
 END_TEST
 
+START_TEST (test_asset_get_last_error_null)
+{
+    smm_error err = smm_asset_get_last_error (NULL);
+    ck_assert_int_eq (err.code, SMM_ERROR_NONE);
+}
+END_TEST
+
+START_TEST (test_asset_get_last_error_initial)
+{
+    smm_asset asset = smm_asset_create (NULL, "A", "T", 1, 1);
+    ck_assert_ptr_nonnull (asset);
+    smm_error err = smm_asset_get_last_error (asset);
+    ck_assert_int_eq (err.code, SMM_ERROR_NONE);
+    smm_asset_free_asset (asset);
+}
+END_TEST
+
+START_TEST (test_search_get_last_error_null)
+{
+    smm_error err = smm_search_get_last_error (NULL);
+    ck_assert_int_eq (err.code, SMM_ERROR_NONE);
+}
+END_TEST
+
+START_TEST (test_search_get_last_error_initial)
+{
+    const char *json = "{\"object_url\": \"/search/1/\", \"distance\": 10, \"length\": 100, \"sweep_width\": 50}";
+    smm_search search = smm_parse_search_json (NULL, json, strlen (json));
+    ck_assert_ptr_nonnull (search);
+    smm_error err = smm_search_get_last_error (search);
+    ck_assert_int_eq (err.code, SMM_ERROR_NONE);
+    smm_search_destroy (search);
+}
+END_TEST
+
+START_TEST (test_report_position_sets_asset_error_not_conn)
+{
+    /* With a NULL conn the network call fails; the error must land on the
+     * asset, not the connection, so two assets sharing a connection cannot
+     * clobber each other's error state. */
+    smm_asset asset = smm_asset_create (NULL, "A", "T", 1, 1);
+    ck_assert_ptr_nonnull (asset);
+    smm_asset_report_position (asset, -43.5, 172.6, 100, 270, 3);
+    smm_error err = smm_asset_get_last_error (asset);
+    ck_assert_int_ne (err.code, SMM_ERROR_NONE);
+    smm_asset_free_asset (asset);
+}
+END_TEST
+
+START_TEST (test_search_action_sets_search_error_not_conn)
+{
+    /* With conn==NULL the network call fails; the error must land on the
+     * search object. */
+    struct smm_search_s search_s;
+    memset (&search_s, 0, sizeof (search_s));
+    search_s.conn = NULL;
+    search_s.asset_id = 1;
+    search_s.url = strdup ("/search/1/");
+    smm_search_accept (&search_s);
+    smm_error err = smm_search_get_last_error (&search_s);
+    ck_assert_int_ne (err.code, SMM_ERROR_NONE);
+    free (search_s.url);
+}
+END_TEST
+
 START_TEST (test_url_path_safe_valid)
 {
     ck_assert_int_eq (smm_url_path_is_safe ("/search/1/"), true);
@@ -900,6 +965,12 @@ smm_suite (void)
     tcase_add_test (tc_conn, test_connection_login_fields_initialised);
     tcase_add_test (tc_conn, test_get_last_error_null_connection);
     tcase_add_test (tc_conn, test_get_last_error_initial);
+    tcase_add_test (tc_conn, test_asset_get_last_error_null);
+    tcase_add_test (tc_conn, test_asset_get_last_error_initial);
+    tcase_add_test (tc_conn, test_search_get_last_error_null);
+    tcase_add_test (tc_conn, test_search_get_last_error_initial);
+    tcase_add_test (tc_conn, test_report_position_sets_asset_error_not_conn);
+    tcase_add_test (tc_conn, test_search_action_sets_search_error_not_conn);
     tcase_add_test (tc_conn, test_get_state_null_connection);
     tcase_add_test (tc_conn, test_get_state_initial);
     tcase_add_test (tc_conn, test_debugging_set);


### PR DESCRIPTION
## Description

smm_connection.last_error was shared by all concurrent operations on the same connection.  Two threads each calling search or asset actions would silently clobber each other's error before the first thread read it, despite the per-object ownership guarantee in the thread-safety docs.

Add smm_error last_error to smm_asset_s (guarded by the asset lock) and smm_search_s (no lock needed; searches are single-threaded).  Add public API functions smm_asset_get_last_error() and smm_search_get_last_error().

Redirect smm_asset_report_position, smm_asset_get_search, smm_search_get_waypoints, and smm_search_action to set the per-object error instead of the connection error.  Connection-level operations (login, smm_asset_get_assets) continue to use smm_connection.last_error.

## Summary by Sourcery

Move error tracking from shared connections to per-asset and per-search objects to avoid cross-thread error clobbering and expose new accessors for these errors.

New Features:
- Add per-asset and per-search last_error fields and public APIs smm_asset_get_last_error() and smm_search_get_last_error() for retrieving object-level errors.

Bug Fixes:
- Ensure asset and search operations record errors on their own objects instead of the shared connection, preventing concurrent operations from overwriting each other’s error state.

Enhancements:
- Document the division of responsibility between connection-level and object-level error reporting in the public header.
- Initialize and manage asset and search error state with appropriate locking for assets and single-threaded access for searches.

Tests:
- Add unit tests covering initial and NULL-object error states and verifying that asset and search operations set errors on the correct objects rather than the connection.