### PR TITLE
ci: pin postgis image by digest

### DIFF
--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -32,7 +32,10 @@ services:
         condition: service_healthy
 
   db:
-    image: postgis/postgis:18-3.6
+    # Pinned by digest for reproducible CI. To refresh:
+    #   docker buildx imagetools inspect postgis/postgis:18-3.6
+    # then update the @sha256 below.
+    image: postgis/postgis:18-3.6@sha256:c48eb5172cfb005ee094a522fe69f27f1ee9e184ba649fe068520a597fa30409
     environment:
       - POSTGRES_DB=smm
       - POSTGRES_USER=smm


### PR DESCRIPTION
## Description

The database image was referenced by the mutable tag postgis:18-3.6, so a rebuild of that tag could change CI behaviour with no change in this repo. Pin it to an immutable @sha256 digest for reproducibility, with a comment on how to refresh it. The SMM image stays on :latest so CI picks up server-side changes automatically; it is isolated in its own job and so cannot block the main build.

## Summary by Sourcery

Build:
- Pin the PostGIS test database image in tests/docker-compose.yml to an immutable sha256 digest and document how to refresh it.