### PR TITLE
fix: accept real-valued distance/length/sweep_width from the server

### DIFF
--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -1030,6 +1030,28 @@ smm_waypoints_free (smm_waypoints waypoints, size_t waypoints_count)
     free (waypoints);
 }
 
+/* Read a non-negative quantity the server may encode as a JSON integer or a
+ * JSON real. json_integer_value() returns 0 for a real value, so accept both;
+ * negative, non-numeric, and out-of-range values clamp into [0, UINT64_MAX]. */
+static uint64_t
+smm_json_number_to_u64 (const json_t *value)
+{
+    if (!json_is_number (value))
+    {
+        return 0;
+    }
+    double d = json_number_value (value);
+    if (d <= 0.0)
+    {
+        return 0;
+    }
+    if (d >= (double)UINT64_MAX)
+    {
+        return UINT64_MAX;
+    }
+    return (uint64_t)d;
+}
+
 smm_search
 smm_parse_search_json (smm_asset asset, const char *data, size_t len)
 {
@@ -1058,21 +1080,9 @@ smm_parse_search_json (smm_asset asset, const char *data, size_t len)
             DEBUG ("object_url is not a safe relative path; ignoring\n");
             url = NULL;
         }
-        tmp = json_object_get (json_root, "distance");
-        if (tmp)
-        {
-            distance = json_integer_value (tmp);
-        }
-        tmp = json_object_get (json_root, "length");
-        if (tmp)
-        {
-            length = json_integer_value (tmp);
-        }
-        tmp = json_object_get (json_root, "sweep_width");
-        if (tmp)
-        {
-            sweep_width = json_integer_value (tmp);
-        }
+        distance = smm_json_number_to_u64 (json_object_get (json_root, "distance"));
+        length = smm_json_number_to_u64 (json_object_get (json_root, "length"));
+        sweep_width = smm_json_number_to_u64 (json_object_get (json_root, "sweep_width"));
         if (url)
         {
             search = smm_search_create (asset, url, length, distance, sweep_width);

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -273,6 +273,31 @@ START_TEST (test_get_search_relative_url_accepted)
 }
 END_TEST
 
+START_TEST (test_get_search_real_numeric_fields)
+{
+    /* The server contract does not guarantee integers; a real-valued
+     * distance/length/sweep_width must still be read (json_integer_value
+     * would have returned 0). */
+    const char *json = "{\"object_url\": \"/search/1/\", \"distance\": 10.7, \"length\": 100.9, \"sweep_width\": 50.5}";
+    smm_search search = smm_parse_search_json (NULL, json, strlen (json));
+    ck_assert_ptr_nonnull (search);
+    ck_assert_uint_eq (smm_search_distance (search), 10);
+    ck_assert_uint_eq (smm_search_length (search), 100);
+    ck_assert_uint_eq (smm_search_sweep_width (search), 50);
+    smm_search_destroy (search);
+}
+END_TEST
+
+START_TEST (test_get_search_negative_numeric_clamps_zero)
+{
+    const char *json = "{\"object_url\": \"/search/1/\", \"distance\": -5, \"length\": 100, \"sweep_width\": 50}";
+    smm_search search = smm_parse_search_json (NULL, json, strlen (json));
+    ck_assert_ptr_nonnull (search);
+    ck_assert_uint_eq (smm_search_distance (search), 0);
+    smm_search_destroy (search);
+}
+END_TEST
+
 START_TEST (test_search_accept_null_conn)
 {
     struct smm_search_s search_s;
@@ -1089,6 +1114,8 @@ smm_suite (void)
     tcase_add_test (tc_search, test_get_search_nonstring_object_url_returns_null);
     tcase_add_test (tc_search, test_get_search_missing_object_url_returns_null);
     tcase_add_test (tc_search, test_get_search_relative_url_accepted);
+    tcase_add_test (tc_search, test_get_search_real_numeric_fields);
+    tcase_add_test (tc_search, test_get_search_negative_numeric_clamps_zero);
     tcase_add_test (tc_search, test_get_search_dotdot_url_rejected);
     tcase_add_test (tc_search, test_get_search_query_url_rejected);
     tcase_add_test (tc_search, test_get_search_encoded_url_rejected);


### PR DESCRIPTION
## Description

smm_parse_search_json() read distance, length and sweep_width with json_integer_value(), which returns 0 for a JSON real. The server contract does not guarantee integers, so a float-encoded value silently became 0.

Add smm_json_number_to_u64(), which accepts either a JSON integer or real, clamps negatives and out-of-range values into [0, UINT64_MAX], and truncates toward zero. Use it for all three fields. Add tests for real-valued and negative inputs.

## Summary by Sourcery

Handle search JSON numeric fields as general non-negative numbers instead of integers only.

Bug Fixes:
- Ensure distance, length, and sweep_width fields correctly parse real-valued JSON numbers instead of silently becoming zero.
- Clamp negative and out-of-range numeric inputs for search fields into the valid [0, UINT64_MAX] range to avoid undefined behavior.

Tests:
- Add tests verifying parsing of real-valued distance/length/sweep_width fields and truncation toward zero.
- Add tests confirming negative numeric values for search fields are clamped to zero.