### PR TITLE
fix: fail instead of formatting URLs in the caller's locale

### DIFF
--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -75,6 +75,13 @@ smm_asprintf_c_locale (char **strp, const char *fmt, ...)
         return -1;
     }
 
+    /* POSIX: uselocale() returns the previous locale on success, or
+     * (locale_t)0 on error. The previous locale is never (locale_t)0 — on a
+     * thread that has not set a per-thread locale it is LC_GLOBAL_LOCALE
+     * ((locale_t)-1), which is a *success* value we must restore below. So the
+     * error test is == 0; do NOT change it to == -1 (that would treat the
+     * common fresh-thread case as a failure and leave the thread in the C
+     * locale). */
     locale_t old_locale = uselocale (c_locale);
     if (old_locale == (locale_t)0)
     {

--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -58,24 +58,35 @@ smm_c_locale_get (void)
 
 /* asprintf() that formats in the private "C" locale (see above), so coordinate
  * conversions use '.' as the decimal separator regardless of the caller's
- * LC_NUMERIC. Returns the asprintf() result; *strp is undefined on failure. */
+ * LC_NUMERIC. Returns the asprintf() result; *strp is undefined on failure.
+ *
+ * If the private "C" locale is unavailable or cannot be installed, the
+ * function fails (returns < 0) rather than formatting in the caller's locale:
+ * emitting a corrupted coordinate such as "lat=-43,5" would be worse than
+ * failing the request outright. */
 static int smm_asprintf_c_locale (char **strp, const char *fmt, ...) __attribute__ ((format (printf, 2, 3)));
 
 static int
 smm_asprintf_c_locale (char **strp, const char *fmt, ...)
 {
     locale_t c_locale = smm_c_locale_get ();
-    locale_t old_locale = (c_locale != (locale_t)0) ? uselocale (c_locale) : (locale_t)0;
+    if (c_locale == (locale_t)0)
+    {
+        return -1;
+    }
+
+    locale_t old_locale = uselocale (c_locale);
+    if (old_locale == (locale_t)0)
+    {
+        return -1;
+    }
 
     va_list ap;
     va_start (ap, fmt);
     int n = vasprintf (strp, fmt, ap);
     va_end (ap);
 
-    if (old_locale != (locale_t)0)
-    {
-        uselocale (old_locale);
-    }
+    uselocale (old_locale);
     return n;
 }
 


### PR DESCRIPTION
## Description

Sourcery (PR #60) noted that if newlocale() fails, smm_c_locale_get() returns NULL and smm_asprintf_c_locale() silently fell back to formatting in the caller's LC_NUMERIC, reintroducing the very decimal-separator bug the helper exists to prevent (and pthread_once means it never retries). Treat an unavailable or un-installable "C" locale as a hard failure (return < 0) so the position/search URL build fails cleanly rather than emitting a corrupted coordinate like "lat=-43,5".

## Summary by Sourcery

Bug Fixes:
- Prevent position/search URL construction from emitting locale-corrupted coordinates by treating missing or failing C locale setup as a hard error.