### PR TITLE
ci: split Docker integration into its own job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,14 +21,31 @@ jobs:
       run: ./configure --enable-werror
     - name: make
       run: make
-    - name: Start Docker SMM
+    - name: make check
+      run: make check
+    - name: make distcheck
+      run: make distcheck
+
+  # The Docker integration stack depends on an external SMM image and a live
+  # database, so it is kept in its own job: a flaky or unhealthy external
+  # service fails only this job, not the unit tests, distcheck, or static
+  # analysis above.
+  integration:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v7
+    - name: Start SMM stack
       run: |
         docker compose -f tests/docker-compose.yml up -d smm db
         ./tests/provision.sh
-    - name: Run Tests in Docker
-      run: docker compose -f tests/docker-compose.yml run tester
-    - name: make distcheck
-      run: make distcheck
+    - name: Run integration tests
+      run: docker compose -f tests/docker-compose.yml run --rm tester
+    - name: Dump stack logs on failure
+      if: failure()
+      run: docker compose -f tests/docker-compose.yml logs --no-color
+    - name: Tear down
+      if: always()
+      run: docker compose -f tests/docker-compose.yml down -v
 
   static-analysis:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

The build job ran the Docker integration stack between `make` and `make distcheck`, so an unhealthy external SMM container failed the job before unit tests or distcheck ran, blocking unrelated PRs. Move the stack into a dedicated `integration` job and run `make check` + `make distcheck` directly in `build`, so unit tests, distcheck, and static analysis no longer depend on the external service. Capture `docker compose logs` on failure and always tear the stack down.

## Summary by Sourcery

Split Docker-based integration stack into its own CI job so that unit tests, distcheck, and static analysis no longer depend on external services.

CI:
- Update build workflow to run `make`, `make check`, and `make distcheck` in the main build job without Docker integration.
- Add a separate `integration` job to start the Docker SMM stack, run integration tests, capture Docker logs on failure, and always tear down the stack.