### PR TITLE
fix: discard redirect bodies between retry attempts

### DIFF
--- a/src/smm-asset-curl.c
+++ b/src/smm-asset-curl.c
@@ -181,6 +181,17 @@ to_buffer (char *ptr, size_t size, size_t nmemb, void *userdata)
     return new_bytes;
 }
 
+void
+smm_buffer_reset (struct buffer_s *buf)
+{
+    if (buf)
+    {
+        free (buf->data);
+        buf->data = NULL;
+        buf->bytes = 0;
+    }
+}
+
 struct smm_curl_res_s *
 smm_connection_curl_retrieve_url_r (smm_connection conn, const char *path, const char *post_data,
                                     size_t (*write_func) (char *ptr, size_t size, size_t nmemb, void *userdata),
@@ -645,14 +656,13 @@ smm_https_upgrade_is_same_host (const char *http_host, const char *https_redirec
 }
 
 struct smm_curl_res_s *
-smm_connection_curl_retrieve_url (smm_connection conn, const char *path, const char *post_data,
-                                  size_t (*write_func) (char *ptr, size_t size, size_t nmemb, void *userdata),
-                                  void *write_data, bool json)
+smm_connection_curl_retrieve_url (smm_connection conn, const char *path, const char *post_data, struct buffer_s *buf,
+                                  bool json)
 {
     bool retry = true;
     int retries = 0;
     struct smm_curl_res_s *res
-        = smm_connection_curl_retrieve_url_r (conn, path, post_data, write_func, write_data, json);
+        = smm_connection_curl_retrieve_url_r (conn, path, post_data, buf ? to_buffer : NULL, buf, json);
 
     while (retry && retries < 3 && res != NULL)
     {
@@ -698,7 +708,11 @@ smm_connection_curl_retrieve_url (smm_connection conn, const char *path, const c
         if (retry && retries < 3)
         {
             smm_curl_res_free (res);
-            res = smm_connection_curl_retrieve_url_r (conn, path, post_data, write_func, write_data, json);
+            /* Discard anything buffered from the redirect response itself
+             * (proxies often attach an HTML body to a 301/302); otherwise it
+             * would be prepended to the body of the retried request. */
+            smm_buffer_reset (buf);
+            res = smm_connection_curl_retrieve_url_r (conn, path, post_data, buf ? to_buffer : NULL, buf, json);
         }
     }
 

--- a/src/smm-asset-internal.h
+++ b/src/smm-asset-internal.h
@@ -116,6 +116,9 @@ struct buffer_s
 };
 
 size_t to_buffer (char *ptr, size_t size, size_t nmemb, void *userdata);
+/* Free any accumulated data and return the buffer to its empty state.
+ * Safe to call on a NULL buffer or one that never received data. */
+void smm_buffer_reset (struct buffer_s *buf);
 
 bool smm_connection_share_init (smm_connection conn);
 void smm_connection_share_destroy (smm_connection conn);
@@ -133,10 +136,12 @@ struct smm_curl_res_s *smm_connection_curl_retrieve_url_r (smm_connection conn, 
                                                            size_t (*write_func) (char *ptr, size_t size, size_t nmemb,
                                                                                  void *userdata),
                                                            void *write_data, bool json);
+/* Retrying fetch: follows the same-host HTTPS upgrade and the login redirect
+ * (up to 3 attempts). The response body is accumulated into buf (which is
+ * reset between attempts so redirect bodies are discarded); pass NULL to
+ * discard the body entirely. */
 struct smm_curl_res_s *smm_connection_curl_retrieve_url (smm_connection conn, const char *path, const char *post_data,
-                                                         size_t (*write_func) (char *ptr, size_t size, size_t nmemb,
-                                                                               void *userdata),
-                                                         void *write_data, bool json);
+                                                         struct buffer_s *buf, bool json);
 /* smm_asset_connection_login is declared in the public header smm-asset.h */
 char *smm_parse_csrf_token (const char *data, size_t len);
 bool smm_parse_assets (smm_connection connection, const char *data, size_t len, smm_assets *assets,

--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -494,7 +494,7 @@ smm_asset_get_assets (smm_connection connection, smm_assets *assets, size_t *ass
     *assets_count = 0;
     smm_connection_clear_error (connection);
 
-    struct smm_curl_res_s *res = smm_connection_curl_retrieve_url (connection, "/assets/", NULL, to_buffer, &buf, true);
+    struct smm_curl_res_s *res = smm_connection_curl_retrieve_url (connection, "/assets/", NULL, &buf, true);
     if (res == NULL)
     {
         smm_connection_set_error (connection, SMM_ERROR_NETWORK, "network failure fetching /assets/");
@@ -800,7 +800,7 @@ smm_asset_report_position (smm_asset asset, double latitude, double longitude, i
     }
     smm_asset_clear_error (asset);
 
-    struct smm_curl_res_s *res = smm_connection_curl_retrieve_url (asset->conn, page, NULL, to_buffer, &buf, false);
+    struct smm_curl_res_s *res = smm_connection_curl_retrieve_url (asset->conn, page, NULL, &buf, false);
     if (res == NULL)
     {
         smm_asset_set_error (asset, SMM_ERROR_NETWORK, "network failure reporting position");
@@ -1031,8 +1031,7 @@ smm_search_get_waypoints (smm_search search, smm_waypoints *waypoints, size_t *w
     *waypoints_count = 0;
     smm_search_clear_error (search);
 
-    struct smm_curl_res_s *res
-        = smm_connection_curl_retrieve_url (search->conn, search->url, NULL, to_buffer, &buf, true);
+    struct smm_curl_res_s *res = smm_connection_curl_retrieve_url (search->conn, search->url, NULL, &buf, true);
 
     if (res == NULL)
     {
@@ -1075,8 +1074,7 @@ smm_search_action (smm_search search, const char *action)
     }
     smm_search_clear_error (search);
 
-    struct smm_curl_res_s *res
-        = smm_connection_curl_retrieve_url (search->conn, action_page, NULL, to_buffer, &buf, false);
+    struct smm_curl_res_s *res = smm_connection_curl_retrieve_url (search->conn, action_page, NULL, &buf, false);
     if (res == NULL)
     {
         smm_search_set_error (search, SMM_ERROR_NETWORK, "network failure sending %s action", action);
@@ -1208,7 +1206,7 @@ smm_asset_get_search (smm_asset asset, double latitude, double longitude)
     }
     smm_asset_clear_error (asset);
 
-    struct smm_curl_res_s *res = smm_connection_curl_retrieve_url (asset->conn, page, NULL, to_buffer, &buf, false);
+    struct smm_curl_res_s *res = smm_connection_curl_retrieve_url (asset->conn, page, NULL, &buf, false);
     if (res == NULL)
     {
         smm_asset_set_error (asset, SMM_ERROR_NETWORK, "network failure fetching closest search");

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -698,6 +698,33 @@ START_TEST (test_to_buffer_rejects_when_full)
 }
 END_TEST
 
+START_TEST (test_buffer_reset_discards_content)
+{
+    /* The retry loop resets the buffer between attempts so a redirect body
+     * is not prepended to the body of the retried request. After a reset the
+     * buffer must accumulate only the new content. */
+    struct buffer_s buf = { NULL, 0 };
+    char redirect_body[] = "<html>301 Moved Permanently</html>";
+    char real_body[] = "{\"assets\": []}";
+    ck_assert_uint_eq (to_buffer (redirect_body, 1, sizeof (redirect_body) - 1, &buf), sizeof (redirect_body) - 1);
+    smm_buffer_reset (&buf);
+    ck_assert_ptr_null (buf.data);
+    ck_assert_uint_eq (buf.bytes, 0);
+    ck_assert_uint_eq (to_buffer (real_body, 1, sizeof (real_body) - 1, &buf), sizeof (real_body) - 1);
+    ck_assert_str_eq (buf.data, "{\"assets\": []}");
+    free (buf.data);
+}
+END_TEST
+
+START_TEST (test_buffer_reset_null_safe)
+{
+    struct buffer_s buf = { NULL, 0 };
+    smm_buffer_reset (&buf); /* empty buffer */
+    ck_assert_ptr_null (buf.data);
+    smm_buffer_reset (NULL); /* must not crash */
+}
+END_TEST
+
 START_TEST (test_content_type_is_json_plain) { ck_assert_int_eq (smm_content_type_is_json ("application/json"), true); }
 END_TEST
 
@@ -1307,6 +1334,8 @@ smm_suite (void)
     tcase_add_test (tc_buffer, test_to_buffer_accumulates);
     tcase_add_test (tc_buffer, test_to_buffer_rejects_oversized_chunk);
     tcase_add_test (tc_buffer, test_to_buffer_rejects_when_full);
+    tcase_add_test (tc_buffer, test_buffer_reset_discards_content);
+    tcase_add_test (tc_buffer, test_buffer_reset_null_safe);
     suite_add_tcase (s, tc_buffer);
 
     TCase *tc_content_type = tcase_create ("ContentType");


### PR DESCRIPTION
## Description

The retrying fetch wrapper followed redirects (same-host https upgrade, login) with CURLOPT_FOLLOWLOCATION off, so the body of the redirect response itself was delivered to the write callback and accumulated into the same buffer as the retried request's body. Proxies commonly attach an HTML body to a 301/302 (e.g. nginx), so the https-upgrade path could yield "<html>301 ...</html>{...json...}" and fail the parse.

Every caller of the wrapper passed to_buffer with a struct buffer_s, so take the buffer directly and reset it between attempts; pass NULL to discard the body. The raw single-shot fetch keeps the generic callback for login's tidy buffer.

## Summary by Sourcery

Ensure the retrying CURL fetch discards redirect response bodies between attempts by managing its own response buffer and resetting it on each retry.

Bug Fixes:
- Prevent redirect response bodies from being prepended to retried request bodies in the retrying CURL fetch wrapper, avoiding malformed payloads from HTTPS upgrades or login redirects.

Enhancements:
- Introduce a reusable buffer reset helper that safely frees and clears response buffers and is tolerant of NULL or empty buffers.
- Simplify the CURL retry helper API so it directly manages a response buffer instead of relying on caller-provided write callbacks.

Tests:
- Add tests verifying that buffer reset discards previous content and correctly accumulates only new response data.
- Add a test ensuring the buffer reset helper is safe to call on NULL and already-empty buffers.