### PR TITLE
fix: never log the login POST body in debug output

### DIFF
--- a/src/smm-asset-curl.c
+++ b/src/smm-asset-curl.c
@@ -186,7 +186,9 @@ smm_connection_curl_retrieve_url_r (smm_connection conn, const char *path, const
     struct curl_slist *headers = NULL;
     bool have_ref = false;
 
-    DEBUG ("(%p, %s, %s, %p)\n", (void *)conn, path, post_data, write_data);
+    /* Never log post_data: for the login request it carries the user's
+     * password. Log only whether a body is present. */
+    DEBUG ("(%p, %s, %s, %p)\n", (void *)conn, path, post_data ? "<redacted body>" : "(none)", write_data);
 
     if (conn == NULL || path == NULL)
     {


### PR DESCRIPTION
## Description

The entry DEBUG() in smm_connection_curl_retrieve_url_r printed post_data verbatim. The only request with a body is the login POST, whose body is csrfmiddlewaretoken=...&username=...&password=..., so turning on debug wrote the user's cleartext password to stdout. Log only whether a body is present.

## Summary by Sourcery

Bug Fixes:
- Redact POST request bodies from debug logging, logging only whether a body is present instead of its contents.