### PR TITLE
feat: add per-connection libcurl timeout setter

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -17,7 +17,7 @@ libsmmasset_internal_la_LIBADD = $(TIDY_LIBS) $(CURL_LIBS) $(JANSSON_LIBS)
 lib_LTLIBRARIES = libsmmasset.la
 libsmmasset_la_SOURCES =
 libsmmasset_la_LIBADD = libsmmasset-internal.la $(TIDY_LIBS) $(CURL_LIBS) $(JANSSON_LIBS)
-libsmmasset_la_LDFLAGS = -no-undefined -version-info 0:0:0 -export-symbols $(srcdir)/libsmmasset.sym
+libsmmasset_la_LDFLAGS = -no-undefined -version-info 1:0:1 -export-symbols $(srcdir)/libsmmasset.sym
 
 EXTRA_DIST = libsmmasset.sym
 

--- a/src/libsmmasset.sym
+++ b/src/libsmmasset.sym
@@ -1,6 +1,7 @@
 smm_asset_connect
 smm_asset_connection_get_state
 smm_asset_connection_login
+smm_asset_connection_timeouts_set
 smm_asset_connection_tls_verify_set
 smm_asset_debugging_set
 smm_asset_free_assets

--- a/src/smm-asset-curl.c
+++ b/src/smm-asset-curl.c
@@ -251,6 +251,8 @@ smm_connection_curl_retrieve_url_r (smm_connection conn, const char *path, const
     struct smm_curl_res_s *res = NULL;
     CURL *curl = NULL;
     bool verify_tls = true;
+    long connect_timeout = 0;
+    long transfer_timeout = 0;
     CURLSH *share = NULL;
     struct curl_slist *headers = NULL;
     bool have_ref = false;
@@ -273,6 +275,8 @@ smm_connection_curl_retrieve_url_r (smm_connection conn, const char *path, const
 
     pthread_mutex_lock (&conn->lock);
     verify_tls = conn->verify_tls;
+    connect_timeout = conn->connect_timeout_secs;
+    transfer_timeout = conn->transfer_timeout_secs;
     share = conn->share;
     conn->refcount++;
     have_ref = true;
@@ -297,8 +301,9 @@ smm_connection_curl_retrieve_url_r (smm_connection conn, const char *path, const
     curl_easy_setopt (curl, CURLOPT_SSL_VERIFYHOST, verify_tls ? 2L : 0L);
     curl_easy_setopt (curl, CURLOPT_COOKIEFILE, "");
     curl_easy_setopt (curl, CURLOPT_FOLLOWLOCATION, 0L);
-    curl_easy_setopt (curl, CURLOPT_CONNECTTIMEOUT, SMM_CURL_CONNECT_TIMEOUT_SECS);
-    curl_easy_setopt (curl, CURLOPT_TIMEOUT, SMM_CURL_TRANSFER_TIMEOUT_SECS);
+    curl_easy_setopt (curl, CURLOPT_CONNECTTIMEOUT,
+                      connect_timeout > 0 ? connect_timeout : SMM_CURL_CONNECT_TIMEOUT_SECS);
+    curl_easy_setopt (curl, CURLOPT_TIMEOUT, transfer_timeout > 0 ? transfer_timeout : SMM_CURL_TRANSFER_TIMEOUT_SECS);
     curl_easy_setopt (curl, CURLOPT_URL, res->full_uri);
 
     if (post_data)

--- a/src/smm-asset-internal.h
+++ b/src/smm-asset-internal.h
@@ -79,6 +79,10 @@ struct smm_connection_s
     char *csrfmiddlewaretoken;
     pthread_mutex_t lock;
     bool verify_tls;
+    /* Per-connection libcurl timeouts in seconds; 0 means use the
+     * SMM_CURL_*_TIMEOUT_SECS defaults. Guarded by lock. */
+    long connect_timeout_secs;
+    long transfer_timeout_secs;
     int refcount;
     bool login_in_progress;
     pthread_cond_t login_cond;

--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -214,6 +214,18 @@ smm_asset_connection_tls_verify_set (smm_connection connection, bool verify)
     }
 }
 
+void
+smm_asset_connection_timeouts_set (smm_connection connection, long connect_secs, long transfer_secs)
+{
+    if (connection != NULL)
+    {
+        pthread_mutex_lock (&connection->lock);
+        connection->connect_timeout_secs = connect_secs;
+        connection->transfer_timeout_secs = transfer_secs;
+        pthread_mutex_unlock (&connection->lock);
+    }
+}
+
 static void
 smm_asset_set_error (smm_asset asset, smm_error_code code, const char *fmt, ...)
 {

--- a/src/smm-asset.h
+++ b/src/smm-asset.h
@@ -241,6 +241,22 @@ bool smm_asset_connection_login (smm_connection connection);
 void smm_asset_connection_tls_verify_set (smm_connection connection, bool verify);
 
 /**
+ * Override the connect and transfer timeouts for this connection.
+ *
+ * Applies to every subsequent request made on the connection. A non-positive
+ * value for either argument keeps the library default (30s connect, 60s
+ * transfer). The defaults suit general use; a latency-sensitive caller (e.g. a
+ * control loop that reports position roughly once a second) can set an
+ * aggressive bound so a single slow or hung endpoint cannot block a call for
+ * the full TCP window.
+ *
+ * @param connection the smm_connection object; NULL is a no-op
+ * @param connect_secs connect timeout in seconds, or <= 0 to keep the default
+ * @param transfer_secs total transfer timeout in seconds, or <= 0 to keep the default
+ */
+void smm_asset_connection_timeouts_set (smm_connection connection, long connect_secs, long transfer_secs);
+
+/**
  * Close a connection to smm and free associated resources.
  *
  * This function should only be called when no other threads are actively

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -1393,6 +1393,35 @@ START_TEST (test_connection_login_fields_initialised)
 }
 END_TEST
 
+START_TEST (test_connection_timeouts_default_unset)
+{
+    /* A fresh connection carries no timeout override (0 == use the defaults). */
+    smm_connection conn = smm_asset_connect ("http://example.com", "user", "pass");
+    ck_assert_ptr_nonnull (conn);
+    ck_assert_int_eq (conn->connect_timeout_secs, 0);
+    ck_assert_int_eq (conn->transfer_timeout_secs, 0);
+    smm_connection_close (conn);
+}
+END_TEST
+
+START_TEST (test_connection_timeouts_set_stores)
+{
+    smm_connection conn = smm_asset_connect ("http://example.com", "user", "pass");
+    ck_assert_ptr_nonnull (conn);
+    smm_asset_connection_timeouts_set (conn, 5, 10);
+    ck_assert_int_eq (conn->connect_timeout_secs, 5);
+    ck_assert_int_eq (conn->transfer_timeout_secs, 10);
+    smm_connection_close (conn);
+}
+END_TEST
+
+START_TEST (test_connection_timeouts_set_null_safe)
+{
+    /* Must not crash on a NULL connection. */
+    smm_asset_connection_timeouts_set (NULL, 5, 10);
+}
+END_TEST
+
 START_TEST (test_get_last_error_null_connection)
 {
     char msg[16] = "sentinel";
@@ -1541,6 +1570,9 @@ smm_suite (void)
     tcase_add_test (tc_conn, test_connect_null_user);
     tcase_add_test (tc_conn, test_connect_null_pass);
     tcase_add_test (tc_conn, test_connection_login_fields_initialised);
+    tcase_add_test (tc_conn, test_connection_timeouts_default_unset);
+    tcase_add_test (tc_conn, test_connection_timeouts_set_stores);
+    tcase_add_test (tc_conn, test_connection_timeouts_set_null_safe);
     tcase_add_test (tc_conn, test_get_last_error_null_connection);
     tcase_add_test (tc_conn, test_get_last_error_initial);
     tcase_add_test (tc_conn, test_asset_get_last_error_null);


### PR DESCRIPTION
## Description

The connect (30s) and transfer (60s) timeouts were hardcoded #defines with no public way to shorten them. A latency-sensitive caller such as cap-fmu, a flight-safety unit that reports position roughly once a second and must stay responsive to RTL/terminate commands, could be blocked for the full TCP window by a single slow or hung endpoint.

Add smm_asset_connection_timeouts_set(connection, connect_secs, transfer_secs), mirroring smm_asset_connection_tls_verify_set: the values are stored on the connection under its lock and applied to every subsequent request via CURLOPT_CONNECTTIMEOUT / CURLOPT_TIMEOUT. A non-positive value keeps the library default, so behaviour is unchanged unless a caller opts in.

Export the new symbol and bump the libtool version-info to 1:0:1 (a backward-compatible interface addition). Add unit tests for the default (unset), the stored override, and NULL-safety.

## Summary by Sourcery

Add configurable per-connection libcurl timeouts to the asset connection API and propagate them through to HTTP requests.

New Features:
- Introduce smm_asset_connection_timeouts_set to allow per-connection overrides of connect and transfer timeouts, falling back to existing defaults when unset.

Enhancements:
- Store per-connection timeout settings on smm_connection and have curl requests honor these values while remaining backward compatible by default.
- Increment the shared library version-info to reflect the new public API symbol.

Tests:
- Add unit tests covering default timeout state, storing custom timeout values, and NULL-safety of the new timeout setter.