### PR TITLE
fix: record SMM_ERROR_INVALID_ARG instead of failing silently

### DIFF
--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -487,6 +487,7 @@ smm_asset_get_assets (smm_connection connection, smm_assets *assets, size_t *ass
 
     if (assets == NULL || assets_count == NULL)
     {
+        smm_connection_set_error (connection, SMM_ERROR_INVALID_ARG, "assets and assets_count must be non-NULL");
         return false;
     }
 
@@ -1024,6 +1025,7 @@ smm_search_get_waypoints (smm_search search, smm_waypoints *waypoints, size_t *w
     }
     if (waypoints == NULL || waypoints_count == NULL)
     {
+        smm_search_set_error (search, SMM_ERROR_INVALID_ARG, "waypoints and waypoints_count must be non-NULL");
         return false;
     }
 

--- a/src/smm-asset.h
+++ b/src/smm-asset.h
@@ -70,8 +70,8 @@ typedef struct
  * - smm_asset_connect() and smm_connection_close() are safe to call from any
  *   thread, but smm_connection_close() must not be called while another thread
  *   is still creating assets or searches from the same connection.
- *   smm_asset_create() acquires a reference on the connection, so closing the
- *   connection before freeing all assets is safe.
+ *   Each asset returned by smm_asset_get_assets() holds a reference on the
+ *   connection, so closing the connection before freeing all assets is safe.
  *
  * - Each smm_asset is owned by a single thread at a time.  Two threads must
  *   not call functions on the same asset concurrently.
@@ -238,8 +238,10 @@ void smm_connection_close (smm_connection connection);
  * Get all the assets that this user account has access to
  *
  * @param connection the smm_connection object to get the assets from
- * @param assets Where to store the assets
- * @param assets_count Where to store how many assets there are
+ * @param assets Where to store the assets (must be non-NULL; otherwise
+ *               SMM_ERROR_INVALID_ARG is recorded on the connection)
+ * @param assets_count Where to store how many assets there are (must be
+ *                     non-NULL, as above)
  *
  * @return true if assets were successfully retrieved (even if there are none), false if there was an error
  */
@@ -353,8 +355,10 @@ uint64_t smm_search_sweep_width (smm_search search);
  * Get all the waypoints associated with a a search
  *
  * @param search the search
- * @param waypoints a place to store the list of waypoints
- * @param waypoints_count a place to store the count of waypoints
+ * @param waypoints a place to store the list of waypoints (must be non-NULL;
+ *                  otherwise SMM_ERROR_INVALID_ARG is recorded on the search)
+ * @param waypoints_count a place to store the count of waypoints (must be
+ *                        non-NULL, as above)
  *
  * @return true if waypoints for the search were stored in waypoints
  */

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -621,6 +621,35 @@ START_TEST (test_report_position_sets_asset_error_not_conn)
 }
 END_TEST
 
+START_TEST (test_get_assets_null_outparams_record_invalid_arg)
+{
+    smm_connection conn = smm_asset_connect ("http://localhost/", "user", "pass");
+    ck_assert_ptr_nonnull (conn);
+    smm_assets assets;
+    size_t count;
+    ck_assert_int_eq (smm_asset_get_assets (conn, NULL, &count), false);
+    ck_assert_int_eq (smm_connection_get_last_error (conn).code, SMM_ERROR_INVALID_ARG);
+    ck_assert_int_eq (smm_asset_get_assets (conn, &assets, NULL), false);
+    ck_assert_int_eq (smm_connection_get_last_error (conn).code, SMM_ERROR_INVALID_ARG);
+    smm_connection_close (conn);
+}
+END_TEST
+
+START_TEST (test_get_waypoints_null_outparams_record_invalid_arg)
+{
+    const char *json = "{\"object_url\": \"/search/1/\", \"distance\": 10, \"length\": 100, \"sweep_width\": 50}";
+    smm_search search = smm_parse_search_json (NULL, json, strlen (json));
+    ck_assert_ptr_nonnull (search);
+    smm_waypoints waypoints;
+    size_t count;
+    ck_assert_int_eq (smm_search_get_waypoints (search, NULL, &count), false);
+    ck_assert_int_eq (smm_search_get_last_error (search).code, SMM_ERROR_INVALID_ARG);
+    ck_assert_int_eq (smm_search_get_waypoints (search, &waypoints, NULL), false);
+    ck_assert_int_eq (smm_search_get_last_error (search).code, SMM_ERROR_INVALID_ARG);
+    smm_search_destroy (search);
+}
+END_TEST
+
 START_TEST (test_search_action_sets_search_error_not_conn)
 {
     /* With conn==NULL the network call fails; the error must land on the
@@ -1390,6 +1419,8 @@ smm_suite (void)
     tcase_add_test (tc_conn, test_search_get_last_error_initial);
     tcase_add_test (tc_conn, test_report_position_sets_asset_error_not_conn);
     tcase_add_test (tc_conn, test_search_action_sets_search_error_not_conn);
+    tcase_add_test (tc_conn, test_get_assets_null_outparams_record_invalid_arg);
+    tcase_add_test (tc_conn, test_get_waypoints_null_outparams_record_invalid_arg);
     tcase_add_test (tc_conn, test_get_state_null_connection);
     tcase_add_test (tc_conn, test_connection_login_null);
     tcase_add_test (tc_conn, test_get_state_initial);


### PR DESCRIPTION
## Description
SMM_ERROR_INVALID_ARG was declared in the public enum but never set; NULL-argument failures returned false with no recorded error. Record it in the two places that have an object to record on: NULL out-params to smm_asset_get_assets() land on the connection, and NULL out-params to smm_search_get_waypoints() land on the search, matching the documented error-domain split. Functions whose invalid argument is the object itself still just return false, as documented.

Also stop referencing the internal smm_asset_create() in the public header's thread-safety notes; describe the connection reference in terms of the public smm_asset_get_assets() instead.