### PR TITLE
build: fix cppcheck suppression for to_buffer callback

### DIFF
--- a/src/smm-asset-curl.c
+++ b/src/smm-asset-curl.c
@@ -176,7 +176,7 @@ eat_data (char *ptr __attribute__ ((unused)), size_t size, size_t nmemb, void *u
 
 /* Signature is fixed by libcurl's curl_write_callback; ptr cannot be const. */
 size_t
-/* cppcheck-suppress[constParameterPointer] */
+/* cppcheck-suppress[constParameterCallback] */
 to_buffer (char *ptr, size_t size, size_t nmemb, void *userdata)
 {
     size_t new_bytes;


### PR DESCRIPTION
## Description

cppcheck 2.21 reports constParameterCallback (not constParameterPointer) for the to_buffer libcurl write callback, so the inline suppression did not match and ./check-code.sh failed with --error-exitcode=1. Use the category cppcheck actually emits, matching the eat_data callback above.

The libcurl-compatible callback signature is unchanged.

## Summary by Sourcery

Build:
- Update cppcheck suppression tag on the to_buffer callback so static analysis passes with cppcheck 2.21.