### PR TITLE
fix: follow 301 and 303 redirects, not only 302

### DIFF
--- a/src/smm-asset-curl.c
+++ b/src/smm-asset-curl.c
@@ -593,6 +593,14 @@ smm_asset_connection_login (smm_connection connection)
 }
 
 bool
+smm_httpcode_is_redirect (long httpcode)
+{
+    /* The redirects we follow: 301 (e.g. Django's SECURE_SSL_REDIRECT
+     * HTTP->HTTPS upgrade), 302 (login redirect), and 303. */
+    return httpcode == HTTP_MOVED_PERMANENTLY || httpcode == HTTP_FOUND || httpcode == HTTP_SEE_OTHER;
+}
+
+bool
 smm_https_upgrade_is_same_host (const char *http_host, const char *https_redirect)
 {
     if (http_host == NULL || https_redirect == NULL)
@@ -626,7 +634,7 @@ smm_connection_curl_retrieve_url (smm_connection conn, const char *path, const c
     {
         retry = false;
         retries++;
-        if (res->success && res->httpcode == HTTP_FOUND && res->redirect_url)
+        if (res->success && smm_httpcode_is_redirect (res->httpcode) && res->redirect_url)
         {
             DEBUG ("Got redirected to (%s) accessing %s\n", res->redirect_url, path);
             /* It's possible we need to upgrade to https */

--- a/src/smm-asset-internal.h
+++ b/src/smm-asset-internal.h
@@ -148,6 +148,10 @@ void smm_asset_set_command_from_plaintext (smm_asset asset, const char *data, si
 
 smm_search smm_parse_search_json (smm_asset asset, const char *data, size_t len);
 
+/* Returns true for the HTTP status codes we treat as followable redirects
+ * (301, 302, 303). */
+bool smm_httpcode_is_redirect (long httpcode);
+
 /* Returns true if https_redirect is an HTTPS upgrade of http_host to the
  * same host:port — used to guard against redirect-based downgrade attacks. */
 bool smm_https_upgrade_is_same_host (const char *http_host, const char *https_redirect);

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -600,6 +600,24 @@ START_TEST (test_curl_timeout_constants)
 }
 END_TEST
 
+START_TEST (test_httpcode_is_redirect)
+{
+    ck_assert_int_eq (smm_httpcode_is_redirect (301), true);
+    ck_assert_int_eq (smm_httpcode_is_redirect (302), true);
+    ck_assert_int_eq (smm_httpcode_is_redirect (303), true);
+}
+END_TEST
+
+START_TEST (test_httpcode_is_not_redirect)
+{
+    ck_assert_int_eq (smm_httpcode_is_redirect (200), false);
+    ck_assert_int_eq (smm_httpcode_is_redirect (304), false);
+    ck_assert_int_eq (smm_httpcode_is_redirect (307), false);
+    ck_assert_int_eq (smm_httpcode_is_redirect (400), false);
+    ck_assert_int_eq (smm_httpcode_is_redirect (0), false);
+}
+END_TEST
+
 START_TEST (test_https_upgrade_same_host)
 {
     ck_assert_int_eq (smm_https_upgrade_is_same_host ("http://example.com", "https://example.com/login/"), true);
@@ -973,6 +991,8 @@ smm_suite (void)
 
     tc_conn = tcase_create ("Connection");
     tcase_add_test (tc_conn, test_curl_timeout_constants);
+    tcase_add_test (tc_conn, test_httpcode_is_redirect);
+    tcase_add_test (tc_conn, test_httpcode_is_not_redirect);
     tcase_add_test (tc_conn, test_curl_retrieve_url_r_returns_null_on_no_response);
     tcase_add_test (tc_conn, test_login_in_progress_reset_on_failure);
     tcase_add_test (tc_conn, test_https_upgrade_same_host);


### PR DESCRIPTION
## Description

The retry loop only acted on HTTP 302, but smm_connection_curl_retrieve_url_r already captures the redirect target for 301, 302 and 303. In particular Django's SECURE_SSL_REDIRECT issues a 301 for the HTTP->HTTPS upgrade, so against a server that enforces HTTPS the same-host upgrade path never triggered and the request just failed.

Introduce smm_httpcode_is_redirect() (301/302/303) and use it to gate the upgrade/login retry logic. The same-host HTTPS guard and the retry cap already prevent downgrade and redirect loops. Add unit tests for the redirect-code predicate.

## Summary by Sourcery

Handle HTTP redirects uniformly for HTTPS upgrade and login retries by recognizing multiple redirect status codes.

Bug Fixes:
- Treat HTTP 301 and 303 responses as followable redirects in addition to 302 for connection retry logic.

Enhancements:
- Introduce a reusable helper to classify followable redirect HTTP status codes.

Tests:
- Add unit tests covering which HTTP status codes are treated as redirects and which are not.