### PR TITLE
fix: normalise trailing slashes off the connection host

### DIFF
--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -134,6 +134,17 @@ smm_asset_connect (const char *host, const char *user, const char *pass)
         return NULL;
     }
 
+    /* Normalise away trailing '/'s: request paths always start with '/', so a
+     * host of "http://example.com/" would otherwise produce double-slash URLs
+     * such as "http://example.com//assets/", which only work behind proxies
+     * that merge slashes. Also makes a base path like
+     * "https://example.com/smm/" concatenate correctly. */
+    size_t host_len = strlen (conn->host);
+    while (host_len > 0 && conn->host[host_len - 1] == '/')
+    {
+        conn->host[--host_len] = '\0';
+    }
+
     pthread_mutex_init (&conn->lock, NULL);
     conn->login_in_progress = false;
     pthread_cond_init (&conn->login_cond, NULL);
@@ -143,11 +154,11 @@ smm_asset_connect (const char *host, const char *user, const char *pass)
         return NULL;
     }
 
-    /* Early host validation */
+    /* Early host validation, on the normalised host actually used in URLs */
     CURLU *curlu = curl_url ();
     if (curlu)
     {
-        if (curl_url_set (curlu, CURLUPART_URL, host, 0) != CURLUE_OK)
+        if (curl_url_set (curlu, CURLUPART_URL, conn->host, 0) != CURLUE_OK)
         {
             conn->state = SMM_CONNECTION_HOST_INVALID;
         }

--- a/src/smm-asset.h
+++ b/src/smm-asset.h
@@ -165,7 +165,9 @@ void smm_asset_debugging_set (bool debug);
  * until then. To establish the session up front and check the result, call
  * @ref smm_asset_connection_login.
  *
- * @param host the URI of the smm server (i.e. https://smm.example.com)
+ * @param host the URI of the smm server (i.e. https://smm.example.com); any
+ *             trailing '/' is ignored, and a base path is allowed (i.e.
+ *             https://example.com/smm)
  * @param user the username to authenticate as
  * @param pass the password to authenticate with
  *

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -1377,6 +1377,71 @@ START_TEST (test_get_state_invalid_host)
 }
 END_TEST
 
+START_TEST (test_connect_strips_trailing_slash)
+{
+    /* Request paths always start with '/', so a trailing '/' on the host
+     * would otherwise yield "http://example.com//assets/". */
+    smm_connection conn = smm_asset_connect ("http://example.com/", "user", "pass");
+    ck_assert_ptr_nonnull (conn);
+    ck_assert_str_eq (conn->host, "http://example.com");
+    ck_assert_int_eq (smm_asset_connection_get_state (conn), SMM_CONNECTION_NEW);
+    smm_connection_close (conn);
+}
+END_TEST
+
+START_TEST (test_connect_strips_multiple_trailing_slashes)
+{
+    smm_connection conn = smm_asset_connect ("http://example.com///", "user", "pass");
+    ck_assert_ptr_nonnull (conn);
+    ck_assert_str_eq (conn->host, "http://example.com");
+    smm_connection_close (conn);
+}
+END_TEST
+
+START_TEST (test_connect_no_trailing_slash_unchanged)
+{
+    smm_connection conn = smm_asset_connect ("http://example.com:8080", "user", "pass");
+    ck_assert_ptr_nonnull (conn);
+    ck_assert_str_eq (conn->host, "http://example.com:8080");
+    smm_connection_close (conn);
+}
+END_TEST
+
+START_TEST (test_connect_base_path_trailing_slash)
+{
+    /* A base path (server behind a reverse-proxy subpath) keeps the path but
+     * loses the trailing '/' so request paths concatenate cleanly. */
+    smm_connection conn = smm_asset_connect ("https://example.com/smm/", "user", "pass");
+    ck_assert_ptr_nonnull (conn);
+    ck_assert_str_eq (conn->host, "https://example.com/smm");
+    ck_assert_int_eq (smm_asset_connection_get_state (conn), SMM_CONNECTION_NEW);
+    smm_connection_close (conn);
+}
+END_TEST
+
+START_TEST (test_https_upgrade_preserves_base_path)
+{
+    /* The https upgrade rebuilds the host from the part after "http://", so a
+     * base path must survive the scheme switch. */
+    smm_connection conn = smm_asset_connect ("http://example.com/smm/", "user", "pass");
+    ck_assert_ptr_nonnull (conn);
+    ck_assert_int_eq (smm_connection_try_https_upgrade (conn, "https://example.com/accounts/login/"), true);
+    ck_assert_str_eq (conn->host, "https://example.com/smm");
+    smm_connection_close (conn);
+}
+END_TEST
+
+START_TEST (test_connect_only_slashes_is_invalid)
+{
+    /* Degenerate input that normalises to the empty string must be reported
+     * as an invalid host, not silently accepted. */
+    smm_connection conn = smm_asset_connect ("///", "user", "pass");
+    ck_assert_ptr_nonnull (conn);
+    ck_assert_int_eq (smm_asset_connection_get_state (conn), SMM_CONNECTION_HOST_INVALID);
+    smm_connection_close (conn);
+}
+END_TEST
+
 Suite *
 smm_suite (void)
 {
@@ -1425,6 +1490,12 @@ smm_suite (void)
     tcase_add_test (tc_conn, test_connection_login_null);
     tcase_add_test (tc_conn, test_get_state_initial);
     tcase_add_test (tc_conn, test_get_state_invalid_host);
+    tcase_add_test (tc_conn, test_connect_strips_trailing_slash);
+    tcase_add_test (tc_conn, test_connect_strips_multiple_trailing_slashes);
+    tcase_add_test (tc_conn, test_connect_no_trailing_slash_unchanged);
+    tcase_add_test (tc_conn, test_connect_base_path_trailing_slash);
+    tcase_add_test (tc_conn, test_https_upgrade_preserves_base_path);
+    tcase_add_test (tc_conn, test_connect_only_slashes_is_invalid);
     tcase_add_test (tc_conn, test_debugging_set);
     suite_add_tcase (s, tc_conn);
 

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -1437,6 +1437,9 @@ START_TEST (test_connect_only_slashes_is_invalid)
      * as an invalid host, not silently accepted. */
     smm_connection conn = smm_asset_connect ("///", "user", "pass");
     ck_assert_ptr_nonnull (conn);
+    /* Normalisation ran before validation: every slash was stripped, and it
+     * is that empty host the validation then rejected. */
+    ck_assert_str_eq (conn->host, "");
     ck_assert_int_eq (smm_asset_connection_get_state (conn), SMM_CONNECTION_HOST_INVALID);
     smm_connection_close (conn);
 }


### PR DESCRIPTION
## Description

Request paths always begin with '/', so a host given as "http://example.com/" — the form the README example uses — produced double-slash request URLs like "http://example.com//assets/", which only work behind proxies that merge slashes. Strip trailing '/'s from the stored host, which also lets a reverse-proxy base path such as "https://example.com/smm/" concatenate correctly, and validate the normalised host rather than the raw argument so degenerate input like "///" is reported as SMM_CONNECTION_HOST_INVALID.

## Summary by Sourcery

Normalise connection hosts by stripping trailing slashes and validating the resulting URL to avoid malformed request paths and reject degenerate hosts.

Bug Fixes:
- Prevent double-slash request URLs by removing trailing '/' characters from stored connection hosts before use.
- Ensure hosts that normalise to an empty or invalid URL are reported as SMM_CONNECTION_HOST_INVALID instead of being silently accepted.

Documentation:
- Document that the connection host may include a base path and that any trailing '/' is ignored.

Tests:
- Add connection tests covering host trailing slash removal, base-path handling, HTTPS upgrade preservation, and rejection of hosts consisting only of slashes.