### PR TITLE
fix: validate outbound position and search coordinates

### DIFF
--- a/src/smm-asset-internal.h
+++ b/src/smm-asset-internal.h
@@ -184,6 +184,12 @@ void smm_asset_free_asset (smm_asset assets);
 char *smm_asset_build_position_url (long long asset_id, double lat, double lon, int32_t alt, uint16_t heading,
                                     uint8_t fix);
 
+/* Validate outbound coordinates: finite and within WGS84 ranges
+ * (lat [-90,90], lon [-180,180]). */
+bool smm_coords_valid (double lat, double lon);
+/* As smm_coords_valid, and require heading in [0,359] and fix in {0,2,3}. */
+bool smm_position_inputs_valid (double lat, double lon, uint16_t heading, uint8_t fix);
+
 void smm_asset_set_command_from_plaintext (smm_asset asset, const char *data, size_t len);
 
 smm_search smm_parse_search_json (smm_asset asset, const char *data, size_t len);

--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -25,6 +25,7 @@
 
 #include <inttypes.h>
 #include <locale.h>
+#include <math.h>
 #include <pthread.h>
 #include <stdarg.h>
 #include <stdlib.h>
@@ -906,6 +907,28 @@ smm_url_path_is_safe (const char *url)
     return true;
 }
 
+bool
+smm_coords_valid (double lat, double lon)
+{
+    /* Reject NaN/infinity outright, then bound to valid WGS84 ranges so a bad
+     * coordinate can never be formatted into a request URL as "nan"/"inf" or
+     * sent as an operationally invalid position. */
+    if (!isfinite (lat) || !isfinite (lon))
+        return false;
+    return lat >= -90.0 && lat <= 90.0 && lon >= -180.0 && lon <= 180.0;
+}
+
+bool
+smm_position_inputs_valid (double lat, double lon, uint16_t heading, uint8_t fix)
+{
+    if (!smm_coords_valid (lat, lon))
+        return false;
+    if (heading > 359)
+        return false;
+    /* The public API documents fix as 0 (unknown), 2 (2D), or 3 (3D). */
+    return fix == 0 || fix == 2 || fix == 3;
+}
+
 char *
 smm_asset_build_position_url (long long asset_id, double lat, double lon, int32_t alt, uint16_t heading, uint8_t fix)
 {
@@ -926,6 +949,12 @@ smm_asset_report_position (smm_asset asset, double latitude, double longitude, i
 {
     if (!asset)
     {
+        return false;
+    }
+    if (!smm_position_inputs_valid (latitude, longitude, heading, fix))
+    {
+        smm_asset_set_error (asset, SMM_ERROR_INVALID_ARG,
+                             "invalid position inputs (latitude, longitude, heading, or fix out of range)");
         return false;
     }
     struct buffer_s buf = { NULL, 0 };
@@ -1330,6 +1359,11 @@ smm_asset_get_search (smm_asset asset, double latitude, double longitude)
 {
     if (!asset)
     {
+        return NULL;
+    }
+    if (!smm_coords_valid (latitude, longitude))
+    {
+        smm_asset_set_error (asset, SMM_ERROR_INVALID_ARG, "invalid search coordinates (latitude or longitude)");
         return NULL;
     }
     smm_search search = NULL;

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -3,6 +3,7 @@
 #include <arpa/inet.h>
 #include <check.h>
 #include <locale.h>
+#include <math.h>
 #include <netinet/in.h>
 #include <pthread.h>
 #include <stdio.h>
@@ -575,6 +576,88 @@ START_TEST (test_get_search_null_asset)
 {
     smm_search s = smm_asset_get_search (NULL, -43.5, 172.6);
     ck_assert_ptr_null (s);
+}
+END_TEST
+
+START_TEST (test_coords_valid_accepts_boundaries)
+{
+    ck_assert_int_eq (smm_coords_valid (0.0, 0.0), true);
+    ck_assert_int_eq (smm_coords_valid (90.0, 180.0), true);
+    ck_assert_int_eq (smm_coords_valid (-90.0, -180.0), true);
+}
+END_TEST
+
+START_TEST (test_coords_valid_rejects_nan_inf)
+{
+    ck_assert_int_eq (smm_coords_valid (NAN, 0.0), false);
+    ck_assert_int_eq (smm_coords_valid (0.0, NAN), false);
+    ck_assert_int_eq (smm_coords_valid (INFINITY, 0.0), false);
+    ck_assert_int_eq (smm_coords_valid (0.0, -INFINITY), false);
+}
+END_TEST
+
+START_TEST (test_coords_valid_rejects_out_of_range)
+{
+    ck_assert_int_eq (smm_coords_valid (90.1, 0.0), false);
+    ck_assert_int_eq (smm_coords_valid (-91.0, 0.0), false);
+    ck_assert_int_eq (smm_coords_valid (0.0, 180.1), false);
+    ck_assert_int_eq (smm_coords_valid (0.0, -180.1), false);
+}
+END_TEST
+
+START_TEST (test_position_inputs_valid_heading)
+{
+    ck_assert_int_eq (smm_position_inputs_valid (0.0, 0.0, 359, 3), true);
+    ck_assert_int_eq (smm_position_inputs_valid (0.0, 0.0, 360, 3), false);
+}
+END_TEST
+
+START_TEST (test_position_inputs_valid_fix)
+{
+    ck_assert_int_eq (smm_position_inputs_valid (0.0, 0.0, 0, 0), true);
+    ck_assert_int_eq (smm_position_inputs_valid (0.0, 0.0, 0, 2), true);
+    ck_assert_int_eq (smm_position_inputs_valid (0.0, 0.0, 0, 3), true);
+    ck_assert_int_eq (smm_position_inputs_valid (0.0, 0.0, 0, 1), false);
+    ck_assert_int_eq (smm_position_inputs_valid (0.0, 0.0, 0, 4), false);
+}
+END_TEST
+
+START_TEST (test_position_inputs_valid_full_boundary)
+{
+    ck_assert_int_eq (smm_position_inputs_valid (90.0, 180.0, 359, 3), true);
+    ck_assert_int_eq (smm_position_inputs_valid (-90.0, -180.0, 0, 0), true);
+}
+END_TEST
+
+START_TEST (test_report_position_nan_sets_invalid_arg)
+{
+    /* Invalid inputs are rejected before any network I/O, with the asset's
+     * error recorded. */
+    smm_connection conn = smm_asset_connect ("http://example.com", "user", "pass");
+    ck_assert_ptr_nonnull (conn);
+    smm_asset asset = smm_asset_create (conn, "A", "T", 1, 1);
+    ck_assert_ptr_nonnull (asset);
+
+    ck_assert_int_eq (smm_asset_report_position (asset, NAN, 172.6, 100, 270, 3), false);
+    ck_assert_int_eq (smm_asset_get_last_error (asset, NULL, 0), SMM_ERROR_INVALID_ARG);
+
+    smm_asset_free_asset (asset);
+    smm_connection_close (conn);
+}
+END_TEST
+
+START_TEST (test_get_search_nan_sets_invalid_arg)
+{
+    smm_connection conn = smm_asset_connect ("http://example.com", "user", "pass");
+    ck_assert_ptr_nonnull (conn);
+    smm_asset asset = smm_asset_create (conn, "A", "T", 1, 1);
+    ck_assert_ptr_nonnull (asset);
+
+    ck_assert_ptr_null (smm_asset_get_search (asset, NAN, 172.6));
+    ck_assert_int_eq (smm_asset_get_last_error (asset, NULL, 0), SMM_ERROR_INVALID_ARG);
+
+    smm_asset_free_asset (asset);
+    smm_connection_close (conn);
 }
 END_TEST
 
@@ -1826,6 +1909,14 @@ smm_suite (void)
     tcase_add_test (tc_position, test_last_command_null_asset);
     tcase_add_test (tc_position, test_last_goto_pos_null_asset);
     tcase_add_test (tc_position, test_get_search_null_asset);
+    tcase_add_test (tc_position, test_coords_valid_accepts_boundaries);
+    tcase_add_test (tc_position, test_coords_valid_rejects_nan_inf);
+    tcase_add_test (tc_position, test_coords_valid_rejects_out_of_range);
+    tcase_add_test (tc_position, test_position_inputs_valid_heading);
+    tcase_add_test (tc_position, test_position_inputs_valid_fix);
+    tcase_add_test (tc_position, test_position_inputs_valid_full_boundary);
+    tcase_add_test (tc_position, test_report_position_nan_sets_invalid_arg);
+    tcase_add_test (tc_position, test_get_search_nan_sets_invalid_arg);
     suite_add_tcase (s, tc_position);
 
     tc_csrf = tcase_create ("CSRF");


### PR DESCRIPTION
## Description

smm_asset_report_position and smm_asset_get_search formatted raw double coordinates straight into request URLs without rejecting NaN, infinity, or out-of-range values, so a bad input could produce URLs containing "nan"/"inf" or send operationally invalid positions. heading and fix were also unchecked despite documented ranges.

Add smm_coords_valid (finite, lat [-90,90], lon [-180,180]) and smm_position_inputs_valid (coords plus heading [0,359] and fix in {0,2,3}). Validate at the public entry points before any URL building or network I/O, recording SMM_ERROR_INVALID_ARG on the asset and returning failure. The URL builder stays a pure formatter.

Add tests for the validators (NaN/inf, out-of-range, heading, fix, boundaries) and that report_position/get_search set SMM_ERROR_INVALID_ARG on invalid input.

## Summary by Sourcery

Validate outbound asset position and search coordinates at public API entry points and fail fast on invalid inputs.

Enhancements:
- Add internal helpers to validate coordinates and position inputs against finite WGS84 ranges, heading, and fix constraints.
- Ensure asset position and search operations return failure and record SMM_ERROR_INVALID_ARG when given invalid coordinates or related inputs.

Tests:
- Add unit tests covering coordinate and position input validators for boundary, NaN/inf, and out-of-range values.
- Add tests verifying report_position and get_search set SMM_ERROR_INVALID_ARG and do not proceed when given invalid coordinates.