### PR TITLE
fix: require positive asset id (and type_id) when parsing

### DIFF
--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -499,21 +499,35 @@ smm_parse_assets (smm_connection connection, const char *data, size_t len, smm_a
                 {
                     if (strcmp (key, "id") == 0)
                     {
+                        /* Require a positive integer: the id is a server primary
+                         * key substituted into request URLs, so 0 and negative
+                         * values are rejected (have_id stays false, dropping the
+                         * asset) rather than driving requests at nonsensical
+                         * paths such as /data/assets/-1/. */
                         if (json_is_integer (val))
                         {
-                            asset_id = json_integer_value (val);
-                            have_id = true;
+                            json_int_t id_value = json_integer_value (val);
+                            if (id_value > 0)
+                            {
+                                asset_id = id_value;
+                                have_id = true;
+                            }
                         }
                     }
                     else if (strcmp (key, "type_id") == 0)
                     {
-                        /* Validate as an integer, consistent with "id", so a
-                         * non-integer value is left as the -1 sentinel rather
-                         * than silently coerced to 0. type_id is optional, so
-                         * an absent or malformed one does not drop the asset. */
+                        /* Validate as a positive integer, consistent with "id",
+                         * so a non-integer or non-positive value is left as the
+                         * -1 sentinel rather than silently coerced. type_id is
+                         * optional, so an absent or malformed one does not drop
+                         * the asset. */
                         if (json_is_integer (val))
                         {
-                            asset_type_id = json_integer_value (val);
+                            json_int_t type_id_value = json_integer_value (val);
+                            if (type_id_value > 0)
+                            {
+                                asset_type_id = type_id_value;
+                            }
                         }
                     }
                     else if (strcmp (key, "name") == 0)
@@ -527,8 +541,8 @@ smm_parse_assets (smm_connection connection, const char *data, size_t len, smm_a
                 }
                 /* The id is required: it is substituted into request URLs
                  * (position reports, search lookups). Drop any asset that
-                 * lacks a valid integer id rather than issuing requests
-                 * against a sentinel id of -1. */
+                 * lacks a valid positive integer id rather than issuing
+                 * requests against a sentinel id of -1. */
                 if (!have_id)
                 {
                     DEBUG ("asset entry has no valid integer id; skipping\n");

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -202,6 +202,66 @@ START_TEST (test_assets_parsing_drops_only_invalid)
 }
 END_TEST
 
+START_TEST (test_assets_parsing_zero_id)
+{
+    /* id 0 is not a valid server primary key; the asset is dropped. */
+    const char *json = "{\"assets\": [{\"id\": 0, \"type_id\": 2, \"name\": \"Asset 1\", \"type_name\": \"Type 1\"}]}";
+    smm_assets assets;
+    size_t count;
+    bool res = smm_parse_assets (NULL, json, strlen (json), &assets, &count);
+
+    ck_assert_uint_eq (res, true);
+    ck_assert_uint_eq (count, 0);
+    ck_assert_ptr_null (assets);
+}
+END_TEST
+
+START_TEST (test_assets_parsing_negative_id)
+{
+    /* A negative id would build paths like /data/assets/-1/; reject it. */
+    const char *json = "{\"assets\": [{\"id\": -1, \"type_id\": 2, \"name\": \"Asset 1\", \"type_name\": \"Type 1\"}]}";
+    smm_assets assets;
+    size_t count;
+    bool res = smm_parse_assets (NULL, json, strlen (json), &assets, &count);
+
+    ck_assert_uint_eq (res, true);
+    ck_assert_uint_eq (count, 0);
+    ck_assert_ptr_null (assets);
+}
+END_TEST
+
+START_TEST (test_assets_parsing_negative_type_id)
+{
+    /* type_id is optional; a negative value is left at the sentinel and does
+     * not drop an otherwise valid asset. */
+    const char *json = "{\"assets\": [{\"id\": 1, \"type_id\": -2, \"name\": \"Asset 1\", \"type_name\": \"Type 1\"}]}";
+    smm_assets assets;
+    size_t count;
+    bool res = smm_parse_assets (NULL, json, strlen (json), &assets, &count);
+
+    ck_assert_uint_eq (res, true);
+    ck_assert_uint_eq (count, 1);
+    ck_assert_str_eq (smm_asset_name (assets[0]), "Asset 1");
+    smm_asset_free_assets (assets, count);
+}
+END_TEST
+
+START_TEST (test_assets_parsing_zero_id_drops_only_invalid)
+{
+    /* A valid asset is kept even when a sibling entry has a non-positive id. */
+    const char *json = "{\"assets\": [{\"id\": 0, \"name\": \"Bad\"}, {\"id\": 7, \"type_id\": 2, \"name\": \"Good\", "
+                       "\"type_name\": \"Type 1\"}]}";
+    smm_assets assets;
+    size_t count;
+    bool res = smm_parse_assets (NULL, json, strlen (json), &assets, &count);
+
+    ck_assert_uint_eq (res, true);
+    ck_assert_uint_eq (count, 1);
+    ck_assert_str_eq (smm_asset_name (assets[0]), "Good");
+    smm_asset_free_assets (assets, count);
+}
+END_TEST
+
 START_TEST (test_command_parsing_goto)
 {
     const char *json = "{\"action\": \"GOTO\", \"latitude\": -43.5, \"longitude\": 172.6}";
@@ -1696,6 +1756,10 @@ smm_suite (void)
     tcase_add_test (tc_assets, test_assets_parsing_noninteger_id);
     tcase_add_test (tc_assets, test_assets_parsing_noninteger_type_id);
     tcase_add_test (tc_assets, test_assets_parsing_drops_only_invalid);
+    tcase_add_test (tc_assets, test_assets_parsing_zero_id);
+    tcase_add_test (tc_assets, test_assets_parsing_negative_id);
+    tcase_add_test (tc_assets, test_assets_parsing_negative_type_id);
+    tcase_add_test (tc_assets, test_assets_parsing_zero_id_drops_only_invalid);
     tcase_add_test (tc_assets, test_assets_parsing_missing_type_id);
     suite_add_tcase (s, tc_assets);
 


### PR DESCRIPTION
## Description

smm_parse_assets accepted any integer id, including 0 and negatives, which are then substituted into request URLs (position reports, search lookups), producing nonsensical paths such as /data/assets/-1/. Require the id to be a positive integer before marking it valid, so a non-positive id is dropped exactly like a missing or non-integer one and the surrounding parse still succeeds. Apply the same positive check to the optional type_id, leaving a non-positive value at the -1 sentinel rather than dropping the asset.

Add tests for zero/negative id (dropped), negative type_id (tolerated), and drop-only-invalid with a non-positive id sibling.

## Summary by Sourcery

Ensure asset parsing enforces positive identifiers and adds coverage for edge cases.

Bug Fixes:
- Require asset ids to be positive integers before accepting assets for subsequent requests, preventing invalid URLs using zero or negative ids.
- Treat non-positive type_id values as invalid while keeping the asset, leaving the sentinel value instead of propagating bad type identifiers.

Tests:
- Add tests verifying assets with zero or negative ids are dropped, negative type_id is tolerated without dropping the asset, and only invalid entries are skipped when mixed with valid assets.