### PR TITLE
build: suppress both cppcheck names for to_buffer callback

### DIFF
--- a/src/smm-asset-curl.c
+++ b/src/smm-asset-curl.c
@@ -176,7 +176,10 @@ eat_data (char *ptr __attribute__ ((unused)), size_t size, size_t nmemb, void *u
 
 /* Signature is fixed by libcurl's curl_write_callback; ptr cannot be const. */
 size_t
-/* cppcheck-suppress[constParameterPointer] */
+/* cppcheck reports this as constParameterPointer or constParameterCallback
+ * depending on its version (CI's cppcheck and a current local one disagree);
+ * suppress both so the gate is reproducible across versions. */
+/* cppcheck-suppress[constParameterPointer,constParameterCallback] */
 to_buffer (char *ptr, size_t size, size_t nmemb, void *userdata)
 {
     size_t new_bytes;


### PR DESCRIPTION
## Description

cppcheck reports the to_buffer write callback as constParameterPointer in CI but constParameterCallback on a current local cppcheck, so suppressing only one name leaves ./check-code.sh failing in the other environment (this broke the static-analysis CI job). Suppress both ids in the inline comment; CI does not enable the information level, so the unmatched name is not reported as an unmatchedSuppression error.

## Summary by Sourcery

Build:
- Adjust cppcheck inline suppression to cover both constParameterPointer and constParameterCallback IDs for the to_buffer write callback, ensuring consistent check-code.sh behavior across environments.