### PR TITLE
fix: format coordinates locale-independently in request URLs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: Install Deps
-      run: sudo apt update && sudo apt install -y libcurl4-openssl-dev libtidy-dev libjansson-dev check
+      run: sudo apt update && sudo apt install -y libcurl4-openssl-dev libtidy-dev libjansson-dev check locales-all
     - name: autogen
       run: ./autogen.sh
     - name: configure

--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -23,6 +23,7 @@
 #include "smm-asset.h"
 #include "smm-asset-internal.h"
 
+#include <locale.h>
 #include <pthread.h>
 #include <stdarg.h>
 #include <stdlib.h>
@@ -31,6 +32,52 @@
 #include <jansson.h>
 
 _Atomic bool smm_debug = false;
+
+/*
+ * SMM expects coordinates in URLs formatted with '.' as the decimal separator.
+ * printf-family conversions honour the thread's LC_NUMERIC, so a caller running
+ * under a locale such as de_DE would otherwise emit "lat=-43,5" and corrupt the
+ * request. We keep a private "C" locale and switch to it (per-thread, via
+ * uselocale) only while formatting numbers.
+ */
+static locale_t smm_c_locale = (locale_t)0;
+static pthread_once_t smm_c_locale_once = PTHREAD_ONCE_INIT;
+
+static void
+smm_c_locale_init (void)
+{
+    smm_c_locale = newlocale (LC_NUMERIC_MASK, "C", (locale_t)0);
+}
+
+static locale_t
+smm_c_locale_get (void)
+{
+    pthread_once (&smm_c_locale_once, smm_c_locale_init);
+    return smm_c_locale;
+}
+
+/* asprintf() that formats in the private "C" locale (see above), so coordinate
+ * conversions use '.' as the decimal separator regardless of the caller's
+ * LC_NUMERIC. Returns the asprintf() result; *strp is undefined on failure. */
+static int smm_asprintf_c_locale (char **strp, const char *fmt, ...) __attribute__ ((format (printf, 2, 3)));
+
+static int
+smm_asprintf_c_locale (char **strp, const char *fmt, ...)
+{
+    locale_t c_locale = smm_c_locale_get ();
+    locale_t old_locale = (c_locale != (locale_t)0) ? uselocale (c_locale) : (locale_t)0;
+
+    va_list ap;
+    va_start (ap, fmt);
+    int n = vasprintf (strp, fmt, ap);
+    va_end (ap);
+
+    if (old_locale != (locale_t)0)
+    {
+        uselocale (old_locale);
+    }
+    return n;
+}
 
 void
 smm_asset_debugging_set (bool debug)
@@ -634,8 +681,8 @@ smm_asset_build_position_url (long long asset_id, double lat, double lon, unsign
                               uint8_t fix)
 {
     char *page = NULL;
-    if (asprintf (&page, "/data/assets/%lld/position/add/?lat=%lf&lon=%lf&alt=%u&heading=%u&fix=%u", asset_id, lat, lon,
-                  alt, heading, fix)
+    if (smm_asprintf_c_locale (&page, "/data/assets/%lld/position/add/?lat=%lf&lon=%lf&alt=%u&heading=%u&fix=%u",
+                               asset_id, lat, lon, alt, heading, fix)
         < 0)
     {
         return NULL;
@@ -1050,8 +1097,8 @@ smm_asset_get_search (smm_asset asset, double latitude, double longitude)
     struct buffer_s buf = { NULL, 0 };
 
     char *page = NULL;
-    if (asprintf (&page, "/search/find/closest/?asset_id=%lli&latitude=%lf&longitude=%lf", asset->asset_id, latitude,
-                  longitude)
+    if (smm_asprintf_c_locale (&page, "/search/find/closest/?asset_id=%lli&latitude=%lf&longitude=%lf", asset->asset_id,
+                               latitude, longitude)
         < 0)
     {
         return NULL;

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -1,6 +1,7 @@
 #include "smm-asset-internal.h"
 #include "smm-asset.h"
 #include <check.h>
+#include <locale.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -425,6 +426,42 @@ START_TEST (test_build_position_url_heading)
     ck_assert_ptr_nonnull (strstr (url, "heading="));
     ck_assert_ptr_null (strstr (url, "bearing="));
     free (url);
+}
+END_TEST
+
+/* Coordinates must always use '.' as the decimal separator regardless of the
+ * caller's LC_NUMERIC. We assert this under the current locale (always) and,
+ * when a comma-decimal locale is installed, under that locale too. */
+START_TEST (test_build_position_url_locale_independent)
+{
+    char *url = smm_asset_build_position_url (42, -43.5, 172.6, 100, 270, 3);
+    ck_assert_ptr_nonnull (url);
+    ck_assert_ptr_nonnull (strstr (url, "lat=-43.500000"));
+    ck_assert_ptr_nonnull (strstr (url, "lon=172.600000"));
+    free (url);
+
+    /* Try a few locales that format decimals with a comma. If none are
+     * installed (e.g. a minimal CI image) the loop is a no-op and the
+     * assertions above still guard the common case. */
+    const char *comma_locales[] = { "de_DE.UTF-8", "de_DE.utf8", "de_DE", "fr_FR.UTF-8", "nl_NL.UTF-8" };
+    for (size_t i = 0; i < sizeof (comma_locales) / sizeof (comma_locales[0]); i++)
+    {
+        locale_t loc = newlocale (LC_NUMERIC_MASK, comma_locales[i], (locale_t)0);
+        if (loc == (locale_t)0)
+        {
+            continue;
+        }
+        locale_t old = uselocale (loc);
+        url = smm_asset_build_position_url (42, -43.5, 172.6, 100, 270, 3);
+        uselocale (old);
+        freelocale (loc);
+
+        ck_assert_ptr_nonnull (url);
+        ck_assert_ptr_nonnull (strstr (url, "lat=-43.500000"));
+        ck_assert_ptr_null (strstr (url, ","));
+        free (url);
+        break;
+    }
 }
 END_TEST
 
@@ -966,6 +1003,7 @@ smm_suite (void)
 
     TCase *tc_position = tcase_create ("Position");
     tcase_add_test (tc_position, test_build_position_url_heading);
+    tcase_add_test (tc_position, test_build_position_url_locale_independent);
     tcase_add_test (tc_position, test_set_command_from_plaintext_continue);
     tcase_add_test (tc_position, test_set_command_from_plaintext_other);
     tcase_add_test (tc_position, test_set_command_from_plaintext_null);


### PR DESCRIPTION
## Description

smm_asset_build_position_url() and smm_asset_get_search() formatted latitude/longitude with printf %lf, which honours the thread's LC_NUMERIC. A caller running under a comma-decimal locale (de_DE, fr_FR, etc.) would emit "lat=-43,500000", corrupting the request the server sees.

Keep a private "C" locale (created once via pthread_once) and switch to it per-thread with uselocale() only around the asprintf that formats the coordinates, restoring the caller's locale immediately afterwards.

Add a test asserting '.' separators under the current locale and, when a comma-decimal locale is installed, under that locale too; install locales-all in CI so the comma path is actually exercised.

## Summary by Sourcery

Ensure asset coordinate URLs are formatted with a dot decimal separator regardless of the caller's locale.

Bug Fixes:
- Prevent latitude/longitude in request URLs from using locale-dependent comma decimal separators that break server parsing.

Enhancements:
- Introduce a locale-aware formatting helper that temporarily switches to a private C locale when constructing URL strings.

CI:
- Install locales-all in the CI workflow so comma-decimal locale tests are exercised.

Tests:
- Add tests verifying that position URLs use '.' as the decimal separator under both default and comma-decimal locales.