### PR TITLE
feat: add runtime library version queries

### DIFF
--- a/src/libsmmasset.sym
+++ b/src/libsmmasset.sym
@@ -12,6 +12,8 @@ smm_asset_last_goto_pos
 smm_asset_name
 smm_asset_report_position
 smm_asset_type
+smm_asset_version_number
+smm_asset_version_string
 smm_connection_close
 smm_connection_get_last_error
 smm_search_accept

--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -103,7 +103,7 @@ smm_asset_version_string (void)
     return SMM_VERSION_STRING;
 }
 
-unsigned int
+uint32_t
 smm_asset_version_number (void)
 {
     return SMM_VERSION_NUMBER;

--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -97,6 +97,18 @@ smm_asprintf_c_locale (char **strp, const char *fmt, ...)
     return n;
 }
 
+const char *
+smm_asset_version_string (void)
+{
+    return SMM_VERSION_STRING;
+}
+
+unsigned int
+smm_asset_version_number (void)
+{
+    return SMM_VERSION_NUMBER;
+}
+
 void
 smm_asset_debugging_set (bool debug)
 {

--- a/src/smm-asset.h
+++ b/src/smm-asset.h
@@ -35,6 +35,12 @@
 #define SMM_VERSION_STRING "1.0.0"
 
 /**
+ * Numeric library version: (major << 16) | (minor << 8) | patch.
+ * Suitable for comparisons, e.g. #if SMM_VERSION_NUMBER >= 0x010100.
+ */
+#define SMM_VERSION_NUMBER ((SMM_VERSION_MAJOR << 16) | (SMM_VERSION_MINOR << 8) | SMM_VERSION_PATCH)
+
+/**
  * Error codes returned by smm_connection_get_last_error()
  */
 typedef enum
@@ -147,6 +153,24 @@ typedef enum
     SMM_COMMAND_MISSION_COMPLETE, /*!< The mission has concluded, return to base */
     SMM_COMMAND_UNKNOWN,          /*!< The command from the server is not known */
 } smm_asset_command;
+
+/**
+ * Get the version string of the library linked at runtime.
+ *
+ * This may differ from the SMM_VERSION_STRING the application was compiled
+ * against when a different library version is installed.
+ *
+ * @return a static string such as "1.0.0"; do not free it
+ */
+const char *smm_asset_version_string (void);
+
+/**
+ * Get the numeric version of the library linked at runtime.
+ *
+ * @return the version in @ref SMM_VERSION_NUMBER format:
+ *         (major << 16) | (minor << 8) | patch
+ */
+unsigned int smm_asset_version_number (void);
 
 /**
  * Enable/disable the debugging

--- a/src/smm-asset.h
+++ b/src/smm-asset.h
@@ -170,7 +170,7 @@ const char *smm_asset_version_string (void);
  * @return the version in @ref SMM_VERSION_NUMBER format:
  *         (major << 16) | (minor << 8) | patch
  */
-unsigned int smm_asset_version_number (void);
+uint32_t smm_asset_version_number (void);
 
 /**
  * Enable/disable the debugging

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -1322,6 +1322,18 @@ START_TEST (test_debugging_set)
 }
 END_TEST
 
+START_TEST (test_version_runtime_matches_headers)
+{
+    /* The runtime queries must agree with the macros the tests were compiled
+     * against (the tests always run against the just-built library). */
+    ck_assert_str_eq (smm_asset_version_string (), SMM_VERSION_STRING);
+    ck_assert_uint_eq (smm_asset_version_number (), SMM_VERSION_NUMBER);
+    ck_assert_uint_eq (smm_asset_version_number () >> 16, SMM_VERSION_MAJOR);
+    ck_assert_uint_eq ((smm_asset_version_number () >> 8) & 0xff, SMM_VERSION_MINOR);
+    ck_assert_uint_eq (smm_asset_version_number () & 0xff, SMM_VERSION_PATCH);
+}
+END_TEST
+
 START_TEST (test_connection_login_fields_initialised)
 {
     smm_connection conn = smm_asset_connect ("not a url", "user", "pass");
@@ -1500,6 +1512,7 @@ smm_suite (void)
     tcase_add_test (tc_conn, test_https_upgrade_preserves_base_path);
     tcase_add_test (tc_conn, test_connect_only_slashes_is_invalid);
     tcase_add_test (tc_conn, test_debugging_set);
+    tcase_add_test (tc_conn, test_version_runtime_matches_headers);
     suite_add_tcase (s, tc_conn);
 
     TCase *tc_position = tcase_create ("Position");


### PR DESCRIPTION
## Description

Applications linked against the shared library had no way to ask which version they are actually running against; the SMM_VERSION_* macros only describe the headers used at compile time. Add smm_asset_version_string() and smm_asset_version_number() (the latter in the new SMM_VERSION_NUMBER packed format, (major << 16) | (minor << 8) | patch) and export them.

Named under the existing smm_asset_* prefix, matching the other library-global call smm_asset_debugging_set(), rather than opening a new smm_version_* namespace that would be frozen by 1.0.0. No -version-info bump: 1.0.0 has not shipped, so this release still defines the initial .so.0 ABI.

## Summary by Sourcery

Add runtime-queryable library version APIs and corresponding tests to ensure they match the compile-time version macros.

New Features:
- Expose smm_asset_version_string() to retrieve the linked library version string at runtime.
- Expose smm_asset_version_number() to retrieve the linked library version as a packed numeric value suitable for comparisons.

Tests:
- Add a unit test verifying that the runtime version string and numeric value match the compile-time SMM_VERSION_* macros.