### PR TITLE
fix: reject non-http(s) URL schemes in smm_asset_connect

### DIFF
--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -188,8 +188,18 @@ smm_asset_connect (const char *host, const char *user, const char *pass)
         }
         else
         {
-            /* Host looks valid; login happens lazily on the first request. */
-            conn->state = SMM_CONNECTION_NEW;
+            /* Parse succeeded, but libcurl accepts schemes this library cannot
+             * use as an SMM host (ftp, file, ...). Accept only http(s) with a
+             * non-empty host; login still happens lazily on the first request.
+             * libcurl lowercases the scheme, so a plain strcmp is sufficient. */
+            char *scheme = NULL;
+            char *chost = NULL;
+            bool http_ok = curl_url_get (curlu, CURLUPART_SCHEME, &scheme, 0) == CURLUE_OK && scheme
+                           && (strcmp (scheme, "http") == 0 || strcmp (scheme, "https") == 0)
+                           && curl_url_get (curlu, CURLUPART_HOST, &chost, 0) == CURLUE_OK && chost && chost[0] != '\0';
+            conn->state = http_ok ? SMM_CONNECTION_NEW : SMM_CONNECTION_HOST_INVALID;
+            curl_free (scheme);
+            curl_free (chost);
         }
         curl_url_cleanup (curlu);
     }

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -1117,6 +1117,42 @@ START_TEST (test_invalid_host)
 }
 END_TEST
 
+START_TEST (test_connect_ftp_scheme_invalid)
+{
+    smm_connection conn = smm_asset_connect ("ftp://example.com", "user", "pass");
+    ck_assert_ptr_nonnull (conn);
+    ck_assert_int_eq (smm_asset_connection_get_state (conn), SMM_CONNECTION_HOST_INVALID);
+    smm_connection_close (conn);
+}
+END_TEST
+
+START_TEST (test_connect_file_scheme_invalid)
+{
+    smm_connection conn = smm_asset_connect ("file:///tmp/smm", "user", "pass");
+    ck_assert_ptr_nonnull (conn);
+    ck_assert_int_eq (smm_asset_connection_get_state (conn), SMM_CONNECTION_HOST_INVALID);
+    smm_connection_close (conn);
+}
+END_TEST
+
+START_TEST (test_connect_mailto_scheme_invalid)
+{
+    smm_connection conn = smm_asset_connect ("mailto:user@example.com", "user", "pass");
+    ck_assert_ptr_nonnull (conn);
+    ck_assert_int_eq (smm_asset_connection_get_state (conn), SMM_CONNECTION_HOST_INVALID);
+    smm_connection_close (conn);
+}
+END_TEST
+
+START_TEST (test_connect_schemeless_invalid)
+{
+    smm_connection conn = smm_asset_connect ("example.com", "user", "pass");
+    ck_assert_ptr_nonnull (conn);
+    ck_assert_int_eq (smm_asset_connection_get_state (conn), SMM_CONNECTION_HOST_INVALID);
+    smm_connection_close (conn);
+}
+END_TEST
+
 START_TEST (test_connect_null_host)
 {
     smm_connection conn = smm_asset_connect (NULL, "user", "pass");
@@ -1575,6 +1611,10 @@ smm_suite (void)
     tcase_add_test (tc_conn, test_state_for_curl_error_http_error_keeps_state);
     tcase_add_test (tc_conn, test_state_for_curl_error_connection_failures);
     tcase_add_test (tc_conn, test_invalid_host);
+    tcase_add_test (tc_conn, test_connect_ftp_scheme_invalid);
+    tcase_add_test (tc_conn, test_connect_file_scheme_invalid);
+    tcase_add_test (tc_conn, test_connect_mailto_scheme_invalid);
+    tcase_add_test (tc_conn, test_connect_schemeless_invalid);
     tcase_add_test (tc_conn, test_connect_null_host);
     tcase_add_test (tc_conn, test_connect_null_user);
     tcase_add_test (tc_conn, test_connect_null_pass);


### PR DESCRIPTION
## Description

SMM_CONNECTION_HOST_INVALID is documented as covering hosts that are not http(s)://, but smm_asset_connect only checked that libcurl could parse the URL, so schemes the library cannot use as an SMM host (ftp, file, ...) were accepted as SMM_CONNECTION_NEW. After parsing, read CURLUPART_SCHEME and require http or https with a non-empty host; otherwise report SMM_CONNECTION_HOST_INVALID. Trailing-slash and base-path handling are unchanged.

Add tests for ftp://, file://, mailto:, and scheme-less hosts.

## Summary by Sourcery

Validate SMM asset connection URLs to only accept http(s) hosts and treat other schemes as invalid.

Bug Fixes:
- Reject non-http(s) URL schemes and scheme-less hosts in smm_asset_connect by reporting SMM_CONNECTION_HOST_INVALID instead of creating a new connection.

Tests:
- Add connection tests ensuring ftp, file, mailto, and scheme-less URLs are classified as SMM_CONNECTION_HOST_INVALID.