### PR TITLE
fix: bound recursion when searching the login page for the CSRF token

### DIFF
--- a/src/smm-asset-curl.c
+++ b/src/smm-asset-curl.c
@@ -360,10 +360,20 @@ populate_tidy (char *ptr, size_t size, size_t nmemb, void *userdata)
     return size * nmemb;
 }
 
+/* Bound on how deeply extract_csrfmiddlewaretoken recurses into the parsed
+ * login page. A login form is shallow; this only exists so a pathologically
+ * nested (hostile) document cannot exhaust the stack. */
+#define SMM_CSRF_MAX_DEPTH 256
+
 static bool
-extract_csrfmiddlewaretoken (TidyDoc tdoc, TidyNode tnod, char **token)
+extract_csrfmiddlewaretoken (TidyDoc tdoc, TidyNode tnod, char **token, int depth)
 {
     bool res = false;
+    if (depth >= SMM_CSRF_MAX_DEPTH)
+    {
+        DEBUG ("CSRF search exceeded max depth %i; stopping descent\n", SMM_CSRF_MAX_DEPTH);
+        return false;
+    }
     for (TidyNode child = tidyGetChild (tnod); child; child = tidyGetNext (child))
     {
         ctmbstr name = tidyNodeGetName (child);
@@ -434,7 +444,7 @@ extract_csrfmiddlewaretoken (TidyDoc tdoc, TidyNode tnod, char **token)
                 }
             }
         }
-        res = extract_csrfmiddlewaretoken (tdoc, child, token);
+        res = extract_csrfmiddlewaretoken (tdoc, child, token, depth + 1);
         if (res)
         {
             return res;
@@ -471,7 +481,7 @@ smm_parse_csrf_token (const char *data, size_t len)
     if (tidyParseBuffer (tdoc, &docbuf) >= 0)
     {
         tidyCleanAndRepair (tdoc);
-        extract_csrfmiddlewaretoken (tdoc, tidyGetRoot (tdoc), &token);
+        extract_csrfmiddlewaretoken (tdoc, tidyGetRoot (tdoc), &token, 0);
     }
 
     tidyBufFree (&docbuf);

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -48,6 +48,34 @@ START_TEST (test_csrf_extraction_too_long)
 }
 END_TEST
 
+START_TEST (test_csrf_extraction_deeply_nested)
+{
+    /* Bury the token far below the recursion cap inside deeply nested
+     * elements. The walker must stop descending without overflowing the
+     * stack; the token, being out of reach, is simply not returned. */
+    const size_t depth = 600;
+    const char open[] = "<div>";
+    const char close[] = "</div>";
+    const char input[] = "<input type=\"hidden\" name=\"csrfmiddlewaretoken\" value=\"deep\">";
+    size_t cap = depth * (sizeof (open) - 1 + sizeof (close) - 1) + sizeof (input) + 64;
+    char *html = malloc (cap);
+    ck_assert_ptr_nonnull (html);
+
+    size_t pos = 0;
+    for (size_t i = 0; i < depth; i++)
+        pos += (size_t)snprintf (html + pos, cap - pos, "%s", open);
+    pos += (size_t)snprintf (html + pos, cap - pos, "%s", input);
+    for (size_t i = 0; i < depth; i++)
+        pos += (size_t)snprintf (html + pos, cap - pos, "%s", close);
+
+    char *token = smm_parse_csrf_token (html, strlen (html));
+    ck_assert_ptr_null (token);
+
+    free (token);
+    free (html);
+}
+END_TEST
+
 START_TEST (test_assets_parsing)
 {
     const char *json = "{\"assets\": [{\"id\": 1, \"type_id\": 2, \"name\": \"Asset 1\", \"type_name\": \"Type "
@@ -1175,6 +1203,7 @@ smm_suite (void)
     tcase_add_test (tc_csrf, test_csrf_extraction_missing);
     tcase_add_test (tc_csrf, test_csrf_extraction_invalid_chars);
     tcase_add_test (tc_csrf, test_csrf_extraction_too_long);
+    tcase_add_test (tc_csrf, test_csrf_extraction_deeply_nested);
     suite_add_tcase (s, tc_csrf);
 
     TCase *tc_assets = tcase_create ("Assets");


### PR DESCRIPTION
## Description

extract_csrfmiddlewaretoken() recursed once per DOM level with no limit, so a pathologically nested login page from a hostile or broken server could exhaust the stack. Thread a depth counter and stop descending at SMM_CSRF_MAX_DEPTH (256); a real Django login form sits around depth 10, so this only ever trips on adversarial input. Sibling scanning at each level is unaffected.

## Summary by Sourcery

Limit CSRF token extraction recursion depth to avoid stack exhaustion on pathologically nested login pages.

Bug Fixes:
- Prevent stack exhaustion by capping recursion depth when traversing the login page DOM for the CSRF token.

Tests:
- Add a regression test verifying that deeply nested CSRF tokens beyond the recursion cap are not returned and do not cause stack overflow.