### PR TITLE
fix: initialize libcurl global state via pthread_once

### DIFF
--- a/src/smm-asset-curl.c
+++ b/src/smm-asset-curl.c
@@ -39,6 +39,27 @@
 #error No tidy header(s)
 #endif
 
+static pthread_once_t smm_curl_global_once = PTHREAD_ONCE_INIT;
+static CURLcode smm_curl_global_result = CURLE_OK;
+
+static void
+smm_curl_global_init_once (void)
+{
+    smm_curl_global_result = curl_global_init (CURL_GLOBAL_DEFAULT);
+}
+
+/* Initialise libcurl's global state exactly once before any other libcurl API
+ * is used. Thread-safe via pthread_once; returns true on success. There is
+ * deliberately no matching curl_global_cleanup(): as a shared library we cannot
+ * know when the host application is finished with libcurl, and tearing the
+ * global state down underneath it would be unsafe. */
+bool
+smm_curl_global_init (void)
+{
+    pthread_once (&smm_curl_global_once, smm_curl_global_init_once);
+    return smm_curl_global_result == CURLE_OK;
+}
+
 static void
 smm_curl_lock (CURL *handle, curl_lock_data data, curl_lock_access access, void *userptr)
 {

--- a/src/smm-asset-internal.h
+++ b/src/smm-asset-internal.h
@@ -141,6 +141,10 @@ bool smm_connection_state_for_curl_error (CURLcode cres, smm_connection_status *
  * Safe to call on a NULL buffer or one that never received data. */
 void smm_buffer_reset (struct buffer_s *buf);
 
+/* Initialise libcurl's global state once before any other libcurl API use.
+ * Thread-safe (pthread_once); returns true on success. */
+bool smm_curl_global_init (void);
+
 bool smm_connection_share_init (smm_connection conn);
 void smm_connection_share_destroy (smm_connection conn);
 

--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -161,6 +161,17 @@ smm_asset_connect (const char *host, const char *user, const char *pass)
     pthread_mutex_init (&conn->lock, NULL);
     conn->login_in_progress = false;
     pthread_cond_init (&conn->login_cond, NULL);
+
+    /* libcurl's global state must be initialised before any other libcurl call
+     * (curl_share_init and curl_url below, and every request on this
+     * connection). Do it here, the single chokepoint through which every
+     * libcurl-using path is reached. */
+    if (!smm_curl_global_init ())
+    {
+        conn->state = SMM_CONNECTION_FAILURE;
+        return conn;
+    }
+
     if (!smm_connection_share_init (conn))
     {
         smm_connection_unref (conn);

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -1393,6 +1393,15 @@ START_TEST (test_connection_login_fields_initialised)
 }
 END_TEST
 
+START_TEST (test_curl_global_init_succeeds)
+{
+    /* The wrapper initialises libcurl's global state once and is safe to call
+     * repeatedly; both calls must report success. */
+    ck_assert_int_eq (smm_curl_global_init (), true);
+    ck_assert_int_eq (smm_curl_global_init (), true);
+}
+END_TEST
+
 START_TEST (test_connection_timeouts_default_unset)
 {
     /* A fresh connection carries no timeout override (0 == use the defaults). */
@@ -1570,6 +1579,7 @@ smm_suite (void)
     tcase_add_test (tc_conn, test_connect_null_user);
     tcase_add_test (tc_conn, test_connect_null_pass);
     tcase_add_test (tc_conn, test_connection_login_fields_initialised);
+    tcase_add_test (tc_conn, test_curl_global_init_succeeds);
     tcase_add_test (tc_conn, test_connection_timeouts_default_unset);
     tcase_add_test (tc_conn, test_connection_timeouts_set_stores);
     tcase_add_test (tc_conn, test_connection_timeouts_set_null_safe);


### PR DESCRIPTION
## Description

The library used curl_easy_init, curl_share_init, and curl_url but never called curl_global_init, relying on every host application to do so. Add a pthread_once-guarded smm_curl_global_init wrapper that runs curl_global_init(CURL_GLOBAL_DEFAULT) exactly once and caches the result, and call it in smm_asset_connect before curl_share_init / curl_url and any request. On failure the connection reports SMM_CONNECTION_FAILURE.

There is deliberately no curl_global_cleanup: as a shared library we cannot know when the host application is finished with libcurl.

## Summary by Sourcery

Ensure libcurl's global state is initialised exactly once before any other libcurl usage and propagate failures to connection state.

Bug Fixes:
- Guard all libcurl usage behind a pthread_once-based global initialisation wrapper that calls curl_global_init and reports failures via the connection state.

Tests:
- Add a unit test verifying that the libcurl global initialisation wrapper can be called multiple times and always reports success.