### PR TITLE
fix: follow the same-host https upgrade during eager login

### DIFF
--- a/src/smm-asset-curl.c
+++ b/src/smm-asset-curl.c
@@ -511,7 +511,11 @@ smm_connection_try_https_upgrade (smm_connection conn, const char *redirect_url)
         return false;
     }
     pthread_mutex_lock (&conn->lock);
-    if (smm_https_upgrade_is_same_host (conn->host, redirect_url))
+    /* smm_https_upgrade_is_same_host only matches hosts with an explicit
+     * "http://" scheme, which is what makes conn->host + 7 below safe. Check
+     * the prefix here too, so the pointer arithmetic cannot silently outlive
+     * that invariant if the validation ever changes. */
+    if (strncmp (conn->host, "http://", 7) == 0 && smm_https_upgrade_is_same_host (conn->host, redirect_url))
     {
         char *new_host = NULL;
         if (asprintf (&new_host, "https://%s", conn->host + 7) >= 0)

--- a/src/smm-asset-curl.c
+++ b/src/smm-asset-curl.c
@@ -510,15 +510,19 @@ smm_connection_try_https_upgrade (smm_connection conn, const char *redirect_url)
     {
         return false;
     }
+    static const char http_scheme[] = "http://";
+    const size_t http_scheme_len = sizeof (http_scheme) - 1;
+
     pthread_mutex_lock (&conn->lock);
     /* smm_https_upgrade_is_same_host only matches hosts with an explicit
-     * "http://" scheme, which is what makes conn->host + 7 below safe. Check
-     * the prefix here too, so the pointer arithmetic cannot silently outlive
-     * that invariant if the validation ever changes. */
-    if (strncmp (conn->host, "http://", 7) == 0 && smm_https_upgrade_is_same_host (conn->host, redirect_url))
+     * "http://" scheme, which is what makes skipping the scheme below safe.
+     * Check the prefix here too, so the pointer arithmetic cannot silently
+     * outlive that invariant if the validation ever changes. */
+    if (strncmp (conn->host, http_scheme, http_scheme_len) == 0
+        && smm_https_upgrade_is_same_host (conn->host, redirect_url))
     {
         char *new_host = NULL;
-        if (asprintf (&new_host, "https://%s", conn->host + 7) >= 0)
+        if (asprintf (&new_host, "https://%s", conn->host + http_scheme_len) >= 0)
         {
             free (conn->host);
             conn->host = new_host;

--- a/src/smm-asset-curl.c
+++ b/src/smm-asset-curl.c
@@ -503,6 +503,33 @@ smm_parse_csrf_token (const char *data, size_t len)
 }
 
 bool
+smm_connection_try_https_upgrade (smm_connection conn, const char *redirect_url)
+{
+    bool upgraded = false;
+    if (conn == NULL || redirect_url == NULL)
+    {
+        return false;
+    }
+    pthread_mutex_lock (&conn->lock);
+    if (smm_https_upgrade_is_same_host (conn->host, redirect_url))
+    {
+        char *new_host = NULL;
+        if (asprintf (&new_host, "https://%s", conn->host + 7) >= 0)
+        {
+            free (conn->host);
+            conn->host = new_host;
+            upgraded = true;
+        }
+        else
+        {
+            DEBUG ("Failed to create new host\n");
+        }
+    }
+    pthread_mutex_unlock (&conn->lock);
+    return upgraded;
+}
+
+bool
 smm_asset_connection_login (smm_connection connection)
 {
     bool res = false;
@@ -537,6 +564,23 @@ smm_asset_connection_login (smm_connection connection)
      * itself does not recurse back into smm_asset_connection_login. */
     struct smm_curl_res_s *res_get
         = smm_connection_curl_retrieve_url_r (connection, "/accounts/login/", NULL, populate_tidy, &docbuf, false);
+
+    /* The server may answer a plain-http login GET with a same-host redirect
+     * to https (e.g. Django's SECURE_SSL_REDIRECT or a proxy rule). The lazy
+     * request path performs this upgrade, so do the same here rather than
+     * failing an eager login that the lazy path would have survived. One
+     * attempt only; any other redirect is still a failure. */
+    if (res_get && res_get->success && smm_httpcode_is_redirect (res_get->httpcode)
+        && smm_connection_try_https_upgrade (connection, res_get->redirect_url))
+    {
+        DEBUG ("Upgrading login to https\n");
+        smm_curl_res_free (res_get);
+        /* Drop anything the redirect response wrote into the tidy buffer. */
+        tidyBufFree (&docbuf);
+        tidyBufInit (&docbuf);
+        res_get
+            = smm_connection_curl_retrieve_url_r (connection, "/accounts/login/", NULL, populate_tidy, &docbuf, false);
+    }
 
     if (res_get && res_get->success && res_get->httpcode == HTTP_SUCCESS)
     {
@@ -672,24 +716,11 @@ smm_connection_curl_retrieve_url (smm_connection conn, const char *path, const c
         {
             DEBUG ("Got redirected to (%s) accessing %s\n", res->redirect_url, path);
             /* It's possible we need to upgrade to https */
-            pthread_mutex_lock (&conn->lock);
-            if (smm_https_upgrade_is_same_host (conn->host, res->redirect_url))
+            if (smm_connection_try_https_upgrade (conn, res->redirect_url))
             {
-                /* Upgrade to https — same host, just switch the scheme */
                 DEBUG ("Upgrading to https\n");
-                char *new_host = NULL;
-                if (asprintf (&new_host, "https://%s", conn->host + 7) >= 0)
-                {
-                    free (conn->host);
-                    conn->host = new_host;
-                    retry = true;
-                }
-                else
-                {
-                    DEBUG ("Failed to create new host\n");
-                }
+                retry = true;
             }
-            pthread_mutex_unlock (&conn->lock);
 
             if (!retry && strstr (res->redirect_url, "accounts/login") != NULL)
             {

--- a/src/smm-asset-internal.h
+++ b/src/smm-asset-internal.h
@@ -169,7 +169,8 @@ bool smm_https_upgrade_is_same_host (const char *http_host, const char *https_re
 
 /* If redirect_url is a same-host https upgrade of the connection's http
  * host, switch the connection to the https host and return true. Returns
- * false (connection unchanged) for any other redirect, or on NULL args. */
+ * false (connection unchanged) for any other redirect, or on NULL args.
+ * Acquires conn->lock internally; callers must not hold conn->lock. */
 bool smm_connection_try_https_upgrade (smm_connection conn, const char *redirect_url);
 
 /* Returns true if url is a safe relative path: starts with '/', contains

--- a/src/smm-asset-internal.h
+++ b/src/smm-asset-internal.h
@@ -167,6 +167,11 @@ bool smm_httpcode_is_redirect (long httpcode);
  * same host:port — used to guard against redirect-based downgrade attacks. */
 bool smm_https_upgrade_is_same_host (const char *http_host, const char *https_redirect);
 
+/* If redirect_url is a same-host https upgrade of the connection's http
+ * host, switch the connection to the https host and return true. Returns
+ * false (connection unchanged) for any other redirect, or on NULL args. */
+bool smm_connection_try_https_upgrade (smm_connection conn, const char *redirect_url);
+
 /* Returns true if url is a safe relative path: starts with '/', contains
  * no '..' segments, no query ('?'), no fragment ('#'), and no percent-
  * encoded characters ('%'). */

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -923,6 +923,10 @@ redirect_server_thread (void *arg)
     if (fd >= 0)
     {
         char req[1024];
+        /* Drain the request; its content does not affect the canned response.
+         * glibc declares read/write warn_unused_result, and gcc ignores a
+         * plain (void) cast for those, so "(void)!" is needed to keep
+         * -Wunused-result (via -Wall, with --enable-werror) quiet. */
         (void)!read (fd, req, sizeof (req));
         const char body[] = "<html><body>301 Moved Permanently</body></html>";
         char resp[512];

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -860,6 +860,37 @@ START_TEST (test_https_upgrade_non_http_http_host)
 }
 END_TEST
 
+START_TEST (test_try_https_upgrade_switches_host)
+{
+    smm_connection conn = smm_asset_connect ("http://example.com", "user", "pass");
+    ck_assert_ptr_nonnull (conn);
+    ck_assert_int_eq (smm_connection_try_https_upgrade (conn, "https://example.com/accounts/login/"), true);
+    ck_assert_str_eq (conn->host, "https://example.com");
+    smm_connection_close (conn);
+}
+END_TEST
+
+START_TEST (test_try_https_upgrade_rejects_other_host)
+{
+    smm_connection conn = smm_asset_connect ("http://example.com", "user", "pass");
+    ck_assert_ptr_nonnull (conn);
+    ck_assert_int_eq (smm_connection_try_https_upgrade (conn, "https://evil.com/accounts/login/"), false);
+    ck_assert_str_eq (conn->host, "http://example.com");
+    smm_connection_close (conn);
+}
+END_TEST
+
+START_TEST (test_try_https_upgrade_null_args)
+{
+    smm_connection conn = smm_asset_connect ("http://example.com", "user", "pass");
+    ck_assert_ptr_nonnull (conn);
+    ck_assert_int_eq (smm_connection_try_https_upgrade (conn, NULL), false);
+    ck_assert_int_eq (smm_connection_try_https_upgrade (NULL, "https://example.com/"), false);
+    ck_assert_str_eq (conn->host, "http://example.com");
+    smm_connection_close (conn);
+}
+END_TEST
+
 START_TEST (test_https_upgrade_already_https)
 {
     /* conn is already https — smm_https_upgrade_is_same_host must return false
@@ -1221,6 +1252,9 @@ smm_suite (void)
     tcase_add_test (tc_conn, test_https_upgrade_null_args);
     tcase_add_test (tc_conn, test_https_upgrade_non_http_http_host);
     tcase_add_test (tc_conn, test_https_upgrade_already_https);
+    tcase_add_test (tc_conn, test_try_https_upgrade_switches_host);
+    tcase_add_test (tc_conn, test_try_https_upgrade_rejects_other_host);
+    tcase_add_test (tc_conn, test_try_https_upgrade_null_args);
     tcase_add_test (tc_conn, test_invalid_host);
     tcase_add_test (tc_conn, test_connect_null_host);
     tcase_add_test (tc_conn, test_connect_null_user);

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -1,10 +1,15 @@
 #include "smm-asset-internal.h"
 #include "smm-asset.h"
+#include <arpa/inet.h>
 #include <check.h>
 #include <locale.h>
+#include <netinet/in.h>
+#include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
 
 START_TEST (test_csrf_extraction)
 {
@@ -899,6 +904,92 @@ START_TEST (test_https_upgrade_already_https)
 }
 END_TEST
 
+/* Minimal single-purpose HTTP server for the eager-login upgrade test: the
+ * first connection is answered with a same-host https 301 (carrying an HTML
+ * body, as proxies do); the second connection — the upgraded retry, which
+ * arrives speaking TLS — is closed immediately so the login fails fast. */
+struct redirect_server_s
+{
+    int listen_fd;
+    uint16_t port;
+};
+
+static void *
+redirect_server_thread (void *arg)
+{
+    struct redirect_server_s *srv = (struct redirect_server_s *)arg;
+
+    int fd = accept (srv->listen_fd, NULL, NULL);
+    if (fd >= 0)
+    {
+        char req[1024];
+        (void)!read (fd, req, sizeof (req));
+        const char body[] = "<html><body>301 Moved Permanently</body></html>";
+        char resp[512];
+        int n = snprintf (resp, sizeof (resp),
+                          "HTTP/1.1 301 Moved Permanently\r\n"
+                          "Location: https://127.0.0.1:%u/accounts/login/\r\n"
+                          "Content-Type: text/html\r\n"
+                          "Content-Length: %zu\r\n"
+                          "Connection: close\r\n"
+                          "\r\n"
+                          "%s",
+                          srv->port, sizeof (body) - 1, body);
+        (void)!write (fd, resp, (size_t)n);
+        close (fd);
+    }
+
+    /* The upgraded retry: close without answering the TLS handshake. If the
+     * retry never happens (regression), this accept blocks and the test is
+     * failed by the check timeout. */
+    fd = accept (srv->listen_fd, NULL, NULL);
+    if (fd >= 0)
+    {
+        close (fd);
+    }
+    return NULL;
+}
+
+START_TEST (test_eager_login_follows_https_upgrade)
+{
+    struct redirect_server_s srv;
+    struct sockaddr_in addr;
+    socklen_t addr_len = sizeof (addr);
+
+    srv.listen_fd = socket (AF_INET, SOCK_STREAM, 0);
+    ck_assert_int_ge (srv.listen_fd, 0);
+    memset (&addr, 0, sizeof (addr));
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl (INADDR_LOOPBACK);
+    addr.sin_port = 0; /* ephemeral */
+    ck_assert_int_eq (bind (srv.listen_fd, (struct sockaddr *)&addr, sizeof (addr)), 0);
+    ck_assert_int_eq (listen (srv.listen_fd, 2), 0);
+    ck_assert_int_eq (getsockname (srv.listen_fd, (struct sockaddr *)&addr, &addr_len), 0);
+    srv.port = ntohs (addr.sin_port);
+
+    pthread_t thread;
+    ck_assert_int_eq (pthread_create (&thread, NULL, redirect_server_thread, &srv), 0);
+
+    char host[64];
+    snprintf (host, sizeof (host), "http://127.0.0.1:%u", srv.port);
+    smm_connection conn = smm_asset_connect (host, "user", "pass");
+    ck_assert_ptr_nonnull (conn);
+
+    /* The login itself fails (the upgraded retry reaches a socket that does
+     * not speak TLS), but the redirect must have switched the connection to
+     * the https host — that retry happening at all is the regression this
+     * test covers. */
+    ck_assert_int_eq (smm_asset_connection_login (conn), false);
+    char expected_host[64];
+    snprintf (expected_host, sizeof (expected_host), "https://127.0.0.1:%u", srv.port);
+    ck_assert_str_eq (conn->host, expected_host);
+
+    pthread_join (thread, NULL);
+    close (srv.listen_fd);
+    smm_connection_close (conn);
+}
+END_TEST
+
 START_TEST (test_curl_retrieve_url_r_returns_null_on_no_response)
 {
     /* Exercises the httpcode==0 cleanup path in smm_connection_curl_retrieve_url_r.
@@ -1255,6 +1346,7 @@ smm_suite (void)
     tcase_add_test (tc_conn, test_try_https_upgrade_switches_host);
     tcase_add_test (tc_conn, test_try_https_upgrade_rejects_other_host);
     tcase_add_test (tc_conn, test_try_https_upgrade_null_args);
+    tcase_add_test (tc_conn, test_eager_login_follows_https_upgrade);
     tcase_add_test (tc_conn, test_invalid_host);
     tcase_add_test (tc_conn, test_connect_null_host);
     tcase_add_test (tc_conn, test_connect_null_user);


### PR DESCRIPTION
## Description

smm_asset_connection_login() uses the raw non-retrying fetch (to avoid recursing into itself on the login redirect), so a server that answers the plain-http login GET with a 301 to https — Django's SECURE_SSL_REDIRECT or a proxy rule — failed the eager login with SMM_CONNECTION_FAILURE, even though the lazy request path upgrades and succeeds against the same server.

Factor the validated same-host https upgrade out of the retrying wrapper into smm_connection_try_https_upgrade() and use it in login too: upgrade once, discard the redirect body from the tidy buffer, and retry the GET. Any other redirect is still a failure, and the retried GET remains non-recursing.

## Summary by Sourcery

Handle same-host HTTP→HTTPS redirects consistently for asset connections, including during eager login, by centralizing the upgrade logic and validating the connection host update.

Bug Fixes:
- Ensure eager login follows same-host HTTPS upgrade redirects instead of failing the connection when servers enforce HTTPS on the login endpoint.

Enhancements:
- Factor same-host HTTPS upgrade handling into a reusable helper used by both generic request retry logic and login handling.
- Add validation to only switch the connection host on safe same-host HTTPS redirects and ignore other redirect targets.

Tests:
- Add unit tests covering the new HTTPS upgrade helper, including null-argument handling and rejection of cross-host redirects.
- Add an integration-style test with a minimal HTTP server to verify eager login performs a same-host HTTPS upgrade and retries the login request.