### PR TITLE
refactor!: return error code and copy message in smm_*_get_last_error

### DIFF
--- a/src/smm-asset-internal.h
+++ b/src/smm-asset-internal.h
@@ -59,6 +59,16 @@ extern _Atomic bool smm_debug;
         }                                                                                                              \
     } while (0)
 
+/* Snapshot of the most recent error recorded on an object. Internal only:
+ * the public API returns the code and copies the message into a caller
+ * buffer (smm_*_get_last_error), so this layout — in particular the message
+ * size — can change without affecting the ABI. */
+typedef struct
+{
+    smm_error_code code;
+    char message[256];
+} smm_error;
+
 struct smm_connection_s
 {
     char *host;

--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -238,16 +238,25 @@ smm_asset_clear_error (smm_asset asset)
     pthread_mutex_unlock (&asset->lock);
 }
 
-smm_error
-smm_asset_get_last_error (smm_asset asset)
+smm_error_code
+smm_asset_get_last_error (smm_asset asset, char *message, size_t message_len)
 {
-    smm_error result = { SMM_ERROR_NONE, { 0 } };
+    if (message != NULL && message_len > 0)
+    {
+        message[0] = '\0';
+    }
     if (asset == NULL)
-        return result;
+    {
+        return SMM_ERROR_NONE;
+    }
     pthread_mutex_lock (&asset->lock);
-    result = asset->last_error;
+    smm_error_code code = asset->last_error.code;
+    if (message != NULL && message_len > 0)
+    {
+        snprintf (message, message_len, "%s", asset->last_error.message);
+    }
     pthread_mutex_unlock (&asset->lock);
-    return result;
+    return code;
 }
 
 static void
@@ -271,13 +280,22 @@ smm_search_clear_error (smm_search search)
     search->last_error.message[0] = '\0';
 }
 
-smm_error
-smm_search_get_last_error (smm_search search)
+smm_error_code
+smm_search_get_last_error (smm_search search, char *message, size_t message_len)
 {
-    smm_error result = { SMM_ERROR_NONE, { 0 } };
+    if (message != NULL && message_len > 0)
+    {
+        message[0] = '\0';
+    }
     if (search == NULL)
-        return result;
-    return search->last_error;
+    {
+        return SMM_ERROR_NONE;
+    }
+    if (message != NULL && message_len > 0)
+    {
+        snprintf (message, message_len, "%s", search->last_error.message);
+    }
+    return search->last_error.code;
 }
 
 void
@@ -309,18 +327,25 @@ smm_connection_clear_error (smm_connection conn)
     pthread_mutex_unlock (&conn->lock);
 }
 
-smm_error
-smm_connection_get_last_error (smm_connection connection)
+smm_error_code
+smm_connection_get_last_error (smm_connection connection, char *message, size_t message_len)
 {
-    smm_error result = { SMM_ERROR_NONE, { 0 } };
+    if (message != NULL && message_len > 0)
+    {
+        message[0] = '\0';
+    }
     if (connection == NULL)
     {
-        return result;
+        return SMM_ERROR_NONE;
     }
     pthread_mutex_lock (&connection->lock);
-    result = connection->last_error;
+    smm_error_code code = connection->last_error.code;
+    if (message != NULL && message_len > 0)
+    {
+        snprintf (message, message_len, "%s", connection->last_error.message);
+    }
     pthread_mutex_unlock (&connection->lock);
-    return result;
+    return code;
 }
 
 void

--- a/src/smm-asset.h
+++ b/src/smm-asset.h
@@ -55,15 +55,6 @@ typedef enum
 } smm_error_code;
 
 /**
- * Structured error detail attached to an smm_connection.
- */
-typedef struct
-{
-    smm_error_code code; /*!< Machine-readable error code */
-    char message[256];   /*!< Human-readable description */
-} smm_error;
-
-/**
  * @section thread_safety Thread-safety guarantees
  *
  * - A single smm_connection may be shared across threads.  The connection's
@@ -437,14 +428,17 @@ void smm_waypoints_free (smm_waypoints waypoints, size_t waypoints_count);
  * stored on the respective asset or search object; use
  * smm_asset_get_last_error() and smm_search_get_last_error() instead.
  *
- * Returns a snapshot of the last error, copied under the connection lock.
- * Safe to call concurrently with other library functions.
- * Returns a zeroed smm_error (code == SMM_ERROR_NONE) if connection is NULL.
+ * The code and message are a consistent snapshot of one error, copied
+ * together under the connection lock.  Safe to call concurrently with other
+ * library functions.
  *
- * @param connection the smm_connection to query
- * @return a copy of the last recorded error
+ * @param connection the smm_connection to query; NULL reports SMM_ERROR_NONE
+ * @param message buffer for the NUL-terminated human-readable description
+ *                (truncated to fit), or NULL to query only the code
+ * @param message_len size of @a message in bytes; ignored when message is NULL
+ * @return the machine-readable code of the last recorded error
  */
-smm_error smm_connection_get_last_error (smm_connection connection);
+smm_error_code smm_connection_get_last_error (smm_connection connection, char *message, size_t message_len);
 
 /**
  * Retrieve the most recent error recorded on an asset.
@@ -454,12 +448,13 @@ smm_error smm_connection_get_last_error (smm_connection connection);
  * operations on different assets sharing the same connection do not
  * clobber each other's error state.
  *
- * Returns a zeroed smm_error (code == SMM_ERROR_NONE) if asset is NULL.
- *
- * @param asset the smm_asset to query
- * @return a copy of the last recorded error
+ * @param asset the smm_asset to query; NULL reports SMM_ERROR_NONE
+ * @param message buffer for the NUL-terminated human-readable description
+ *                (truncated to fit), or NULL to query only the code
+ * @param message_len size of @a message in bytes; ignored when message is NULL
+ * @return the machine-readable code of the last recorded error
  */
-smm_error smm_asset_get_last_error (smm_asset asset);
+smm_error_code smm_asset_get_last_error (smm_asset asset, char *message, size_t message_len);
 
 /**
  * Retrieve the most recent error recorded on a search.
@@ -469,9 +464,10 @@ smm_error smm_asset_get_last_error (smm_asset asset);
  * concurrent operations on different searches sharing the same connection
  * do not clobber each other's error state.
  *
- * Returns a zeroed smm_error (code == SMM_ERROR_NONE) if search is NULL.
- *
- * @param search the smm_search to query
- * @return a copy of the last recorded error
+ * @param search the smm_search to query; NULL reports SMM_ERROR_NONE
+ * @param message buffer for the NUL-terminated human-readable description
+ *                (truncated to fit), or NULL to query only the code
+ * @param message_len size of @a message in bytes; ignored when message is NULL
+ * @return the machine-readable code of the last recorded error
  */
-smm_error smm_search_get_last_error (smm_search search);
+smm_error_code smm_search_get_last_error (smm_search search, char *message, size_t message_len);

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -574,8 +574,9 @@ END_TEST
 
 START_TEST (test_asset_get_last_error_null)
 {
-    smm_error err = smm_asset_get_last_error (NULL);
-    ck_assert_int_eq (err.code, SMM_ERROR_NONE);
+    char msg[16] = "sentinel";
+    ck_assert_int_eq (smm_asset_get_last_error (NULL, msg, sizeof (msg)), SMM_ERROR_NONE);
+    ck_assert_str_eq (msg, "");
 }
 END_TEST
 
@@ -583,16 +584,18 @@ START_TEST (test_asset_get_last_error_initial)
 {
     smm_asset asset = smm_asset_create (NULL, "A", "T", 1, 1);
     ck_assert_ptr_nonnull (asset);
-    smm_error err = smm_asset_get_last_error (asset);
-    ck_assert_int_eq (err.code, SMM_ERROR_NONE);
+    char msg[64];
+    ck_assert_int_eq (smm_asset_get_last_error (asset, msg, sizeof (msg)), SMM_ERROR_NONE);
+    ck_assert_str_eq (msg, "");
     smm_asset_free_asset (asset);
 }
 END_TEST
 
 START_TEST (test_search_get_last_error_null)
 {
-    smm_error err = smm_search_get_last_error (NULL);
-    ck_assert_int_eq (err.code, SMM_ERROR_NONE);
+    char msg[16] = "sentinel";
+    ck_assert_int_eq (smm_search_get_last_error (NULL, msg, sizeof (msg)), SMM_ERROR_NONE);
+    ck_assert_str_eq (msg, "");
 }
 END_TEST
 
@@ -601,8 +604,9 @@ START_TEST (test_search_get_last_error_initial)
     const char *json = "{\"object_url\": \"/search/1/\", \"distance\": 10, \"length\": 100, \"sweep_width\": 50}";
     smm_search search = smm_parse_search_json (NULL, json, strlen (json));
     ck_assert_ptr_nonnull (search);
-    smm_error err = smm_search_get_last_error (search);
-    ck_assert_int_eq (err.code, SMM_ERROR_NONE);
+    char msg[64];
+    ck_assert_int_eq (smm_search_get_last_error (search, msg, sizeof (msg)), SMM_ERROR_NONE);
+    ck_assert_str_eq (msg, "");
     smm_search_destroy (search);
 }
 END_TEST
@@ -615,8 +619,27 @@ START_TEST (test_report_position_sets_asset_error_not_conn)
     smm_asset asset = smm_asset_create (NULL, "A", "T", 1, 1);
     ck_assert_ptr_nonnull (asset);
     smm_asset_report_position (asset, -43.5, 172.6, 100, 270, 3);
-    smm_error err = smm_asset_get_last_error (asset);
-    ck_assert_int_ne (err.code, SMM_ERROR_NONE);
+    char msg[256];
+    ck_assert_int_ne (smm_asset_get_last_error (asset, msg, sizeof (msg)), SMM_ERROR_NONE);
+    /* A real error must come with a human-readable description. */
+    ck_assert_int_gt (strlen (msg), 0);
+    smm_asset_free_asset (asset);
+}
+END_TEST
+
+START_TEST (test_get_last_error_message_truncated_to_buffer)
+{
+    /* A message longer than the caller's buffer is truncated and still
+     * NUL-terminated; the code is unaffected. */
+    smm_asset asset = smm_asset_create (NULL, "A", "T", 1, 1);
+    ck_assert_ptr_nonnull (asset);
+    smm_asset_report_position (asset, -43.5, 172.6, 100, 270, 3);
+    char tiny[4];
+    ck_assert_int_ne (smm_asset_get_last_error (asset, tiny, sizeof (tiny)), SMM_ERROR_NONE);
+    ck_assert_uint_eq (strlen (tiny), sizeof (tiny) - 1);
+    /* NULL message / zero length only query the code. */
+    ck_assert_int_ne (smm_asset_get_last_error (asset, NULL, 0), SMM_ERROR_NONE);
+    ck_assert_int_ne (smm_asset_get_last_error (asset, tiny, 0), SMM_ERROR_NONE);
     smm_asset_free_asset (asset);
 }
 END_TEST
@@ -628,9 +651,9 @@ START_TEST (test_get_assets_null_outparams_record_invalid_arg)
     smm_assets assets;
     size_t count;
     ck_assert_int_eq (smm_asset_get_assets (conn, NULL, &count), false);
-    ck_assert_int_eq (smm_connection_get_last_error (conn).code, SMM_ERROR_INVALID_ARG);
+    ck_assert_int_eq (smm_connection_get_last_error (conn, NULL, 0), SMM_ERROR_INVALID_ARG);
     ck_assert_int_eq (smm_asset_get_assets (conn, &assets, NULL), false);
-    ck_assert_int_eq (smm_connection_get_last_error (conn).code, SMM_ERROR_INVALID_ARG);
+    ck_assert_int_eq (smm_connection_get_last_error (conn, NULL, 0), SMM_ERROR_INVALID_ARG);
     smm_connection_close (conn);
 }
 END_TEST
@@ -643,9 +666,9 @@ START_TEST (test_get_waypoints_null_outparams_record_invalid_arg)
     smm_waypoints waypoints;
     size_t count;
     ck_assert_int_eq (smm_search_get_waypoints (search, NULL, &count), false);
-    ck_assert_int_eq (smm_search_get_last_error (search).code, SMM_ERROR_INVALID_ARG);
+    ck_assert_int_eq (smm_search_get_last_error (search, NULL, 0), SMM_ERROR_INVALID_ARG);
     ck_assert_int_eq (smm_search_get_waypoints (search, &waypoints, NULL), false);
-    ck_assert_int_eq (smm_search_get_last_error (search).code, SMM_ERROR_INVALID_ARG);
+    ck_assert_int_eq (smm_search_get_last_error (search, NULL, 0), SMM_ERROR_INVALID_ARG);
     smm_search_destroy (search);
 }
 END_TEST
@@ -660,8 +683,7 @@ START_TEST (test_search_action_sets_search_error_not_conn)
     search_s.asset_id = 1;
     search_s.url = strdup ("/search/1/");
     smm_search_accept (&search_s);
-    smm_error err = smm_search_get_last_error (&search_s);
-    ck_assert_int_ne (err.code, SMM_ERROR_NONE);
+    ck_assert_int_ne (smm_search_get_last_error (&search_s, NULL, 0), SMM_ERROR_NONE);
     free (search_s.url);
 }
 END_TEST
@@ -1347,8 +1369,9 @@ END_TEST
 
 START_TEST (test_get_last_error_null_connection)
 {
-    smm_error err = smm_connection_get_last_error (NULL);
-    ck_assert_int_eq (err.code, SMM_ERROR_NONE);
+    char msg[16] = "sentinel";
+    ck_assert_int_eq (smm_connection_get_last_error (NULL, msg, sizeof (msg)), SMM_ERROR_NONE);
+    ck_assert_str_eq (msg, "");
 }
 END_TEST
 
@@ -1356,8 +1379,9 @@ START_TEST (test_get_last_error_initial)
 {
     smm_connection conn = smm_asset_connect ("http://localhost/", "user", "pass");
     ck_assert_ptr_nonnull (conn);
-    smm_error err = smm_connection_get_last_error (conn);
-    ck_assert_int_eq (err.code, SMM_ERROR_NONE);
+    char msg[64];
+    ck_assert_int_eq (smm_connection_get_last_error (conn, msg, sizeof (msg)), SMM_ERROR_NONE);
+    ck_assert_str_eq (msg, "");
     smm_connection_close (conn);
 }
 END_TEST
@@ -1498,6 +1522,7 @@ smm_suite (void)
     tcase_add_test (tc_conn, test_search_get_last_error_null);
     tcase_add_test (tc_conn, test_search_get_last_error_initial);
     tcase_add_test (tc_conn, test_report_position_sets_asset_error_not_conn);
+    tcase_add_test (tc_conn, test_get_last_error_message_truncated_to_buffer);
     tcase_add_test (tc_conn, test_search_action_sets_search_error_not_conn);
     tcase_add_test (tc_conn, test_get_assets_null_outparams_record_invalid_arg);
     tcase_add_test (tc_conn, test_get_waypoints_null_outparams_record_invalid_arg);


### PR DESCRIPTION
## Description

The public smm_error struct embedded a fixed char message[256] and was returned by value, freezing that layout into the 1.0.0 ABI: the buffer could never grow without an ABI break. Remove the struct from the public header and have the getters return the smm_error_code directly, copying the NUL-terminated message (truncated as needed) into a caller-supplied buffer; pass NULL to query only the code. Code and message are still copied together under the object lock, so the snapshot stays consistent.

The struct moves to the internal header unchanged as the storage format, which is now free to change in future releases. No version-info bump: these functions have not shipped (1.0.0 is still unreleased).

## Summary by Sourcery

Refactor error reporting APIs to return error codes directly while copying human-readable messages into caller-provided buffers, decoupling the public ABI from the internal error storage layout.

Enhancements:
- Change smm_connection_get_last_error, smm_asset_get_last_error, and smm_search_get_last_error to return smm_error_code and write the associated message into an optional caller-supplied buffer, allowing future changes to the internal error struct.
- Move the smm_error struct definition from the public header into an internal header so that the internal error storage format, including message size, can evolve without breaking ABI.

Tests:
- Update existing tests to use the new get_last_error signatures and validate both returned codes and copied messages.
- Add coverage to ensure error messages are truncated to fit the caller’s buffer, remain NUL-terminated, and that passing NULL or zero-length buffers still correctly reports the error code.