### PR TITLE
build: add check-code.sh static-analysis gate and wire it into CI

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,33 @@
+---
+# Check families enabled for this C library.
+#
+# Disabled checks and why:
+#  - portability-avoid-pragma-once: the public and internal headers use
+#    '#pragma once' deliberately; it is supported by every compiler we target.
+#  - clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling:
+#    flags every memcpy/snprintf in favour of the C11 Annex K *_s functions,
+#    which are not available in glibc; not actionable here.
+#  - bugprone-easily-swappable-parameters: the geo API legitimately takes
+#    adjacent (latitude, longitude) and (size, nmemb) pairs; renaming or
+#    retyping them would not improve safety.
+#  - misc-include-cleaner: would demand directly including every libcurl
+#    sub-header for each symbol; <curl/curl.h> is the documented entry point.
+#  - bugprone-multi-level-implicit-pointer-conversion: fires on the standard
+#    C realloc()/free() idiom for arrays of typed pointers (void* <-> T**);
+#    adding explicit casts everywhere would add noise without improving safety.
+Checks: >-
+  -*,
+  bugprone-*,
+  performance-*,
+  portability-*,
+  clang-analyzer-*,
+  -portability-avoid-pragma-once,
+  -clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling,
+  -bugprone-easily-swappable-parameters,
+  -bugprone-multi-level-implicit-pointer-conversion,
+  -misc-include-cleaner
+
+# Headers under src/ are part of the project; include findings from them.
+HeaderFilterRegex: "src/.*"
+WarningsAsErrors: "*"
+...

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,3 +29,29 @@ jobs:
       run: docker compose -f tests/docker-compose.yml run tester
     - name: make distcheck
       run: make distcheck
+
+  static-analysis:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - name: Install Deps
+      run: |
+        sudo apt update
+        sudo apt install -y libcurl4-openssl-dev libtidy-dev libjansson-dev check \
+          cppcheck clang-tidy bear
+
+    # clang-format output is version-dependent; pin the exact version the tree
+    # is formatted with so the formatting gate is reproducible.
+    - name: Install pinned clang-format
+      run: |
+        python3 -m venv /tmp/clang-format-venv
+        /tmp/clang-format-venv/bin/pip install -q clang-format==22.1.5
+
+    - name: autogen
+      run: ./autogen.sh
+    - name: configure
+      run: ./configure
+    - name: build with compile database
+      run: bear -- make
+    - name: code checks (clang-format, cppcheck, clang-tidy)
+      run: CLANG_FORMAT=/tmp/clang-format-venv/bin/clang-format ./check-code.sh

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,13 @@ missing
 src/smm-asset.pc
 *.tar.gz
 *~
+
+# check-code.sh / static analysis artifacts
+compile_commands.json
+clang-tidy.log
+stamp-h1
+test-driver
+tests/check_smm
+tests/*.o
+tests/*.log
+tests/*.trs

--- a/check-code.sh
+++ b/check-code.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Static code checks: formatting, cppcheck, and clang-tidy.
+#
+# Run from the top of the source tree after building with a compile database
+# (e.g. `bear -- make`), which clang-tidy needs via compile_commands.json.
+#
+# File sets are globbed rather than enumerated so new sources are covered by
+# the gate automatically.
+
+# clang-format output is not stable across major versions. The tree is
+# formatted with clang-format 22.1.x; CI pins that exact version and points
+# CLANG_FORMAT at it. Locally, set CLANG_FORMAT if your system clang-format
+# is a different major version.
+clang_format="${CLANG_FORMAT:-clang-format}"
+"$clang_format" --dry-run -Werror src/*.c src/*.h tests/*.c
+
+cppcheck --enable=warning,performance,portability,style --error-exitcode=1 \
+	--inline-suppr --std=c11 -I src src/*.c
+
+# The clang-tidy gate is enforced primarily by WarningsAsErrors in .clang-tidy:
+# run-clang-tidy then exits non-zero and `set -o pipefail` fails the pipeline.
+# HeaderFilterRegex already restricts diagnostics to our own sources. The grep
+# below is a backstop that matches clang-tidy's "path:line:col: warning:"
+# diagnostic format rather than any stray "warning"/"error" word in the output.
+run-clang-tidy -p . 'src/.*\.c$' 2>&1 | tee clang-tidy.log
+! grep -Eq ': (warning|error):' clang-tidy.log

--- a/src/smm-asset-curl.c
+++ b/src/smm-asset-curl.c
@@ -146,13 +146,17 @@ smm_curl_res_free (struct smm_curl_res_s *res)
     }
 }
 
+/* Signature is fixed by libcurl's curl_write_callback; params cannot be const. */
 static size_t
+/* cppcheck-suppress[constParameterCallback] */
 eat_data (char *ptr __attribute__ ((unused)), size_t size, size_t nmemb, void *userdata __attribute__ ((unused)))
 {
     return size * nmemb;
 }
 
+/* Signature is fixed by libcurl's curl_write_callback; ptr cannot be const. */
 size_t
+/* cppcheck-suppress[constParameterPointer] */
 to_buffer (char *ptr, size_t size, size_t nmemb, void *userdata)
 {
     size_t new_bytes = size * nmemb;
@@ -312,6 +316,8 @@ smm_connection_curl_retrieve_url_r (smm_connection conn, const char *path, const
             }
         }
         break;
+        default:
+            break;
     }
 
 out:
@@ -553,8 +559,7 @@ smm_asset_connection_login (smm_connection connection)
             break;
         case SMM_CONNECTION_AUTHENTICATION_FAILURE:
             connection->last_error.code = SMM_ERROR_AUTH;
-            snprintf (connection->last_error.message, sizeof (connection->last_error.message),
-                      "authentication failed");
+            snprintf (connection->last_error.message, sizeof (connection->last_error.message), "authentication failed");
             break;
         case SMM_CONNECTION_PROTOCOL_ERROR:
             connection->last_error.code = SMM_ERROR_PROTOCOL;
@@ -568,8 +573,7 @@ smm_asset_connection_login (smm_connection connection)
             break;
         default:
             connection->last_error.code = SMM_ERROR_SERVER;
-            snprintf (connection->last_error.message, sizeof (connection->last_error.message),
-                      "login failed");
+            snprintf (connection->last_error.message, sizeof (connection->last_error.message), "login failed");
             break;
     }
     connection->login_in_progress = false;

--- a/src/smm-asset-internal.h
+++ b/src/smm-asset-internal.h
@@ -79,18 +79,18 @@ struct smm_asset_s
     double last_command_lat;
     double last_command_lon;
     pthread_mutex_t lock;
-    smm_error last_error;  /* guarded by lock */
+    smm_error last_error; /* guarded by lock */
 };
 
 struct smm_search_s
 {
-    smm_connection conn;   /* owns a reference; acquired in smm_search_create */
-    long long asset_id;    /* cached from the creating asset */
+    smm_connection conn; /* owns a reference; acquired in smm_search_create */
+    long long asset_id;  /* cached from the creating asset */
     char *url;
     uint64_t distance;
     uint64_t length;
     uint64_t sweep_width;
-    smm_error last_error;  /* not guarded; searches are single-threaded */
+    smm_error last_error; /* not guarded; searches are single-threaded */
 };
 
 struct smm_curl_res_s

--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -545,7 +545,7 @@ smm_parse_command (const char *data, size_t len, smm_asset_command *command, dou
 }
 
 static bool
-smm_asset_update_command (smm_asset asset, struct buffer_s *buf)
+smm_asset_update_command (smm_asset asset, const struct buffer_s *buf)
 {
     bool res;
     pthread_mutex_lock (&asset->lock);

--- a/src/smm-asset.h
+++ b/src/smm-asset.h
@@ -31,13 +31,13 @@
  */
 typedef enum
 {
-    SMM_ERROR_NONE = 0,         /*!< No error */
-    SMM_ERROR_NETWORK,          /*!< Network or connection failure */
-    SMM_ERROR_AUTH,             /*!< Authentication failure */
-    SMM_ERROR_PROTOCOL,         /*!< Unexpected or malformed response */
-    SMM_ERROR_PARSE,            /*!< JSON or HTML parse failure */
-    SMM_ERROR_INVALID_ARG,      /*!< Invalid argument (e.g. NULL pointer) */
-    SMM_ERROR_SERVER,           /*!< Server returned an unexpected HTTP status */
+    SMM_ERROR_NONE = 0,    /*!< No error */
+    SMM_ERROR_NETWORK,     /*!< Network or connection failure */
+    SMM_ERROR_AUTH,        /*!< Authentication failure */
+    SMM_ERROR_PROTOCOL,    /*!< Unexpected or malformed response */
+    SMM_ERROR_PARSE,       /*!< JSON or HTML parse failure */
+    SMM_ERROR_INVALID_ARG, /*!< Invalid argument (e.g. NULL pointer) */
+    SMM_ERROR_SERVER,      /*!< Server returned an unexpected HTTP status */
 } smm_error_code;
 
 /**
@@ -45,8 +45,8 @@ typedef enum
  */
 typedef struct
 {
-    smm_error_code code;  /*!< Machine-readable error code */
-    char message[256];    /*!< Human-readable description */
+    smm_error_code code; /*!< Machine-readable error code */
+    char message[256];   /*!< Human-readable description */
 } smm_error;
 
 /**

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -508,22 +508,13 @@ START_TEST (test_url_path_safe_dotdot)
 }
 END_TEST
 
-START_TEST (test_url_path_safe_query)
-{
-    ck_assert_int_eq (smm_url_path_is_safe ("/search/1/?injected=evil"), false);
-}
+START_TEST (test_url_path_safe_query) { ck_assert_int_eq (smm_url_path_is_safe ("/search/1/?injected=evil"), false); }
 END_TEST
 
-START_TEST (test_url_path_safe_fragment)
-{
-    ck_assert_int_eq (smm_url_path_is_safe ("/search/1/#frag"), false);
-}
+START_TEST (test_url_path_safe_fragment) { ck_assert_int_eq (smm_url_path_is_safe ("/search/1/#frag"), false); }
 END_TEST
 
-START_TEST (test_url_path_safe_encoded)
-{
-    ck_assert_int_eq (smm_url_path_is_safe ("/search/%2e%2e/admin/"), false);
-}
+START_TEST (test_url_path_safe_encoded) { ck_assert_int_eq (smm_url_path_is_safe ("/search/%2e%2e/admin/"), false); }
 END_TEST
 
 START_TEST (test_url_path_safe_absolute)
@@ -533,10 +524,7 @@ START_TEST (test_url_path_safe_absolute)
 }
 END_TEST
 
-START_TEST (test_url_path_safe_null)
-{
-    ck_assert_int_eq (smm_url_path_is_safe (NULL), false);
-}
+START_TEST (test_url_path_safe_null) { ck_assert_int_eq (smm_url_path_is_safe (NULL), false); }
 END_TEST
 
 START_TEST (test_get_search_dotdot_url_rejected)


### PR DESCRIPTION
## Description

Adopt the check-code.sh convention used by the sibling projects (flight-safety-system et al.): a single script that runs clang-format, cppcheck, and clang-tidy over the library sources, plus a CI job that runs it with a pinned clang-format.

- check-code.sh: clang-format --dry-run -Werror, cppcheck (warning,performance,portability,style), and run-clang-tidy.
- .clang-tidy: curated C check set with documented suppressions for idioms that don't apply (pragma once, glibc lacking Annex K *_s, realloc/free typed-pointer conversions, libcurl include entry point).
- .github/workflows/build.yml: new static-analysis job that builds with a compile database (bear) and runs check-code.sh; clang-format pinned to 22.1.5 for reproducibility.
- Reformat sources with clang-format 22.1.x to satisfy the gate.
- Minor fixes to pass the gate: const-qualify an internal buffer param, add a no-op default case to the httpcode switch, and suppress two cppcheck false positives on libcurl-callback signatures.
- .gitignore: ignore compile_commands.json, clang-tidy.log, and build artifacts.

## Summary by Sourcery

Introduce a static analysis gate script and enforce it in CI, along with code and formatting adjustments required to pass it.

Enhancements:
- Tighten internal API const-correctness, add a default branch to HTTP status handling, and document cppcheck suppressions on libcurl callbacks.

Build:
- Add check-code.sh script to run clang-format, cppcheck, and clang-tidy over core sources using a compile_commands.json database.

CI:
- Add a static-analysis GitHub Actions job that installs analysis tooling, pins clang-format 22.1.5, builds with bear, and runs the new check-code.sh gate.

Tests:
- Reformat selected tests to comply with the new clang-format style.

Chores:
- Reformat core source and header files to the standardized clang-format style and ignore analysis artifacts like compile_commands.json and clang-tidy.log.