### PR TITLE
fix: distinguish a new connection from an invalid object

### DIFF
--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -133,6 +133,11 @@ smm_asset_connect (const char *host, const char *user, const char *pass)
         {
             conn->state = SMM_CONNECTION_HOST_INVALID;
         }
+        else
+        {
+            /* Host looks valid; login happens lazily on the first request. */
+            conn->state = SMM_CONNECTION_NEW;
+        }
         curl_url_cleanup (curlu);
     }
     else

--- a/src/smm-asset.h
+++ b/src/smm-asset.h
@@ -123,13 +123,14 @@ typedef struct smm_waypoint_s **smm_waypoints;
  */
 typedef enum
 {
-    SMM_CONNECTION_UNKNOWN,                /*!< Unknown state or invalid object */
+    SMM_CONNECTION_UNKNOWN,                /*!< Invalid object (e.g. NULL connection) */
     SMM_CONNECTION_CONNECTED,              /*!< Currently connected */
     SMM_CONNECTION_HOST_INVALID,           /*!< Host URL invalid, i.e. not http(s):// or not a valid domain */
     SMM_CONNECTION_NO_HOST_CONNECTION,     /*!< Unable to connect to host */
     SMM_CONNECTION_AUTHENTICATION_FAILURE, /*!< Unable to authenticate with host */
     SMM_CONNECTION_PROTOCOL_ERROR,         /*!< Unexpected response from host */
     SMM_CONNECTION_FAILURE,                /*!< Unable to communicate, for another reason */
+    SMM_CONNECTION_NEW,                    /*!< Valid host accepted, but no request made yet (login is lazy) */
 } smm_connection_status;
 
 /**
@@ -168,6 +169,10 @@ smm_connection smm_asset_connect (const char *host, const char *user, const char
 
 /**
  * Check the state of a connection
+ *
+ * Authentication is performed lazily on the first request, so a freshly
+ * connected object with a valid host reports SMM_CONNECTION_NEW until a
+ * request transitions it to SMM_CONNECTION_CONNECTED (or an error state).
  *
  * @param connection the smm_connection object to check
  *

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -1034,7 +1034,16 @@ START_TEST (test_get_state_initial)
 {
     smm_connection conn = smm_asset_connect ("http://localhost/", "user", "pass");
     ck_assert_ptr_nonnull (conn);
-    ck_assert_int_eq (smm_asset_connection_get_state (conn), SMM_CONNECTION_UNKNOWN);
+    ck_assert_int_eq (smm_asset_connection_get_state (conn), SMM_CONNECTION_NEW);
+    smm_connection_close (conn);
+}
+END_TEST
+
+START_TEST (test_get_state_invalid_host)
+{
+    smm_connection conn = smm_asset_connect ("not a url", "user", "pass");
+    ck_assert_ptr_nonnull (conn);
+    ck_assert_int_eq (smm_asset_connection_get_state (conn), SMM_CONNECTION_HOST_INVALID);
     smm_connection_close (conn);
 }
 END_TEST
@@ -1077,6 +1086,7 @@ smm_suite (void)
     tcase_add_test (tc_conn, test_search_action_sets_search_error_not_conn);
     tcase_add_test (tc_conn, test_get_state_null_connection);
     tcase_add_test (tc_conn, test_get_state_initial);
+    tcase_add_test (tc_conn, test_get_state_invalid_host);
     tcase_add_test (tc_conn, test_debugging_set);
     suite_add_tcase (s, tc_conn);
 


### PR DESCRIPTION
## Description

SMM_CONNECTION_UNKNOWN doubled as both "invalid object" and "valid host, not yet authenticated", so a freshly connected object to a good host reported UNKNOWN — indistinguishable from a NULL/garbage connection.

Add SMM_CONNECTION_NEW (appended to keep existing enum values stable) and set it in smm_asset_connect() once the host validates. UNKNOWN now means only an invalid object. Document the lazy-login transition on smm_asset_connection_get_state() and add a HOST_INVALID state test.

## Summary by Sourcery

Clarify connection state reporting by distinguishing new, valid connections from invalid objects.

New Features:
- Introduce SMM_CONNECTION_NEW state for freshly created connections to a valid host before any request is made.

Bug Fixes:
- Ensure SMM_CONNECTION_UNKNOWN is used only for invalid connection objects rather than also representing unauthenticated but valid connections.

Documentation:
- Document the lazy-login behavior and the transition from SMM_CONNECTION_NEW to other connection states in smm_asset_connection_get_state().

Tests:
- Update initial connection state test to expect the new SMM_CONNECTION_NEW status and add a test for invalid host connections reporting SMM_CONNECTION_HOST_INVALID.