### PR TITLE
fix: match Content-Type ignoring case and parameters

### DIFF
--- a/src/smm-asset-internal.h
+++ b/src/smm-asset-internal.h
@@ -160,3 +160,8 @@ bool smm_https_upgrade_is_same_host (const char *http_host, const char *https_re
  * no '..' segments, no query ('?'), no fragment ('#'), and no percent-
  * encoded characters ('%'). */
 bool smm_url_path_is_safe (const char *url);
+
+/* Returns true if content_type is the application/json media type, ignoring
+ * ASCII case, leading whitespace, and any parameters (e.g. "; charset=utf-8").
+ * A NULL content_type returns false. */
+bool smm_content_type_is_json (const char *content_type);

--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -660,6 +660,51 @@ smm_asset_set_command_from_plaintext (smm_asset asset, const char *data, size_t 
     pthread_mutex_unlock (&asset->lock);
 }
 
+/* ASCII-only, case-insensitive comparison of the first n bytes. Used for
+ * media-type matching so the result does not depend on the caller's locale
+ * (e.g. the Turkish dotless-i rule that would break strncasecmp). */
+static bool
+smm_ascii_caseeq (const char *a, const char *b, size_t n)
+{
+    for (size_t i = 0; i < n; i++)
+    {
+        unsigned char ca = (unsigned char)a[i];
+        unsigned char cb = (unsigned char)b[i];
+        if (ca >= 'A' && ca <= 'Z')
+            ca = (unsigned char)(ca + ('a' - 'A'));
+        if (cb >= 'A' && cb <= 'Z')
+            cb = (unsigned char)(cb + ('a' - 'A'));
+        if (ca != cb)
+            return false;
+    }
+    return true;
+}
+
+bool
+smm_content_type_is_json (const char *content_type)
+{
+    static const char json[] = "application/json";
+    const size_t json_len = sizeof (json) - 1;
+
+    if (content_type == NULL)
+        return false;
+
+    /* Skip any leading whitespace before the media type. */
+    while (*content_type == ' ' || *content_type == '\t')
+        content_type++;
+
+    if (!smm_ascii_caseeq (content_type, json, json_len))
+        return false;
+
+    /* The media type must end here: only whitespace or a ';' parameter
+     * delimiter may follow (e.g. "application/json; charset=utf-8"). This
+     * rejects look-alikes such as "application/json-patch+json". */
+    const char *after = content_type + json_len;
+    while (*after == ' ' || *after == '\t')
+        after++;
+    return *after == '\0' || *after == ';';
+}
+
 bool
 smm_url_path_is_safe (const char *url)
 {
@@ -726,7 +771,7 @@ smm_asset_report_position (smm_asset asset, double latitude, double longitude, u
     free (page);
 
     /* if json data was returned, update the current action */
-    if (res->content_type != NULL && strcmp (res->content_type, "application/json") == 0)
+    if (smm_content_type_is_json (res->content_type))
     {
         smm_asset_update_command (asset, &buf);
     }
@@ -1132,7 +1177,7 @@ smm_asset_get_search (smm_asset asset, double latitude, double longitude)
     }
     free (page);
 
-    if (res->content_type != NULL && strcmp (res->content_type, "application/json") == 0)
+    if (smm_content_type_is_json (res->content_type))
     {
         search = smm_parse_search_json (asset, buf.data, buf.bytes);
     }

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -589,6 +589,40 @@ END_TEST
 START_TEST (test_url_path_safe_null) { ck_assert_int_eq (smm_url_path_is_safe (NULL), false); }
 END_TEST
 
+START_TEST (test_content_type_is_json_plain) { ck_assert_int_eq (smm_content_type_is_json ("application/json"), true); }
+END_TEST
+
+START_TEST (test_content_type_is_json_with_charset)
+{
+    ck_assert_int_eq (smm_content_type_is_json ("application/json; charset=utf-8"), true);
+    ck_assert_int_eq (smm_content_type_is_json ("application/json;charset=utf-8"), true);
+    ck_assert_int_eq (smm_content_type_is_json ("application/json \t; charset=utf-8"), true);
+}
+END_TEST
+
+START_TEST (test_content_type_is_json_case_insensitive)
+{
+    ck_assert_int_eq (smm_content_type_is_json ("Application/JSON"), true);
+    ck_assert_int_eq (smm_content_type_is_json ("APPLICATION/JSON; CHARSET=UTF-8"), true);
+}
+END_TEST
+
+START_TEST (test_content_type_is_json_leading_whitespace)
+{
+    ck_assert_int_eq (smm_content_type_is_json ("  application/json"), true);
+}
+END_TEST
+
+START_TEST (test_content_type_is_json_rejects_lookalikes)
+{
+    ck_assert_int_eq (smm_content_type_is_json ("application/json-patch+json"), false);
+    ck_assert_int_eq (smm_content_type_is_json ("application/jsonx"), false);
+    ck_assert_int_eq (smm_content_type_is_json ("text/html"), false);
+    ck_assert_int_eq (smm_content_type_is_json (""), false);
+    ck_assert_int_eq (smm_content_type_is_json (NULL), false);
+}
+END_TEST
+
 START_TEST (test_get_search_dotdot_url_rejected)
 {
     const char *json = "{\"object_url\": \"/search/1/../../admin/\", \"distance\": 10, \"length\": 100, "
@@ -1130,6 +1164,14 @@ smm_suite (void)
     tcase_add_test (tc_url, test_url_path_safe_absolute);
     tcase_add_test (tc_url, test_url_path_safe_null);
     suite_add_tcase (s, tc_url);
+
+    TCase *tc_content_type = tcase_create ("ContentType");
+    tcase_add_test (tc_content_type, test_content_type_is_json_plain);
+    tcase_add_test (tc_content_type, test_content_type_is_json_with_charset);
+    tcase_add_test (tc_content_type, test_content_type_is_json_case_insensitive);
+    tcase_add_test (tc_content_type, test_content_type_is_json_leading_whitespace);
+    tcase_add_test (tc_content_type, test_content_type_is_json_rejects_lookalikes);
+    suite_add_tcase (s, tc_content_type);
 
     TCase *tc_position_ext = tcase_create ("PositionExt");
     tcase_add_test (tc_position_ext, test_build_position_url_values);


### PR DESCRIPTION
## Description

smm_asset_report_position and smm_asset_get_search decided whether the response body was JSON with an exact strcmp against "application/json". That fails the moment the server sends a charset parameter ("application/json; charset=utf-8") or a different case, silently falling back to plaintext command parsing and discarding GOTO/RTL commands and search results.

Add smm_content_type_is_json(), which matches the application/json media type ignoring ASCII case, leading whitespace, and any parameters, while still rejecting look-alikes such as application/json-patch+json. The ASCII-only case fold avoids the locale dependence of strncasecmp.

## Summary by Sourcery

Improve detection of JSON HTTP responses and update dependent code paths to handle common Content-Type variations correctly.

Bug Fixes:
- Correct JSON response detection for asset position reports and search results when the Content-Type header includes parameters or different casing.

Enhancements:
- Introduce a locale-independent helper to recognize the application/json media type while ignoring ASCII case, leading whitespace, and parameters.
- Expose the new JSON Content-Type helper in the internal header for reuse.

Tests:
- Add a dedicated ContentType test case covering normal, parameterized, case-variant, whitespace-prefixed, and invalid Content-Type values for JSON detection.