### PR TITLE
fix: accept signed altitude in position reports

### DIFF
--- a/src/smm-asset-internal.h
+++ b/src/smm-asset-internal.h
@@ -148,8 +148,7 @@ smm_asset smm_asset_create (smm_connection connection, const char *name, const c
                             long long asset_type_id);
 void smm_asset_free_asset (smm_asset assets);
 
-char *smm_asset_build_position_url (long long asset_id, double lat, double lon, unsigned int alt, uint16_t heading,
-                                    uint8_t fix);
+char *smm_asset_build_position_url (long long asset_id, double lat, double lon, int alt, uint16_t heading, uint8_t fix);
 
 void smm_asset_set_command_from_plaintext (smm_asset asset, const char *data, size_t len);
 

--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -771,11 +771,10 @@ smm_url_path_is_safe (const char *url)
 }
 
 char *
-smm_asset_build_position_url (long long asset_id, double lat, double lon, unsigned int alt, uint16_t heading,
-                              uint8_t fix)
+smm_asset_build_position_url (long long asset_id, double lat, double lon, int alt, uint16_t heading, uint8_t fix)
 {
     char *page = NULL;
-    if (smm_asprintf_c_locale (&page, "/data/assets/%lld/position/add/?lat=%lf&lon=%lf&alt=%u&heading=%u&fix=%u",
+    if (smm_asprintf_c_locale (&page, "/data/assets/%lld/position/add/?lat=%lf&lon=%lf&alt=%d&heading=%u&fix=%u",
                                asset_id, lat, lon, alt, heading, fix)
         < 0)
     {
@@ -785,7 +784,7 @@ smm_asset_build_position_url (long long asset_id, double lat, double lon, unsign
 }
 
 bool
-smm_asset_report_position (smm_asset asset, double latitude, double longitude, unsigned int altitude, uint16_t heading,
+smm_asset_report_position (smm_asset asset, double latitude, double longitude, int altitude, uint16_t heading,
                            uint8_t fix)
 {
     if (!asset)

--- a/src/smm-asset.h
+++ b/src/smm-asset.h
@@ -277,14 +277,15 @@ const char *smm_asset_type (smm_asset asset);
  * @param asset the Asset
  * @param latitude The current latitude in degrees
  * @param longitude The current longitude in degrees
- * @param altitude The current altitude in meters
+ * @param altitude The current altitude in metres (may be negative, e.g. below
+ *                 mean sea level)
  * @param heading the current course over ground in degrees true
  * @param fix the accurancy of the current fix (0=unknown, 2=2d only, 3 = 3d fix)
  *
  * @return true if the position was reported to the server
  */
-bool smm_asset_report_position (smm_asset asset, double latitude, double longitude, unsigned int altitude,
-                                uint16_t heading, uint8_t fix);
+bool smm_asset_report_position (smm_asset asset, double latitude, double longitude, int altitude, uint16_t heading,
+                                uint8_t fix);
 
 /**
  * Get the last command we saw from the server

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -1084,6 +1084,17 @@ START_TEST (test_build_position_url_values)
 }
 END_TEST
 
+START_TEST (test_build_position_url_negative_altitude)
+{
+    /* Altitude may be below mean sea level; it must be sent as a signed value,
+     * not wrapped through an unsigned conversion. */
+    char *url = smm_asset_build_position_url (7, -43.5, 172.6, -12, 270, 3);
+    ck_assert_ptr_nonnull (url);
+    ck_assert_ptr_nonnull (strstr (url, "alt=-12"));
+    free (url);
+}
+END_TEST
+
 START_TEST (test_build_position_url_heading_boundary)
 {
     char *url0 = smm_asset_build_position_url (1, 0.0, 0.0, 0, 0, 0);
@@ -1308,6 +1319,7 @@ smm_suite (void)
 
     TCase *tc_position_ext = tcase_create ("PositionExt");
     tcase_add_test (tc_position_ext, test_build_position_url_values);
+    tcase_add_test (tc_position_ext, test_build_position_url_negative_altitude);
     tcase_add_test (tc_position_ext, test_build_position_url_heading_boundary);
     tcase_add_test (tc_position_ext, test_asset_last_goto_pos_not_goto);
     tcase_add_test (tc_position_ext, test_asset_last_goto_pos_goto);


### PR DESCRIPTION
## Description

smm_asset_report_position() (and the internal URL builder) took altitude as unsigned int and formatted it with %u. Real altitudes can be negative — below mean sea level, or GPS noise crossing zero before a solid fix — and the asset side sources it from a signed value. Passing a negative altitude through the unsigned parameter was undefined behaviour and would have reported a bogus ~4.29e9 m. Take altitude as int and format with %d.

This is an API/ABI change to an as-yet-unreleased 1.0.0.

## Summary by Sourcery

Allow signed altitudes in asset position reporting and URL generation to avoid incorrect values for below-sea-level or slightly negative readings.

Bug Fixes:
- Fix altitude handling in position report URLs to prevent unsigned wrapping of negative altitudes into large positive values.

Enhancements:
- Change public and internal position reporting APIs to use signed altitude parameters and update formatting accordingly.

Tests:
- Add a regression test verifying that negative altitudes are correctly encoded in position URLs.