### PR TITLE
fix: drop assets that lack a valid integer id

### DIFF
--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -383,13 +383,18 @@ smm_parse_assets (smm_connection connection, const char *data, size_t len, smm_a
                 json_t *val = NULL;
                 json_int_t asset_id = -1;
                 json_int_t asset_type_id = -1;
+                bool have_id = false;
                 const char *name = NULL;
                 const char *type = NULL;
                 json_object_foreach (value, key, val)
                 {
                     if (strcmp (key, "id") == 0)
                     {
-                        asset_id = json_integer_value (val);
+                        if (json_is_integer (val))
+                        {
+                            asset_id = json_integer_value (val);
+                            have_id = true;
+                        }
                     }
                     else if (strcmp (key, "type_id") == 0)
                     {
@@ -403,6 +408,15 @@ smm_parse_assets (smm_connection connection, const char *data, size_t len, smm_a
                     {
                         type = json_string_value (val);
                     }
+                }
+                /* The id is required: it is substituted into request URLs
+                 * (position reports, search lookups). Drop any asset that
+                 * lacks a valid integer id rather than issuing requests
+                 * against a sentinel id of -1. */
+                if (!have_id)
+                {
+                    DEBUG ("asset entry has no valid integer id; skipping\n");
+                    continue;
                 }
                 smm_asset new_asset = smm_asset_create (connection, name, type, asset_id, asset_type_id);
                 if (new_asset)

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -108,14 +108,46 @@ END_TEST
 
 START_TEST (test_assets_parsing_missing_id)
 {
+    /* An asset with no id cannot be addressed in request URLs, so it is
+     * dropped; the surrounding parse still succeeds. */
     const char *json = "{\"assets\": [{\"type_id\": 2, \"name\": \"Asset 1\", \"type_name\": \"Type 1\"}]}";
     smm_assets assets;
     size_t count;
     bool res = smm_parse_assets (NULL, json, strlen (json), &assets, &count);
 
     ck_assert_uint_eq (res, true);
+    ck_assert_uint_eq (count, 0);
+    ck_assert_ptr_null (assets);
+}
+END_TEST
+
+START_TEST (test_assets_parsing_noninteger_id)
+{
+    /* A non-integer id is treated the same as a missing id. */
+    const char *json = "{\"assets\": [{\"id\": \"oops\", \"type_id\": 2, \"name\": \"Asset 1\", \"type_name\": "
+                       "\"Type 1\"}]}";
+    smm_assets assets;
+    size_t count;
+    bool res = smm_parse_assets (NULL, json, strlen (json), &assets, &count);
+
+    ck_assert_uint_eq (res, true);
+    ck_assert_uint_eq (count, 0);
+    ck_assert_ptr_null (assets);
+}
+END_TEST
+
+START_TEST (test_assets_parsing_drops_only_invalid)
+{
+    /* A valid asset is kept even when another entry in the array lacks an id. */
+    const char *json = "{\"assets\": [{\"name\": \"No Id\"}, {\"id\": 7, \"type_id\": 2, \"name\": \"Good\", "
+                       "\"type_name\": \"Type 1\"}]}";
+    smm_assets assets;
+    size_t count;
+    bool res = smm_parse_assets (NULL, json, strlen (json), &assets, &count);
+
+    ck_assert_uint_eq (res, true);
     ck_assert_uint_eq (count, 1);
-    ck_assert_str_eq (smm_asset_name (assets[0]), "Asset 1");
+    ck_assert_str_eq (smm_asset_name (assets[0]), "Good");
     smm_asset_free_assets (assets, count);
 }
 END_TEST
@@ -1118,6 +1150,8 @@ smm_suite (void)
     tcase_add_test (tc_assets, test_assets_parsing_empty);
     tcase_add_test (tc_assets, test_assets_parsing_invalid);
     tcase_add_test (tc_assets, test_assets_parsing_missing_id);
+    tcase_add_test (tc_assets, test_assets_parsing_noninteger_id);
+    tcase_add_test (tc_assets, test_assets_parsing_drops_only_invalid);
     tcase_add_test (tc_assets, test_assets_parsing_missing_type_id);
     suite_add_tcase (s, tc_assets);
 


### PR DESCRIPTION
## Description

smm_parse_assets() created an smm_asset even when the server entry had no "id" (or a non-integer one), leaving asset_id at the sentinel -1. That id is later substituted straight into request URLs (position reports, search lookups), so a malformed entry would have produced requests against /data/assets/-1/.... Track a valid integer id per entry and skip any that lack one; the overall parse still succeeds and well-formed siblings are kept.

## Summary by Sourcery

Ensure asset parsing drops entries lacking a valid integer id while preserving valid siblings.

Bug Fixes:
- Prevent issuing requests using sentinel asset IDs by skipping assets without a valid integer id.

Tests:
- Add tests verifying assets without an id or with a non-integer id are dropped and that valid assets are still parsed.