### PR TITLE
docs: fix README search example leak and thread-safety wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,15 @@ int main(int argc, char *argv[])
 
 		/* You can also get a search to conduct by */
 		smm_search search;
-		do {
-			search = smm_asset_get_search (asset, -43, 172);
-		} while (search != NULL && !smm_search_accept (search));
+		while ((search = smm_asset_get_search (asset, -43, 172)) != NULL)
+		{
+			if (smm_search_accept (search))
+			{
+				break;
+			}
+			/* The server declined this search; discard it and ask again */
+			smm_search_destroy (search);
+		}
 
 		if (search != NULL)
 		{

--- a/src/smm-asset.h
+++ b/src/smm-asset.h
@@ -52,8 +52,12 @@ typedef struct
 /**
  * @section thread_safety Thread-safety guarantees
  *
- * - A single smm_connection may be shared across threads.  All functions that
- *   operate on an smm_connection are internally serialised with a mutex.
+ * - A single smm_connection may be shared across threads.  The connection's
+ *   shared state (cookies, CSRF token, DNS/TLS cache, connection status and
+ *   error record) is protected by an internal mutex, so concurrent calls on
+ *   the same connection are safe.  Calls are not globally serialised: the
+ *   mutex is not held across network I/O, so independent requests on the same
+ *   connection may be in flight in parallel.
  *
  * - smm_asset_connect() and smm_connection_close() are safe to call from any
  *   thread, but smm_connection_close() must not be called while another thread


### PR DESCRIPTION
## Description

The README's get-a-search loop overwrote `search` on every iteration without destroying the previous one, leaking each search the server declined. Rewrite it to destroy a non-accepted search before asking again.

Correct the thread-safety section in smm-asset.h: connection calls are not "internally serialised with a mutex" — the mutex guards shared connection state but is not held across network I/O, so independent requests on one connection may run in parallel. Describe that accurately.

## Summary by Sourcery

Update documentation examples and thread-safety description for search handling and shared connections.

Documentation:
- Adjust README search example to avoid leaking declined searches and demonstrate proper destruction before retrying.
- Clarify smm_connection thread-safety guarantees to state that shared state is mutex-protected but independent requests on the same connection may run in parallel.