### PR TITLE
fix: guard libcurl write callbacks against size*nmemb overflow

### DIFF
--- a/src/smm-asset-curl.c
+++ b/src/smm-asset-curl.c
@@ -25,6 +25,7 @@
 #include "smm-asset.h"
 
 #include <pthread.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -146,12 +147,31 @@ smm_curl_res_free (struct smm_curl_res_s *res)
     }
 }
 
+/* Compute size*nmemb for a libcurl write callback, guarding against size_t
+ * overflow. Returns false (leaving *out untouched) when the product would
+ * overflow, so the caller can abort the transfer by returning 0. libcurl
+ * normally passes bounded chunks, but the arithmetic must be correct at the
+ * boundary so a wrapped length cannot defeat later size checks. */
+static bool
+smm_curl_chunk_size (size_t size, size_t nmemb, size_t *out)
+{
+    if (size != 0 && nmemb > SIZE_MAX / size)
+        return false;
+    *out = size * nmemb;
+    return true;
+}
+
 /* Signature is fixed by libcurl's curl_write_callback; params cannot be const. */
 static size_t
 /* cppcheck-suppress[constParameterCallback] */
 eat_data (char *ptr __attribute__ ((unused)), size_t size, size_t nmemb, void *userdata __attribute__ ((unused)))
 {
-    return size * nmemb;
+    size_t total;
+    if (!smm_curl_chunk_size (size, nmemb, &total))
+    {
+        return 0;
+    }
+    return total;
 }
 
 /* Signature is fixed by libcurl's curl_write_callback; ptr cannot be const. */
@@ -159,7 +179,11 @@ size_t
 /* cppcheck-suppress[constParameterPointer] */
 to_buffer (char *ptr, size_t size, size_t nmemb, void *userdata)
 {
-    size_t new_bytes = size * nmemb;
+    size_t new_bytes;
+    if (!smm_curl_chunk_size (size, nmemb, &new_bytes))
+    {
+        return 0;
+    }
     struct buffer_s *buf = (struct buffer_s *)userdata;
     /* Refuse to grow the buffer past the cap. Returning a short count makes
      * curl fail the transfer with CURLE_WRITE_ERROR. The comparison is written
@@ -383,8 +407,13 @@ out:
 static size_t
 populate_tidy (char *ptr, size_t size, size_t nmemb, void *userdata)
 {
-    tidyBufAppend ((TidyBuffer *)userdata, ptr, size * nmemb);
-    return size * nmemb;
+    size_t total;
+    if (!smm_curl_chunk_size (size, nmemb, &total))
+    {
+        return 0;
+    }
+    tidyBufAppend ((TidyBuffer *)userdata, ptr, total);
+    return total;
 }
 
 /* Bound on how deeply extract_csrfmiddlewaretoken recurses into the parsed

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -754,6 +754,17 @@ START_TEST (test_to_buffer_rejects_when_full)
 }
 END_TEST
 
+START_TEST (test_to_buffer_rejects_size_overflow)
+{
+    /* size * nmemb would overflow size_t; the callback must refuse the chunk
+     * rather than wrap to a small length that defeats the cap check. */
+    struct buffer_s buf = { NULL, 0 };
+    char chunk[] = "x";
+    ck_assert_uint_eq (to_buffer (chunk, SIZE_MAX, 2, &buf), 0);
+    ck_assert_ptr_null (buf.data);
+}
+END_TEST
+
 START_TEST (test_buffer_reset_discards_content)
 {
     /* The retry loop resets the buffer between attempts so a redirect body
@@ -1648,6 +1659,7 @@ smm_suite (void)
     tcase_add_test (tc_buffer, test_to_buffer_accumulates);
     tcase_add_test (tc_buffer, test_to_buffer_rejects_oversized_chunk);
     tcase_add_test (tc_buffer, test_to_buffer_rejects_when_full);
+    tcase_add_test (tc_buffer, test_to_buffer_rejects_size_overflow);
     tcase_add_test (tc_buffer, test_buffer_reset_discards_content);
     tcase_add_test (tc_buffer, test_buffer_reset_null_safe);
     suite_add_tcase (s, tc_buffer);


### PR DESCRIPTION
## Description

eat_data, to_buffer, and populate_tidy computed size*nmemb before any bounds check. A product that overflows size_t wraps to a small value and can defeat to_buffer's response cap or feed a bogus length to tidyBufAppend. Add a shared smm_curl_chunk_size helper that refuses the chunk when the multiplication would overflow, and have each callback return 0 (aborting the transfer) in that case.

Add a regression test driving to_buffer with an overflowing (size, nmemb).

## Summary by Sourcery

Guard libcurl write callbacks against size_t overflow and add regression coverage for the new behavior.

Bug Fixes:
- Prevent size_t overflow in libcurl write callbacks from bypassing buffer size caps or passing incorrect lengths to tidy.

Tests:
- Add a regression test ensuring to_buffer rejects chunks whose size*nmemb would overflow size_t.