### PR TITLE
fix: fail malformed or empty route geometry in waypoint parsing

### DIFF
--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -1116,46 +1116,63 @@ smm_parse_waypoints (const char *data, size_t len, smm_waypoints *waypoints, siz
                     json_t *json_geometry = json_object_get (json_search, "geometry");
                     if (json_is_object (json_geometry))
                     {
+                        json_t *json_type = json_object_get (json_geometry, "type");
                         json_t *json_coords = json_object_get (json_geometry, "coordinates");
-                        if (json_is_array (json_coords))
+                        /* The search route is a GeoJSON LineString with at least
+                         * two points. Require the declared type and a coordinate
+                         * array of the minimum length; anything else is a
+                         * malformed route rather than a (possibly empty or
+                         * truncated) success. */
+                        if (json_is_string (json_type) && strcmp (json_string_value (json_type), "LineString") == 0
+                            && json_is_array (json_coords) && json_array_size (json_coords) >= 2)
                         {
+                            bool ok = true;
                             size_t index = 0;
                             json_t *value = NULL;
                             json_array_foreach (json_coords, index, value)
                             {
-                                double lat = 0.0;
-                                double lon = 0.0;
-                                json_t *json_lat = json_array_get (value, 1);
                                 json_t *json_lon = json_array_get (value, 0);
-                                if (!json_is_number (json_lat) || !json_is_number (json_lon))
+                                json_t *json_lat = json_array_get (value, 1);
+                                /* Any malformed tuple fails the whole parse
+                                 * rather than being silently skipped, so a
+                                 * truncated route is never reported. */
+                                if (!json_is_array (value) || !json_is_number (json_lon) || !json_is_number (json_lat))
                                 {
-                                    continue;
+                                    DEBUG ("malformed coordinate tuple at index %zu\n", index);
+                                    ok = false;
+                                    break;
                                 }
-                                lat = json_number_value (json_lat);
-                                lon = json_number_value (json_lon);
+                                double lon = json_number_value (json_lon);
+                                double lat = json_number_value (json_lat);
+                                if (!smm_coords_valid (lat, lon))
+                                {
+                                    DEBUG ("coordinate out of range at index %zu\n", index);
+                                    ok = false;
+                                    break;
+                                }
                                 smm_waypoint new_wp = smm_waypoint_create (lat, lon);
-                                if (new_wp)
+                                if (new_wp == NULL)
                                 {
-                                    smm_waypoint *tmp
-                                        = realloc (*waypoints, (*waypoints_count + 1) * sizeof (smm_waypoint));
-                                    if (tmp)
-                                    {
-                                        *waypoints = tmp;
-                                        (*waypoints)[*waypoints_count] = new_wp;
-                                        *waypoints_count += 1;
-                                    }
-                                    else
-                                    {
-                                        smm_waypoint_free (new_wp);
-                                        smm_waypoints_free (*waypoints, *waypoints_count);
-                                        *waypoints = NULL;
-                                        *waypoints_count = 0;
-                                        json_decref (json_root);
-                                        return false;
-                                    }
+                                    ok = false;
+                                    break;
                                 }
+                                smm_waypoint *tmp
+                                    = realloc (*waypoints, (*waypoints_count + 1) * sizeof (smm_waypoint));
+                                if (tmp == NULL)
+                                {
+                                    smm_waypoint_free (new_wp);
+                                    ok = false;
+                                    break;
+                                }
+                                *waypoints = tmp;
+                                (*waypoints)[*waypoints_count] = new_wp;
+                                *waypoints_count += 1;
                             }
-                            res = true;
+                            res = ok;
+                        }
+                        else
+                        {
+                            DEBUG ("geometry is not a LineString with >= 2 coordinates\n");
                         }
                     }
                 }
@@ -1174,6 +1191,16 @@ smm_parse_waypoints (const char *data, size_t len, smm_waypoints *waypoints, siz
     else
     {
         DEBUG ("JSON Parse Error on line %i: %s\n", json_error.line, json_error.text);
+    }
+
+    if (!res)
+    {
+        /* Discard any partially-built list on failure so a malformed route is
+         * never reported as a truncated or empty success. Safe on the initial
+         * NULL/empty state. */
+        smm_waypoints_free (*waypoints, *waypoints_count);
+        *waypoints = NULL;
+        *waypoints_count = 0;
     }
 
     return res;

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -433,7 +433,8 @@ END_TEST
 
 START_TEST (test_waypoint_parsing)
 {
-    const char *json = "{\"features\": [{\"geometry\": {\"coordinates\": [[172.6, -43.5], [172.7, -43.6]]}}]}";
+    const char *json = "{\"features\": [{\"geometry\": {\"type\": \"LineString\", \"coordinates\": [[172.6, -43.5], "
+                       "[172.7, -43.6]]}}]}";
     smm_waypoints waypoints;
     size_t count;
     bool res = smm_parse_waypoints (json, strlen (json), &waypoints, &count);
@@ -1503,7 +1504,8 @@ START_TEST (test_waypoint_parsing_integer_coords)
 {
     /* GeoJSON coordinates may be integers; json_real_value returns 0 for
      * integer JSON nodes, so we must use json_number_value instead. */
-    const char *json = "{\"features\": [{\"geometry\": {\"coordinates\": [[173, -44], [172, -43]]}}]}";
+    const char *json
+        = "{\"features\": [{\"geometry\": {\"type\": \"LineString\", \"coordinates\": [[173, -44], [172, -43]]}}]}";
     smm_waypoints waypoints;
     size_t count;
     bool res = smm_parse_waypoints (json, strlen (json), &waypoints, &count);
@@ -1544,6 +1546,106 @@ END_TEST
 START_TEST (test_waypoints_parsing_no_features_key)
 {
     const char *json = "{\"type\": \"FeatureCollection\"}";
+    smm_waypoints waypoints = NULL;
+    size_t count = 0;
+    bool res = smm_parse_waypoints (json, strlen (json), &waypoints, &count);
+    ck_assert_uint_eq (res, false);
+    ck_assert_uint_eq (count, 0);
+}
+END_TEST
+
+START_TEST (test_waypoints_parsing_non_linestring)
+{
+    const char *json = "{\"features\": [{\"geometry\": {\"type\": \"Point\", \"coordinates\": [[172.6, -43.5], [172.7, "
+                       "-43.6]]}}]}";
+    smm_waypoints waypoints = NULL;
+    size_t count = 0;
+    bool res = smm_parse_waypoints (json, strlen (json), &waypoints, &count);
+    ck_assert_uint_eq (res, false);
+    ck_assert_uint_eq (count, 0);
+}
+END_TEST
+
+START_TEST (test_waypoints_parsing_single_point)
+{
+    /* A LineString needs at least two points; one is a malformed route. */
+    const char *json
+        = "{\"features\": [{\"geometry\": {\"type\": \"LineString\", \"coordinates\": [[172.6, -43.5]]}}]}";
+    smm_waypoints waypoints = NULL;
+    size_t count = 0;
+    bool res = smm_parse_waypoints (json, strlen (json), &waypoints, &count);
+    ck_assert_uint_eq (res, false);
+    ck_assert_uint_eq (count, 0);
+}
+END_TEST
+
+START_TEST (test_waypoints_parsing_empty_coordinates)
+{
+    const char *json = "{\"features\": [{\"geometry\": {\"type\": \"LineString\", \"coordinates\": []}}]}";
+    smm_waypoints waypoints = NULL;
+    size_t count = 0;
+    bool res = smm_parse_waypoints (json, strlen (json), &waypoints, &count);
+    ck_assert_uint_eq (res, false);
+    ck_assert_uint_eq (count, 0);
+}
+END_TEST
+
+START_TEST (test_waypoints_parsing_non_array_entry)
+{
+    /* Coordinate entries must themselves be [lon, lat] arrays. */
+    const char *json = "{\"features\": [{\"geometry\": {\"type\": \"LineString\", \"coordinates\": [172.6, -43.5]}}]}";
+    smm_waypoints waypoints = NULL;
+    size_t count = 0;
+    bool res = smm_parse_waypoints (json, strlen (json), &waypoints, &count);
+    ck_assert_uint_eq (res, false);
+    ck_assert_uint_eq (count, 0);
+}
+END_TEST
+
+START_TEST (test_waypoints_parsing_tuple_missing_lat)
+{
+    const char *json
+        = "{\"features\": [{\"geometry\": {\"type\": \"LineString\", \"coordinates\": [[172.6], [172.7]]}}]}";
+    smm_waypoints waypoints = NULL;
+    size_t count = 0;
+    bool res = smm_parse_waypoints (json, strlen (json), &waypoints, &count);
+    ck_assert_uint_eq (res, false);
+    ck_assert_uint_eq (count, 0);
+}
+END_TEST
+
+START_TEST (test_waypoints_parsing_nonnumeric_coord)
+{
+    const char *json = "{\"features\": [{\"geometry\": {\"type\": \"LineString\", \"coordinates\": [[\"x\", \"y\"], "
+                       "[\"a\", \"b\"]]}}]}";
+    smm_waypoints waypoints = NULL;
+    size_t count = 0;
+    bool res = smm_parse_waypoints (json, strlen (json), &waypoints, &count);
+    ck_assert_uint_eq (res, false);
+    ck_assert_uint_eq (count, 0);
+}
+END_TEST
+
+START_TEST (test_waypoints_parsing_one_valid_one_invalid)
+{
+    /* A single bad point fails the whole parse rather than returning a
+     * truncated route; the partially-built list must be discarded. */
+    const char *json = "{\"features\": [{\"geometry\": {\"type\": \"LineString\", \"coordinates\": [[172.6, -43.5], "
+                       "[\"x\", \"y\"]]}}]}";
+    smm_waypoints waypoints = NULL;
+    size_t count = 0;
+    bool res = smm_parse_waypoints (json, strlen (json), &waypoints, &count);
+    ck_assert_uint_eq (res, false);
+    ck_assert_uint_eq (count, 0);
+    ck_assert_ptr_null (waypoints);
+}
+END_TEST
+
+START_TEST (test_waypoints_parsing_out_of_range)
+{
+    const char *json
+        = "{\"features\": [{\"geometry\": {\"type\": \"LineString\", \"coordinates\": [[200.0, 0.0], [0.0, "
+          "0.0]]}}]}";
     smm_waypoints waypoints = NULL;
     size_t count = 0;
     bool res = smm_parse_waypoints (json, strlen (json), &waypoints, &count);
@@ -1969,6 +2071,14 @@ smm_suite (void)
     tcase_add_test (tc_waypoints, test_waypoints_parsing_missing_geometry);
     tcase_add_test (tc_waypoints, test_waypoints_parsing_missing_coordinates);
     tcase_add_test (tc_waypoints, test_waypoints_parsing_no_features_key);
+    tcase_add_test (tc_waypoints, test_waypoints_parsing_non_linestring);
+    tcase_add_test (tc_waypoints, test_waypoints_parsing_single_point);
+    tcase_add_test (tc_waypoints, test_waypoints_parsing_empty_coordinates);
+    tcase_add_test (tc_waypoints, test_waypoints_parsing_non_array_entry);
+    tcase_add_test (tc_waypoints, test_waypoints_parsing_tuple_missing_lat);
+    tcase_add_test (tc_waypoints, test_waypoints_parsing_nonnumeric_coord);
+    tcase_add_test (tc_waypoints, test_waypoints_parsing_one_valid_one_invalid);
+    tcase_add_test (tc_waypoints, test_waypoints_parsing_out_of_range);
     suite_add_tcase (s, tc_waypoints);
 
     TCase *tc_search = tcase_create ("Search");


### PR DESCRIPTION
## Description

smm_parse_waypoints silently skipped invalid coordinate tuples and returned success once it reached the end of the array, so malformed GeoJSON could become a truncated route or a "successful" empty one. It also never checked the geometry type or coordinate ranges.

Require geometry.type == "LineString" with at least two coordinates; treat any malformed tuple (non-array entry, missing or non-numeric lon/lat) or out-of-range coordinate as a parse failure rather than skipping it; and discard any partially-built list on failure so the caller never receives a truncated or empty route reported as success.

Update the two positive tests to include the LineString type and add failure tests for non-LineString geometry, single point, empty coordinates, non-array entry, missing/non-numeric coordinates, one-valid-one-invalid, and out-of-range coordinates.

## Summary by Sourcery

Enforce strict validation of GeoJSON LineString route geometry in waypoint parsing so malformed, truncated, or empty routes are reported as failures rather than successes.

Bug Fixes:
- Treat non-LineString geometry, insufficient or empty coordinates, malformed tuples, non-numeric values, and out-of-range coordinates as parse failures instead of silently producing truncated or empty waypoint lists.

Tests:
- Update existing waypoint parsing tests to include the LineString geometry type and add coverage for various malformed and invalid route geometries that must fail parsing.