### PR TITLE
fix: do not flip the connection state on HTTP-level errors

### DIFF
--- a/src/smm-asset-curl.c
+++ b/src/smm-asset-curl.c
@@ -181,6 +181,30 @@ to_buffer (char *ptr, size_t size, size_t nmemb, void *userdata)
     return new_bytes;
 }
 
+bool
+smm_connection_state_for_curl_error (CURLcode cres, smm_connection_status *state)
+{
+    switch (cres)
+    {
+        case CURLE_URL_MALFORMAT:
+            *state = SMM_CONNECTION_HOST_INVALID;
+            return true;
+        case CURLE_COULDNT_RESOLVE_HOST:
+        case CURLE_COULDNT_CONNECT:
+            *state = SMM_CONNECTION_NO_HOST_CONNECTION;
+            return true;
+        case CURLE_HTTP_RETURNED_ERROR:
+            /* The server was reached and answered; an HTTP-level error (a
+             * 404/500 from one endpoint) says nothing about the connection
+             * or the session, so leave the connection state alone. The
+             * caller's per-object last_error carries the HTTP status. */
+            return false;
+        default:
+            *state = SMM_CONNECTION_FAILURE;
+            return true;
+    }
+}
+
 void
 smm_buffer_reset (struct buffer_s *buf)
 {
@@ -287,21 +311,13 @@ smm_connection_curl_retrieve_url_r (smm_connection conn, const char *path, const
 
     if (cres != CURLE_OK)
     {
-        pthread_mutex_lock (&conn->lock);
-        switch (cres)
+        smm_connection_status new_state;
+        if (smm_connection_state_for_curl_error (cres, &new_state))
         {
-            case CURLE_URL_MALFORMAT:
-                conn->state = SMM_CONNECTION_HOST_INVALID;
-                break;
-            case CURLE_COULDNT_RESOLVE_HOST:
-            case CURLE_COULDNT_CONNECT:
-                conn->state = SMM_CONNECTION_NO_HOST_CONNECTION;
-                break;
-            default:
-                conn->state = SMM_CONNECTION_FAILURE;
-                break;
+            pthread_mutex_lock (&conn->lock);
+            conn->state = new_state;
+            pthread_mutex_unlock (&conn->lock);
         }
-        pthread_mutex_unlock (&conn->lock);
     }
 
     curl_easy_getinfo (curl, CURLINFO_RESPONSE_CODE, &res->httpcode);

--- a/src/smm-asset-internal.h
+++ b/src/smm-asset-internal.h
@@ -116,6 +116,13 @@ struct buffer_s
 };
 
 size_t to_buffer (char *ptr, size_t size, size_t nmemb, void *userdata);
+
+/* Map a failed curl transfer to a connection state. Returns false when the
+ * failure says nothing about the connection itself (CURLE_HTTP_RETURNED_ERROR:
+ * the server was reached and answered, so the session may still be good) and
+ * the state should be left unchanged; otherwise stores the new state. */
+bool smm_connection_state_for_curl_error (CURLcode cres, smm_connection_status *state);
+
 /* Free any accumulated data and return the buffer to its empty state.
  * Safe to call on a NULL buffer or one that never received data. */
 void smm_buffer_reset (struct buffer_s *buf);

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -1022,6 +1022,30 @@ START_TEST (test_login_in_progress_reset_on_failure)
 }
 END_TEST
 
+START_TEST (test_state_for_curl_error_http_error_keeps_state)
+{
+    /* A 404/500 from one endpoint (CURLE_HTTP_RETURNED_ERROR under
+     * FAILONERROR) must not flip a connected session into a failure state. */
+    smm_connection_status state = SMM_CONNECTION_CONNECTED;
+    ck_assert_int_eq (smm_connection_state_for_curl_error (CURLE_HTTP_RETURNED_ERROR, &state), false);
+    ck_assert_int_eq (state, SMM_CONNECTION_CONNECTED);
+}
+END_TEST
+
+START_TEST (test_state_for_curl_error_connection_failures)
+{
+    smm_connection_status state;
+    ck_assert_int_eq (smm_connection_state_for_curl_error (CURLE_URL_MALFORMAT, &state), true);
+    ck_assert_int_eq (state, SMM_CONNECTION_HOST_INVALID);
+    ck_assert_int_eq (smm_connection_state_for_curl_error (CURLE_COULDNT_RESOLVE_HOST, &state), true);
+    ck_assert_int_eq (state, SMM_CONNECTION_NO_HOST_CONNECTION);
+    ck_assert_int_eq (smm_connection_state_for_curl_error (CURLE_COULDNT_CONNECT, &state), true);
+    ck_assert_int_eq (state, SMM_CONNECTION_NO_HOST_CONNECTION);
+    ck_assert_int_eq (smm_connection_state_for_curl_error (CURLE_OPERATION_TIMEDOUT, &state), true);
+    ck_assert_int_eq (state, SMM_CONNECTION_FAILURE);
+}
+END_TEST
+
 START_TEST (test_invalid_host)
 {
     smm_connection conn = smm_asset_connect ("not a url", "user", "pass");
@@ -1351,6 +1375,8 @@ smm_suite (void)
     tcase_add_test (tc_conn, test_try_https_upgrade_rejects_other_host);
     tcase_add_test (tc_conn, test_try_https_upgrade_null_args);
     tcase_add_test (tc_conn, test_eager_login_follows_https_upgrade);
+    tcase_add_test (tc_conn, test_state_for_curl_error_http_error_keeps_state);
+    tcase_add_test (tc_conn, test_state_for_curl_error_connection_failures);
     tcase_add_test (tc_conn, test_invalid_host);
     tcase_add_test (tc_conn, test_connect_null_host);
     tcase_add_test (tc_conn, test_connect_null_user);


### PR DESCRIPTION
## Description

With CURLOPT_FAILONERROR, an HTTP >= 400 response surfaces as CURLE_HTTP_RETURNED_ERROR and was mapped, via the default arm of the error switch, to SMM_CONNECTION_FAILURE. Nothing restores CONNECTED except a fresh login, so a single transient 404/500 from one endpoint made smm_asset_connection_get_state() report FAILURE forever while the session kept working.

Extract the mapping into smm_connection_state_for_curl_error() and leave the state untouched for HTTP-level errors: the server was reached and answered, so the failure says nothing about the connection. The per-object last_error already carries the HTTP status. All other CURLcode mappings are unchanged.

## Summary by Sourcery

Preserve the connection state for HTTP-level CURL errors while centralizing CURL error-to-connection-state mapping and covering the behavior with tests.

Bug Fixes:
- Stop marking an active connection as failed when a request encounters an HTTP-level error such as 404/500.

Tests:
- Add unit tests verifying connection state mapping for different CURL error codes, including HTTP errors and connection failures.