### PR TITLE
test: harden the docker tester image build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,42 @@
+# The tester image runs autogen.sh/configure/make itself, so host build
+# artifacts must not leak into the container build: stale objects with fresh
+# timestamps can short-circuit make and link host-toolchain output inside the
+# container. Mirrors .gitignore, plus .git and local-only directories.
+.git
+.claude
+todo
+**/*.o
+**/*.lo
+**/*.la
+**/.libs
+**/.deps
+**/Makefile
+**/Makefile.in
+configure
+config.guess
+config.sub
+config.h
+config.h.in
+config.log
+config.status
+aclocal.m4
+autom4te.cache
+libtool
+ltmain.sh
+m4
+compile
+depcomp
+install-sh
+missing
+ar-lib
+stamp-h1
+test-driver
+compile_commands.json
+clang-tidy.log
+*.tar.gz
+src/smm-asset.pc
+tests/check_smm
+tests/integration_test
+tests/*.log
+tests/*.trs
+**/*~

--- a/tests/Dockerfile.tester
+++ b/tests/Dockerfile.tester
@@ -11,6 +11,7 @@ RUN apt-get update && apt-get install -y \
     libjansson-dev \
     check \
     curl \
+    locales-all \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app


### PR DESCRIPTION
## Description

Add a .dockerignore: the build context is the repo root and the image runs autogen.sh/configure/make itself, so a locally configured tree was copying host build artifacts into the container, where stale objects with fresh timestamps can short-circuit make and link host-toolchain output. autogen.sh runs autoreconf -fvi, so every generated autotools file is recreated inside the image.

Install locales-all in the tester image: the locale-independence test skips its comma-decimal assertions when no such locale is installed, so the in-container run was silently not exercising them. Verified: the image builds clean from a dirty tree and all 131 unit checks pass with de_DE present.

## Summary by Sourcery

Harden the Docker-based test runner image to avoid leaking host build artifacts and ensure locale-dependent tests run in-container.

Tests:
- Ensure the tester Docker image rebuilds artifacts inside the container by ignoring host build outputs via a new .dockerignore.
- Enable execution of locale-dependent unit tests in the tester image by installing the full locales-all package.