### PR TITLE
fix: require fresh, in-range coordinates for GOTO commands

### DIFF
--- a/src/smm-asset-internal.h
+++ b/src/smm-asset-internal.h
@@ -172,6 +172,9 @@ char *smm_parse_csrf_token (const char *data, size_t len);
 bool smm_parse_assets (smm_connection connection, const char *data, size_t len, smm_assets *assets,
                        size_t *assets_count);
 bool smm_parse_command (const char *data, size_t len, smm_asset_command *command, double *lat, double *lon);
+/* Parse a command response and commit it to the asset under its lock.
+ * Coordinates are published only for a valid GOTO. Exposed for testing. */
+bool smm_asset_update_command (smm_asset asset, const struct buffer_s *buf);
 bool smm_parse_waypoints (const char *data, size_t len, smm_waypoints *waypoints, size_t *waypoints_count);
 
 smm_asset smm_asset_create (smm_connection connection, const char *name, const char *type, long long asset_id,

--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -693,21 +693,34 @@ smm_parse_command (const char *data, size_t len, smm_asset_command *command, dou
                 res = true;
                 if (strcmp (cmd_str, "GOTO") == 0)
                 {
-                    /* Get lat and long as well. Accept any
-                     * JSON number (real or integer); the
-                     * server normally emits floats but the
-                     * contract does not guarantee it. */
-                    tmp = json_object_get (json_root, "latitude");
-                    if (json_is_number (tmp))
+                    /* A GOTO is only valid with both coordinates present,
+                     * numeric, and in range. Accept any JSON number (real or
+                     * integer); the server normally emits floats but the
+                     * contract does not guarantee it. A malformed GOTO is
+                     * rejected (res false, command left UNKNOWN) so a partial
+                     * parse can never expose stale coordinates via
+                     * smm_asset_last_goto_pos. */
+                    json_t *json_lat = json_object_get (json_root, "latitude");
+                    json_t *json_lon = json_object_get (json_root, "longitude");
+                    if (json_is_number (json_lat) && json_is_number (json_lon))
                     {
-                        *lat = json_number_value (tmp);
+                        double lat_value = json_number_value (json_lat);
+                        double lon_value = json_number_value (json_lon);
+                        if (lat_value >= -90.0 && lat_value <= 90.0 && lon_value >= -180.0 && lon_value <= 180.0)
+                        {
+                            *lat = lat_value;
+                            *lon = lon_value;
+                            *command = SMM_COMMAND_GOTO;
+                        }
+                        else
+                        {
+                            res = false;
+                        }
                     }
-                    tmp = json_object_get (json_root, "longitude");
-                    if (json_is_number (tmp))
+                    else
                     {
-                        *lon = json_number_value (tmp);
+                        res = false;
                     }
-                    *command = SMM_COMMAND_GOTO;
                 }
                 else if (strcmp (cmd_str, "RON") == 0)
                 {
@@ -746,13 +759,25 @@ smm_parse_command (const char *data, size_t len, smm_asset_command *command, dou
     return res;
 }
 
-static bool
+bool
 smm_asset_update_command (smm_asset asset, const struct buffer_s *buf)
 {
-    bool res;
+    /* Parse into locals first, then commit under the lock. Coordinates are
+     * only published for a valid GOTO, so a malformed GOTO (command left
+     * UNKNOWN by smm_parse_command) cannot leave stale coordinates visible
+     * through smm_asset_last_goto_pos. */
+    smm_asset_command command = SMM_COMMAND_UNKNOWN;
+    double lat = 0.0;
+    double lon = 0.0;
+    bool res = smm_parse_command (buf->data, buf->bytes, &command, &lat, &lon);
+
     pthread_mutex_lock (&asset->lock);
-    res = smm_parse_command (buf->data, buf->bytes, &asset->last_command, &asset->last_command_lat,
-                             &asset->last_command_lon);
+    asset->last_command = command;
+    if (command == SMM_COMMAND_GOTO)
+    {
+        asset->last_command_lat = lat;
+        asset->last_command_lon = lon;
+    }
     pthread_mutex_unlock (&asset->lock);
     return res;
 }

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -342,6 +342,94 @@ START_TEST (test_command_parsing_unknown)
 }
 END_TEST
 
+START_TEST (test_command_parsing_goto_missing_latitude)
+{
+    const char *json = "{\"action\": \"GOTO\", \"longitude\": 172.6}";
+    smm_asset_command cmd;
+    double lat = 0, lon = 0;
+    bool res = smm_parse_command (json, strlen (json), &cmd, &lat, &lon);
+
+    ck_assert_uint_eq (res, false);
+    ck_assert_int_ne (cmd, SMM_COMMAND_GOTO);
+}
+END_TEST
+
+START_TEST (test_command_parsing_goto_missing_longitude)
+{
+    const char *json = "{\"action\": \"GOTO\", \"latitude\": -43.5}";
+    smm_asset_command cmd;
+    double lat = 0, lon = 0;
+    bool res = smm_parse_command (json, strlen (json), &cmd, &lat, &lon);
+
+    ck_assert_uint_eq (res, false);
+    ck_assert_int_ne (cmd, SMM_COMMAND_GOTO);
+}
+END_TEST
+
+START_TEST (test_command_parsing_goto_nonnumeric)
+{
+    const char *json = "{\"action\": \"GOTO\", \"latitude\": \"x\", \"longitude\": \"y\"}";
+    smm_asset_command cmd;
+    double lat = 0, lon = 0;
+    bool res = smm_parse_command (json, strlen (json), &cmd, &lat, &lon);
+
+    ck_assert_uint_eq (res, false);
+    ck_assert_int_ne (cmd, SMM_COMMAND_GOTO);
+}
+END_TEST
+
+START_TEST (test_command_parsing_goto_out_of_range_lat)
+{
+    const char *json = "{\"action\": \"GOTO\", \"latitude\": 91.0, \"longitude\": 172.6}";
+    smm_asset_command cmd;
+    double lat = 0, lon = 0;
+    bool res = smm_parse_command (json, strlen (json), &cmd, &lat, &lon);
+
+    ck_assert_uint_eq (res, false);
+    ck_assert_int_ne (cmd, SMM_COMMAND_GOTO);
+}
+END_TEST
+
+START_TEST (test_command_parsing_goto_out_of_range_lon)
+{
+    const char *json = "{\"action\": \"GOTO\", \"latitude\": -43.5, \"longitude\": 181.0}";
+    smm_asset_command cmd;
+    double lat = 0, lon = 0;
+    bool res = smm_parse_command (json, strlen (json), &cmd, &lat, &lon);
+
+    ck_assert_uint_eq (res, false);
+    ck_assert_int_ne (cmd, SMM_COMMAND_GOTO);
+}
+END_TEST
+
+START_TEST (test_goto_then_malformed_goto_clears_position)
+{
+    /* A valid GOTO publishes a position; a following malformed GOTO must not
+     * keep reporting the stale coordinates. */
+    smm_connection conn = smm_asset_connect ("http://example.com", "user", "pass");
+    ck_assert_ptr_nonnull (conn);
+    smm_asset asset = smm_asset_create (conn, "A", "T", 1, 1);
+    ck_assert_ptr_nonnull (asset);
+    double lat = 0, lon = 0;
+
+    char good[] = "{\"action\": \"GOTO\", \"latitude\": -43.5, \"longitude\": 172.6}";
+    struct buffer_s gbuf = { good, strlen (good) };
+    smm_asset_update_command (asset, &gbuf);
+    ck_assert_int_eq (smm_asset_last_goto_pos (asset, &lat, &lon), true);
+    ck_assert_ldouble_eq_tol (lat, -43.5, 0.0001);
+    ck_assert_ldouble_eq_tol (lon, 172.6, 0.0001);
+
+    char bad[] = "{\"action\": \"GOTO\", \"longitude\": 172.6}"; /* missing latitude */
+    struct buffer_s bbuf = { bad, strlen (bad) };
+    smm_asset_update_command (asset, &bbuf);
+    ck_assert_int_eq (smm_asset_last_goto_pos (asset, &lat, &lon), false);
+    ck_assert_int_eq (smm_asset_last_command (asset), SMM_COMMAND_UNKNOWN);
+
+    smm_asset_free_asset (asset);
+    smm_connection_close (conn);
+}
+END_TEST
+
 START_TEST (test_waypoint_parsing)
 {
     const char *json = "{\"features\": [{\"geometry\": {\"coordinates\": [[172.6, -43.5], [172.7, -43.6]]}}]}";
@@ -1774,6 +1862,11 @@ smm_suite (void)
     tcase_add_test (tc_commands, test_command_parsing_mission_complete);
     tcase_add_test (tc_commands, test_command_parsing_continue);
     tcase_add_test (tc_commands, test_command_parsing_unknown);
+    tcase_add_test (tc_commands, test_command_parsing_goto_missing_latitude);
+    tcase_add_test (tc_commands, test_command_parsing_goto_missing_longitude);
+    tcase_add_test (tc_commands, test_command_parsing_goto_nonnumeric);
+    tcase_add_test (tc_commands, test_command_parsing_goto_out_of_range_lat);
+    tcase_add_test (tc_commands, test_command_parsing_goto_out_of_range_lon);
     tcase_add_test (tc_commands, test_command_parsing_no_action_field);
     suite_add_tcase (s, tc_commands);
 
@@ -1842,6 +1935,7 @@ smm_suite (void)
     tcase_add_test (tc_position_ext, test_build_position_url_heading_boundary);
     tcase_add_test (tc_position_ext, test_asset_last_goto_pos_not_goto);
     tcase_add_test (tc_position_ext, test_asset_last_goto_pos_goto);
+    tcase_add_test (tc_position_ext, test_goto_then_malformed_goto_clears_position);
     suite_add_tcase (s, tc_position_ext);
 
     return s;


### PR DESCRIPTION
## Description

smm_parse_command set SMM_COMMAND_GOTO whenever action was "GOTO", even with absent or non-numeric coordinates, and smm_asset_update_command parsed straight into the persistent asset fields. A malformed GOTO could therefore leave stale coordinates in place while smm_asset_last_goto_pos still reported success.

Require both latitude and longitude to be present, numeric, and in range (lat [-90,90], lon [-180,180]) before setting GOTO; a malformed GOTO is rejected (res false, command left UNKNOWN). smm_asset_update_command now parses into locals and commits under the lock, publishing coordinates only for a valid GOTO, so stale coordinates can never be exposed. Expose smm_asset_update_command for testing.

Add parse-level tests (missing/non-numeric/out-of-range coordinates) and an asset-level test that a malformed GOTO after a valid one stops reporting the old position.

## Summary by Sourcery

Tighten GOTO command handling so that only fully valid coordinates are accepted and stale positions are never exposed after malformed commands.

Bug Fixes:
- Reject GOTO commands that lack latitude or longitude, use non-numeric values, or specify out-of-range coordinates, leaving the command as UNKNOWN.
- Ensure asset last GOTO position is cleared and not left with stale coordinates when a malformed GOTO follows a valid one.

Enhancements:
- Refine smm_asset_update_command to parse into local variables and only publish coordinates for a validated GOTO command, and expose it for testing.

Tests:
- Add command parsing tests covering missing, non-numeric, and out-of-range GOTO coordinates.
- Add an asset-level test verifying that a malformed GOTO after a valid one stops reporting the previous GOTO position.