### PR TITLE
fix: use int32_t for the altitude parameter

### DIFF
--- a/src/smm-asset-internal.h
+++ b/src/smm-asset-internal.h
@@ -170,7 +170,8 @@ smm_asset smm_asset_create (smm_connection connection, const char *name, const c
                             long long asset_type_id);
 void smm_asset_free_asset (smm_asset assets);
 
-char *smm_asset_build_position_url (long long asset_id, double lat, double lon, int alt, uint16_t heading, uint8_t fix);
+char *smm_asset_build_position_url (long long asset_id, double lat, double lon, int32_t alt, uint16_t heading,
+                                    uint8_t fix);
 
 void smm_asset_set_command_from_plaintext (smm_asset asset, const char *data, size_t len);
 

--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -23,6 +23,7 @@
 #include "smm-asset.h"
 #include "smm-asset-internal.h"
 
+#include <inttypes.h>
 #include <locale.h>
 #include <pthread.h>
 #include <stdarg.h>
@@ -820,10 +821,11 @@ smm_url_path_is_safe (const char *url)
 }
 
 char *
-smm_asset_build_position_url (long long asset_id, double lat, double lon, int alt, uint16_t heading, uint8_t fix)
+smm_asset_build_position_url (long long asset_id, double lat, double lon, int32_t alt, uint16_t heading, uint8_t fix)
 {
     char *page = NULL;
-    if (smm_asprintf_c_locale (&page, "/data/assets/%lld/position/add/?lat=%lf&lon=%lf&alt=%d&heading=%u&fix=%u",
+    if (smm_asprintf_c_locale (&page,
+                               "/data/assets/%lld/position/add/?lat=%lf&lon=%lf&alt=%" PRId32 "&heading=%u&fix=%u",
                                asset_id, lat, lon, alt, heading, fix)
         < 0)
     {
@@ -833,7 +835,7 @@ smm_asset_build_position_url (long long asset_id, double lat, double lon, int al
 }
 
 bool
-smm_asset_report_position (smm_asset asset, double latitude, double longitude, int altitude, uint16_t heading,
+smm_asset_report_position (smm_asset asset, double latitude, double longitude, int32_t altitude, uint16_t heading,
                            uint8_t fix)
 {
     if (!asset)

--- a/src/smm-asset.h
+++ b/src/smm-asset.h
@@ -303,7 +303,7 @@ const char *smm_asset_type (smm_asset asset);
  *
  * @return true if the position was reported to the server
  */
-bool smm_asset_report_position (smm_asset asset, double latitude, double longitude, int altitude, uint16_t heading,
+bool smm_asset_report_position (smm_asset asset, double latitude, double longitude, int32_t altitude, uint16_t heading,
                                 uint8_t fix);
 
 /**

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -1323,6 +1323,21 @@ START_TEST (test_build_position_url_negative_altitude)
 }
 END_TEST
 
+START_TEST (test_build_position_url_altitude_int32_range)
+{
+    /* The altitude parameter is int32_t; the full range must format intact. */
+    char *url = smm_asset_build_position_url (7, -43.5, 172.6, INT32_MIN, 270, 3);
+    ck_assert_ptr_nonnull (url);
+    ck_assert_ptr_nonnull (strstr (url, "alt=-2147483648"));
+    free (url);
+
+    url = smm_asset_build_position_url (7, -43.5, 172.6, INT32_MAX, 270, 3);
+    ck_assert_ptr_nonnull (url);
+    ck_assert_ptr_nonnull (strstr (url, "alt=2147483647"));
+    free (url);
+}
+END_TEST
+
 START_TEST (test_build_position_url_heading_boundary)
 {
     char *url0 = smm_asset_build_position_url (1, 0.0, 0.0, 0, 0, 0);
@@ -1648,6 +1663,7 @@ smm_suite (void)
     TCase *tc_position_ext = tcase_create ("PositionExt");
     tcase_add_test (tc_position_ext, test_build_position_url_values);
     tcase_add_test (tc_position_ext, test_build_position_url_negative_altitude);
+    tcase_add_test (tc_position_ext, test_build_position_url_altitude_int32_range);
     tcase_add_test (tc_position_ext, test_build_position_url_heading_boundary);
     tcase_add_test (tc_position_ext, test_asset_last_goto_pos_not_goto);
     tcase_add_test (tc_position_ext, test_asset_last_goto_pos_goto);


### PR DESCRIPTION
## Description

smm_asset_report_position() took a plain int altitude between the fixed-width uint16_t heading and uint8_t fix. Following the uint32_t change to smm_asset_version_number(), make the width explicit here too so the public API carries only fixed-width integer types (size_t for in-memory counts and buffer lengths is deliberate). The internal URL builder follows, formatting with PRId32.

## Summary by Sourcery

Use fixed-width 32-bit integers for altitude in the asset position reporting API and URL builder.

Bug Fixes:
- Ensure altitude values are correctly handled and formatted across the full int32_t range in position URLs.

Enhancements:
- Standardize the altitude parameter type to int32_t in public and internal APIs for asset position reporting.
- Format altitude in position URLs using the int32_t-specific printf format for portability.

Tests:
- Add coverage to verify position URL formatting preserves INT32_MIN and INT32_MAX altitude values.