### PR TITLE
fix: validate asset type_id as an integer like id

### DIFF
--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -398,7 +398,14 @@ smm_parse_assets (smm_connection connection, const char *data, size_t len, smm_a
                     }
                     else if (strcmp (key, "type_id") == 0)
                     {
-                        asset_type_id = json_integer_value (val);
+                        /* Validate as an integer, consistent with "id", so a
+                         * non-integer value is left as the -1 sentinel rather
+                         * than silently coerced to 0. type_id is optional, so
+                         * an absent or malformed one does not drop the asset. */
+                        if (json_is_integer (val))
+                        {
+                            asset_type_id = json_integer_value (val);
+                        }
                     }
                     else if (strcmp (key, "name") == 0)
                     {

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -164,6 +164,23 @@ START_TEST (test_assets_parsing_noninteger_id)
 }
 END_TEST
 
+START_TEST (test_assets_parsing_noninteger_type_id)
+{
+    /* type_id is optional; a non-integer value is tolerated (left at the
+     * sentinel) and does not drop an otherwise valid asset. */
+    const char *json = "{\"assets\": [{\"id\": 1, \"type_id\": \"oops\", \"name\": \"Asset 1\", \"type_name\": "
+                       "\"Type 1\"}]}";
+    smm_assets assets;
+    size_t count;
+    bool res = smm_parse_assets (NULL, json, strlen (json), &assets, &count);
+
+    ck_assert_uint_eq (res, true);
+    ck_assert_uint_eq (count, 1);
+    ck_assert_str_eq (smm_asset_name (assets[0]), "Asset 1");
+    smm_asset_free_assets (assets, count);
+}
+END_TEST
+
 START_TEST (test_assets_parsing_drops_only_invalid)
 {
     /* A valid asset is kept even when another entry in the array lacks an id. */
@@ -1212,6 +1229,7 @@ smm_suite (void)
     tcase_add_test (tc_assets, test_assets_parsing_invalid);
     tcase_add_test (tc_assets, test_assets_parsing_missing_id);
     tcase_add_test (tc_assets, test_assets_parsing_noninteger_id);
+    tcase_add_test (tc_assets, test_assets_parsing_noninteger_type_id);
     tcase_add_test (tc_assets, test_assets_parsing_drops_only_invalid);
     tcase_add_test (tc_assets, test_assets_parsing_missing_type_id);
     suite_add_tcase (s, tc_assets);


### PR DESCRIPTION
## Description

Sourcery (PR #69) noted that after id gained a json_is_integer() guard, type_id still called json_integer_value() directly, silently coercing a non-integer value to 0. type_id is optional, so guard the assignment and leave the -1 sentinel in place for malformed values rather than dropping the asset.

## Summary by Sourcery

Guard asset type_id parsing against non-integer JSON values to align with id handling and keep otherwise valid assets.

Bug Fixes:
- Prevent non-integer type_id values from being silently coerced to 0 by leaving the sentinel value and preserving the asset.

Tests:
- Add regression test ensuring assets with non-integer type_id are accepted and retain their other fields.