### PR TITLE
fix: stop libtidy writing parser diagnostics to the host app's stderr

### DIFF
--- a/src/smm-asset-curl.c
+++ b/src/smm-asset-curl.c
@@ -439,6 +439,7 @@ smm_parse_csrf_token (const char *data, size_t len)
 {
     char *token = NULL;
     TidyBuffer docbuf = { 0 };
+    TidyBuffer errbuf = { 0 };
     TidyDoc tdoc = tidyCreate ();
 
     if (tdoc == NULL)
@@ -449,7 +450,14 @@ smm_parse_csrf_token (const char *data, size_t len)
     tidyOptSetBool (tdoc, TidyForceOutput, yes);
     tidyOptSetInt (tdoc, TidyWrapLen, 4096);
     tidyBufInit (&docbuf);
+    tidyBufInit (&errbuf);
     tidyBufAppend (&docbuf, (void *)data, len);
+
+    /* Redirect tidy's diagnostics into a buffer we discard; otherwise it
+     * writes parser warnings about the login page straight to the host
+     * application's stderr on every login. Best-effort: if the redirect
+     * cannot be installed we still parse rather than failing the login. */
+    tidySetErrorBuffer (tdoc, &errbuf);
 
     if (tidyParseBuffer (tdoc, &docbuf) >= 0)
     {
@@ -458,6 +466,7 @@ smm_parse_csrf_token (const char *data, size_t len)
     }
 
     tidyBufFree (&docbuf);
+    tidyBufFree (&errbuf);
     tidyRelease (tdoc);
 
     return token;


### PR DESCRIPTION
## Description

smm_parse_csrf_token() left tidy's error sink at its default (stderr), so every login dumped "missing <!DOCTYPE>"-style warnings about the server's login page into the calling application's stderr. A library should not write to stderr.

Install a discard buffer with tidySetErrorBuffer() before parsing, and free it alongside the document buffer. Best-effort: if the redirect cannot be installed we still parse rather than failing the login.

## Summary by Sourcery

Bug Fixes:
- Stop libtidy from emitting HTML parser warnings to the host application's stderr during CSRF token parsing by redirecting diagnostics into an internal buffer.