### PR TITLE
ci: disable SECURE_SSL redirect for the SMM test container

### DIFF
--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -7,6 +7,11 @@ services:
       - DB_PASS=smmpass
       - DB_NAME=smm
       - DEBUG=True
+      # The integration test and the healthcheck talk to SMM over plain HTTP on
+      # :8080. Recent images default SECURE_SSL_REDIRECT on (gated by SECURE_SSL),
+      # which 301-redirects every request to https://...:8080 where nothing is
+      # listening for TLS, so the healthcheck and the test both fail. Disable it.
+      - SECURE_SSL=False
       - SECRET_KEY=test-secret-key
       - ALLOWED_HOSTS=localhost,smm
     depends_on:


### PR DESCRIPTION
## Description

The current search-management-map:latest image enables SECURE_SSL_REDIRECT by default (gated by the SECURE_SSL env var), so every request to http://smm:8080 gets a 301 to https://...:8080 where nothing serves TLS. That broke the compose healthcheck (urllib followed the redirect into a TLS handshake error, so the container never became healthy and the bounded provision wait timed out) and would equally break the integration test, which connects over plain HTTP.

Set SECURE_SSL=False for the test container so it serves usable HTTP. Verified end to end against the current :latest: login returns 200, the healthcheck passes, and `docker compose run tester` runs both check_smm and integration_test green.

## Summary by Sourcery

CI:
- Set SECURE_SSL=False for the SMM test container in docker-compose to prevent HTTP requests from being redirected to non-existent HTTPS.