### PR TITLE
feat: expose smm_asset_connection_login() for eager authentication

### DIFF
--- a/src/libsmmasset.sym
+++ b/src/libsmmasset.sym
@@ -1,5 +1,6 @@
 smm_asset_connect
 smm_asset_connection_get_state
+smm_asset_connection_login
 smm_asset_connection_tls_verify_set
 smm_asset_debugging_set
 smm_asset_free_assets

--- a/src/smm-asset-curl.c
+++ b/src/smm-asset-curl.c
@@ -499,6 +499,11 @@ smm_asset_connection_login (smm_connection connection)
     char *csrf_token = NULL;
     smm_connection_status new_state = SMM_CONNECTION_FAILURE;
 
+    if (connection == NULL)
+    {
+        return false;
+    }
+
     /* Serialise concurrent login attempts. If another thread is already
      * logging in, wait for it to finish. When it does, if the connection is
      * now CONNECTED, return success without making another login attempt. */

--- a/src/smm-asset-internal.h
+++ b/src/smm-asset-internal.h
@@ -137,7 +137,7 @@ struct smm_curl_res_s *smm_connection_curl_retrieve_url (smm_connection conn, co
                                                          size_t (*write_func) (char *ptr, size_t size, size_t nmemb,
                                                                                void *userdata),
                                                          void *write_data, bool json);
-bool smm_asset_connection_login (smm_connection connection);
+/* smm_asset_connection_login is declared in the public header smm-asset.h */
 char *smm_parse_csrf_token (const char *data, size_t len);
 bool smm_parse_assets (smm_connection connection, const char *data, size_t len, smm_assets *assets,
                        size_t *assets_count);

--- a/src/smm-asset.h
+++ b/src/smm-asset.h
@@ -159,6 +159,12 @@ void smm_asset_debugging_set (bool debug);
 /**
  * Connect to the specified smm
  *
+ * This only validates the host and allocates the connection object; it does
+ * not authenticate. Authentication happens lazily on the first request, so the
+ * returned object reports SMM_CONNECTION_NEW (not SMM_CONNECTION_CONNECTED)
+ * until then. To establish the session up front and check the result, call
+ * @ref smm_asset_connection_login.
+ *
  * @param host the URI of the smm server (i.e. https://smm.example.com)
  * @param user the username to authenticate as
  * @param pass the password to authenticate with
@@ -172,13 +178,33 @@ smm_connection smm_asset_connect (const char *host, const char *user, const char
  *
  * Authentication is performed lazily on the first request, so a freshly
  * connected object with a valid host reports SMM_CONNECTION_NEW until a
- * request transitions it to SMM_CONNECTION_CONNECTED (or an error state).
+ * request (or an explicit @ref smm_asset_connection_login) transitions it to
+ * SMM_CONNECTION_CONNECTED (or an error state). Do not gate the first request
+ * on this returning SMM_CONNECTION_CONNECTED; either call
+ * smm_asset_connection_login() first, or simply check the result of the
+ * request itself (e.g. @ref smm_asset_get_assets).
  *
  * @param connection the smm_connection object to check
  *
  * @return The current state of the connection
  */
 smm_connection_status smm_asset_connection_get_state (smm_connection connection);
+
+/**
+ * Authenticate the connection now, rather than waiting for the first request
+ * to trigger login lazily.
+ *
+ * On success the connection transitions to SMM_CONNECTION_CONNECTED; on
+ * failure it reflects the relevant error state (see @ref
+ * smm_asset_connection_get_state and @ref smm_connection_get_last_error).
+ * Calling it when already connected is a cheap no-op. Concurrent calls on the
+ * same connection are serialised internally.
+ *
+ * @param connection the smm_connection object to authenticate
+ *
+ * @return true if the connection is authenticated, false otherwise
+ */
+bool smm_asset_connection_login (smm_connection connection);
 
 /**
  * Enable/disable TLS verification for a connection.

--- a/src/smm-asset.h
+++ b/src/smm-asset.h
@@ -197,10 +197,18 @@ smm_connection_status smm_asset_connection_get_state (smm_connection connection)
  * On success the connection transitions to SMM_CONNECTION_CONNECTED; on
  * failure it reflects the relevant error state (see @ref
  * smm_asset_connection_get_state and @ref smm_connection_get_last_error).
- * Calling it when already connected is a cheap no-op. Concurrent calls on the
- * same connection are serialised internally.
+ * Concurrent calls on the same connection are serialised internally.
  *
- * @param connection the smm_connection object to authenticate
+ * Calling it on an already-connected connection is a cheap no-op that returns
+ * true. Any other state — including a connection that previously failed to
+ * authenticate (e.g. bad credentials) — causes a fresh login attempt, which
+ * updates the connection's state and last error accordingly; it is not a
+ * no-op, so a repeatedly-failing call will keep re-contacting the server.
+ *
+ * Passing a NULL @a connection is allowed: the call returns false immediately
+ * with no side effects (no state is changed and no last error is recorded).
+ *
+ * @param connection the smm_connection object to authenticate, or NULL
  *
  * @return true if the connection is authenticated, false otherwise
  */

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -1139,6 +1139,9 @@ START_TEST (test_get_state_null_connection)
 }
 END_TEST
 
+START_TEST (test_connection_login_null) { ck_assert_int_eq (smm_asset_connection_login (NULL), false); }
+END_TEST
+
 START_TEST (test_get_state_initial)
 {
     smm_connection conn = smm_asset_connect ("http://localhost/", "user", "pass");
@@ -1194,6 +1197,7 @@ smm_suite (void)
     tcase_add_test (tc_conn, test_report_position_sets_asset_error_not_conn);
     tcase_add_test (tc_conn, test_search_action_sets_search_error_not_conn);
     tcase_add_test (tc_conn, test_get_state_null_connection);
+    tcase_add_test (tc_conn, test_connection_login_null);
     tcase_add_test (tc_conn, test_get_state_initial);
     tcase_add_test (tc_conn, test_get_state_invalid_host);
     tcase_add_test (tc_conn, test_debugging_set);


### PR DESCRIPTION
## Description

Login is performed lazily on the first request, so after smm_asset_connect() the state is SMM_CONNECTION_NEW and never SMM_CONNECTION_CONNECTED. A caller that naturally gates its first request on get_state() == CONNECTED would therefore never proceed.

Promote the existing internal login routine to the public API so callers can authenticate up front and then check the state (or last error). Add a NULL guard now that it is public, document the lazy-vs-eager behaviour on connect() and get_state(), and export the symbol.

## Summary by Sourcery

Expose explicit connection login in the public API and document lazy vs eager authentication behaviour.

New Features:
- Add public smm_asset_connection_login() API to authenticate a connection eagerly.

Bug Fixes:
- Ensure smm_asset_connection_login() safely handles NULL connections by returning false.

Enhancements:
- Clarify documentation for smm_asset_connect() and smm_asset_connection_get_state() regarding lazy authentication and connection state transitions.
- Export the login symbol and move its declaration from internal to public headers.

Tests:
- Add a unit test verifying smm_asset_connection_login(NULL) returns false.