### PR TITLE
fix: don't leak a connection reference when smm_asset_create fails

### DIFF
--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -437,12 +437,21 @@ smm_asset_create (smm_connection conn, const char *name, const char *type, long 
         return NULL;
     }
 
-    asset->conn = conn;
-    smm_connection_ref (conn);
+    /* Duplicate the strings and initialise the mutex before taking the
+     * connection reference, so any failure here frees only the asset: there is
+     * no reference or initialised mutex to unwind. The connection reference is
+     * taken last, after every fallible step, so no failure path can leak it. */
     asset->name = name ? strdup (name) : NULL;
     asset->type = type ? strdup (type) : NULL;
-
     if ((name && !asset->name) || (type && !asset->type))
+    {
+        free (asset->name);
+        free (asset->type);
+        free (asset);
+        return NULL;
+    }
+
+    if (pthread_mutex_init (&asset->lock, NULL) != 0)
     {
         free (asset->name);
         free (asset->type);
@@ -452,8 +461,8 @@ smm_asset_create (smm_connection conn, const char *name, const char *type, long 
 
     asset->asset_id = asset_id;
     asset->asset_type_id = asset_type_id;
-
-    pthread_mutex_init (&asset->lock, NULL);
+    asset->conn = conn;
+    smm_connection_ref (conn);
 
     return asset;
 }
@@ -595,6 +604,11 @@ smm_asset_get_assets (smm_connection connection, smm_assets *assets, size_t *ass
     bool parse_res = smm_parse_assets (connection, buf.data, buf.bytes, assets, assets_count);
     if (!parse_res)
     {
+        /* False positive: the analyzer sees smm_parse_assets's realloc-failure
+         * cleanup unref an asset's connection and assumes that frees
+         * 'connection', but the caller owns a reference for the duration of
+         * this call, so it cannot be freed here. */
+        /* NOLINTNEXTLINE(clang-analyzer-unix.Malloc) */
         smm_connection_set_error (connection, SMM_ERROR_PARSE, "failed to parse /assets/ response");
     }
 

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -466,6 +466,22 @@ START_TEST (test_asset_outlives_connection)
 }
 END_TEST
 
+START_TEST (test_asset_create_balances_connection_ref)
+{
+    /* smm_asset_create takes one connection reference and smm_asset_free_asset
+     * drops it; the count must return to where it started. */
+    smm_connection conn = smm_asset_connect ("http://example.com", "user", "pass");
+    ck_assert_ptr_nonnull (conn);
+    int before = conn->refcount;
+    smm_asset asset = smm_asset_create (conn, "name", "type", 1, 2);
+    ck_assert_ptr_nonnull (asset);
+    ck_assert_int_eq (conn->refcount, before + 1);
+    smm_asset_free_asset (asset);
+    ck_assert_int_eq (conn->refcount, before);
+    smm_connection_close (conn);
+}
+END_TEST
+
 START_TEST (test_report_position_null_conn)
 {
     smm_asset asset = smm_asset_create (NULL, "A", "T", 1, 1);
@@ -1713,6 +1729,7 @@ smm_suite (void)
     tcase_add_test (tc_search, test_search_complete_null_search);
     tcase_add_test (tc_search, test_search_get_waypoints_null_search);
     tcase_add_test (tc_search, test_asset_outlives_connection);
+    tcase_add_test (tc_search, test_asset_create_balances_connection_ref);
     tcase_add_test (tc_search, test_search_sweep_width);
     tcase_add_test (tc_search, test_search_distance_and_length);
     tcase_add_test (tc_search, test_get_search_absolute_url_ignored);


### PR DESCRIPTION
## Description

smm_asset_create took the connection reference before duplicating the name/type strings, so a strdup failure freed the asset and returned NULL without smm_connection_unref — leaking a connection reference that could never reach refcount 0. pthread_mutex_init failure was also unchecked.

Restructure so the connection reference is taken last, after the strdup calls and pthread_mutex_init have all succeeded: every failure path then frees only the asset, with no reference or initialised mutex to unwind, so the leak is eliminated by construction.

Add a ref-balance regression test (create takes one ref, free drops it).

Completing the ref/free pairing lets clang-analyzer model smm_connection_unref freeing the connection during smm_parse_assets's realloc-failure cleanup and wrongly flag a later use in smm_asset_get_assets; the caller owns a reference for the call's duration, so suppress that one false positive with a NOLINT and comment.

## Summary by Sourcery

Fix connection reference handling in asset creation and address related analysis noise.

Bug Fixes:
- Prevent leaking a connection reference when smm_asset_create fails during string duplication or mutex initialization.

Enhancements:
- Add error handling for pthread_mutex_init failure in asset creation.
- Annotate a known false-positive clang-analyzer warning around connection lifetime in smm_asset_get_assets.

Tests:
- Add a regression test to verify smm_asset_create and smm_asset_free_asset correctly balance the connection reference count.