### PR TITLE
fix: stop smm_ascii_caseeq at a NUL on either side

### DIFF
--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -696,6 +696,11 @@ smm_ascii_caseeq (const char *a, const char *b, size_t n)
     {
         unsigned char ca = (unsigned char)a[i];
         unsigned char cb = (unsigned char)b[i];
+        /* Stop at a terminator on either side. A shorter string mismatches
+         * (and the comparison stays in-bounds) without relying on the
+         * argument that b never contains an embedded NUL. */
+        if (ca == '\0' || cb == '\0')
+            return false;
         if (ca >= 'A' && ca <= 'Z')
             ca = (unsigned char)(ca + ('a' - 'A'));
         if (cb >= 'A' && cb <= 'Z')


### PR DESCRIPTION
## Description

Sourcery (PR #66) flagged smm_ascii_caseeq as potentially reading past a shorter string. The existing code was in fact safe — "application/json" has no embedded NUL, so a short content_type mismatches at its terminator before any out-of-bounds read — but make that explicit with a NUL check rather than leaning on that subtle argument, which also protects any future caller that passes two short strings.

## Summary by Sourcery

Bug Fixes:
- Prevent potential out-of-bounds reads in smm_ascii_caseeq by stopping comparison when either input hits a NUL terminator.