### PR TITLE
fix: cap buffered response size in the curl write callback

### DIFF
--- a/src/smm-asset-curl.c
+++ b/src/smm-asset-curl.c
@@ -161,6 +161,13 @@ to_buffer (char *ptr, size_t size, size_t nmemb, void *userdata)
 {
     size_t new_bytes = size * nmemb;
     struct buffer_s *buf = (struct buffer_s *)userdata;
+    /* Refuse to grow the buffer past the cap. Returning a short count makes
+     * curl fail the transfer with CURLE_WRITE_ERROR. The comparison is written
+     * to avoid overflow in buf->bytes + new_bytes (+1 for the NUL). */
+    if (buf->bytes >= SMM_MAX_RESPONSE_BYTES || new_bytes > SMM_MAX_RESPONSE_BYTES - buf->bytes)
+    {
+        return 0;
+    }
     char *tmp = realloc (buf->data, buf->bytes + new_bytes + 1);
     if (tmp == NULL)
     {

--- a/src/smm-asset-internal.h
+++ b/src/smm-asset-internal.h
@@ -41,6 +41,13 @@ enum http_return_codes
 #define SMM_CURL_CONNECT_TIMEOUT_SECS 30L
 #define SMM_CURL_TRANSFER_TIMEOUT_SECS 60L
 
+/* Upper bound on a buffered response body. The endpoints this library talks
+ * to return small JSON/GeoJSON documents and a login HTML page, so this is a
+ * generous ceiling that protects against a hostile or broken server driving
+ * unbounded memory growth (and guards the buffer arithmetic against overflow).
+ */
+#define SMM_MAX_RESPONSE_BYTES ((size_t)8 * 1024 * 1024)
+
 extern _Atomic bool smm_debug;
 #define DEBUG(...)                                                                                                     \
     do                                                                                                                 \

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -621,6 +621,38 @@ END_TEST
 START_TEST (test_url_path_safe_null) { ck_assert_int_eq (smm_url_path_is_safe (NULL), false); }
 END_TEST
 
+START_TEST (test_to_buffer_accumulates)
+{
+    struct buffer_s buf = { NULL, 0 };
+    char chunk1[] = "abc";
+    char chunk2[] = "de";
+    ck_assert_uint_eq (to_buffer (chunk1, 1, 3, &buf), 3);
+    ck_assert_uint_eq (to_buffer (chunk2, 1, 2, &buf), 2);
+    ck_assert_uint_eq (buf.bytes, 5);
+    ck_assert_str_eq (buf.data, "abcde");
+    free (buf.data);
+}
+END_TEST
+
+START_TEST (test_to_buffer_rejects_oversized_chunk)
+{
+    /* A single chunk larger than the cap is refused without allocating. */
+    struct buffer_s buf = { NULL, 0 };
+    char chunk[] = "x";
+    ck_assert_uint_eq (to_buffer (chunk, 1, SMM_MAX_RESPONSE_BYTES + 1, &buf), 0);
+    ck_assert_ptr_null (buf.data);
+}
+END_TEST
+
+START_TEST (test_to_buffer_rejects_when_full)
+{
+    /* Once bytes have reached the cap, further writes are refused. */
+    struct buffer_s buf = { NULL, SMM_MAX_RESPONSE_BYTES };
+    char chunk[] = "x";
+    ck_assert_uint_eq (to_buffer (chunk, 1, 1, &buf), 0);
+}
+END_TEST
+
 START_TEST (test_content_type_is_json_plain) { ck_assert_int_eq (smm_content_type_is_json ("application/json"), true); }
 END_TEST
 
@@ -1208,6 +1240,12 @@ smm_suite (void)
     tcase_add_test (tc_url, test_url_path_safe_absolute);
     tcase_add_test (tc_url, test_url_path_safe_null);
     suite_add_tcase (s, tc_url);
+
+    TCase *tc_buffer = tcase_create ("Buffer");
+    tcase_add_test (tc_buffer, test_to_buffer_accumulates);
+    tcase_add_test (tc_buffer, test_to_buffer_rejects_oversized_chunk);
+    tcase_add_test (tc_buffer, test_to_buffer_rejects_when_full);
+    suite_add_tcase (s, tc_buffer);
 
     TCase *tc_content_type = tcase_create ("ContentType");
     tcase_add_test (tc_content_type, test_content_type_is_json_plain);


### PR DESCRIPTION
## Description

to_buffer() grew its heap buffer by realloc on every chunk with no upper bound, so a hostile or broken server could drive unbounded memory growth, and buf->bytes + new_bytes + 1 could in principle overflow size_t. Add an 8 MiB ceiling (the endpoints return small JSON/HTML) and refuse further data past it by returning a short count, which makes curl abort the transfer with CURLE_WRITE_ERROR. The overflow-safe comparison also guarantees the subsequent addition cannot wrap.

## Summary by Sourcery

Cap buffered HTTP response bodies and add tests for the curl write callback.

Bug Fixes:
- Prevent unbounded memory growth and potential size overflows in the curl response buffer by enforcing a maximum response size.

Enhancements:
- Introduce a configurable upper limit for buffered response bodies to guard against hostile or malfunctioning servers.

Tests:
- Add unit tests covering normal accumulation into the buffer and rejection of oversized or excess chunks once the cap is reached.