### PR TITLE
fix: make the pkg-config file usable from non-default prefixes

### DIFF
--- a/src/smm-asset.pc.in
+++ b/src/smm-asset.pc.in
@@ -7,5 +7,6 @@ Name: @PACKAGE_NAME@
 Description: Library to act as an Asset for Search Management Map
 URL: https://github.com/canterbury-air-patrol/smm-asset-api
 Version: @VERSION@
-Libs: -lsmmasset
+Requires.private: libcurl jansson tidy
+Libs: -L${libdir} -lsmmasset
 Cflags: -I${includedir}


### PR DESCRIPTION
## Description

Libs lacked -L${libdir}, so `pkg-config --libs smm-asset` produced an unlinkable result for any install prefix outside the default linker path. Also declare the internal dependencies via Requires.private; with shared-only builds this only contributes their Cflags, but it is the correct form should static builds ever be enabled.

## Summary by Sourcery

Ensure the smm-asset pkg-config file correctly exposes linker and dependency information for non-default installation prefixes.

Bug Fixes:
- Add the library directory to the Libs field so pkg-config --libs smm-asset works when installed outside default linker paths.
- Declare internal dependencies in Requires.private to expose their flags correctly and future-proof potential static builds.