### PR TITLE
fix: report parse/protocol errors and 404 no-search in get_search

### DIFF
--- a/src/smm-asset-internal.h
+++ b/src/smm-asset-internal.h
@@ -36,6 +36,7 @@ enum http_return_codes
     HTTP_MOVED_PERMANENTLY = 301,
     HTTP_FOUND = 302,
     HTTP_SEE_OTHER = 303,
+    HTTP_NOT_FOUND = 404,
 };
 
 #define SMM_CURL_CONNECT_TIMEOUT_SECS 30L
@@ -193,6 +194,13 @@ bool smm_position_inputs_valid (double lat, double lon, uint16_t heading, uint8_
 void smm_asset_set_command_from_plaintext (smm_asset asset, const char *data, size_t len);
 
 smm_search smm_parse_search_json (smm_asset asset, const char *data, size_t len);
+
+/* Map a closest-search HTTP response to a search result, recording the asset
+ * error on failure. A 404 is the server's documented "no suitable searches"
+ * result: returns NULL with no error. Returns the search (caller owns it) or
+ * NULL. Exposed for testing. */
+smm_search smm_search_from_response (smm_asset asset, long httpcode, const char *content_type, const char *data,
+                                     size_t len);
 
 /* Returns true for the HTTP status codes we treat as followable redirects
  * (301, 302, 303). */

--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -1407,9 +1407,6 @@ smm_parse_search_json (smm_asset asset, const char *data, size_t len)
     {
         const char *url = NULL;
         long long search_id = 0;
-        uint64_t distance = 0;
-        uint64_t length = 0;
-        uint64_t sweep_width = 0;
         json_t *tmp = json_object_get (json_root, "object_url");
         if (tmp)
         {
@@ -1419,24 +1416,51 @@ smm_parse_search_json (smm_asset asset, const char *data, size_t len)
          * generic smm_url_path_is_safe() predicate is kept for other callers
          * but is not the trust boundary for search actions. */
         bool url_ok = smm_search_parse_object_url (url, &search_id);
-        if (url && !url_ok)
-        {
-            DEBUG ("object_url is not a /search/<id>/ path; ignoring\n");
-        }
-        distance = smm_json_number_to_u64 (json_object_get (json_root, "distance"));
-        length = smm_json_number_to_u64 (json_object_get (json_root, "length"));
-        sweep_width = smm_json_number_to_u64 (json_object_get (json_root, "sweep_width"));
         if (url_ok)
         {
+            uint64_t distance = smm_json_number_to_u64 (json_object_get (json_root, "distance"));
+            uint64_t length = smm_json_number_to_u64 (json_object_get (json_root, "length"));
+            uint64_t sweep_width = smm_json_number_to_u64 (json_object_get (json_root, "sweep_width"));
             search = smm_search_create (asset, search_id, length, distance, sweep_width);
+        }
+        else
+        {
+            /* A successful closest-search response always carries a valid
+             * /search/<id>/ object_url; a missing, non-string, or unexpected
+             * one is a protocol violation by the server. */
+            DEBUG ("object_url is missing or not a /search/<id>/ path\n");
+            smm_asset_set_error (asset, SMM_ERROR_PROTOCOL, "search response has a missing or invalid object_url");
         }
         json_decref (json_root);
     }
     else
     {
         DEBUG ("JSON Parse Error on line %i: %s\n", json_error.line, json_error.text);
+        smm_asset_set_error (asset, SMM_ERROR_PARSE, "failed to parse closest search JSON");
     }
     return search;
+}
+
+smm_search
+smm_search_from_response (smm_asset asset, long httpcode, const char *content_type, const char *data, size_t len)
+{
+    if (httpcode == HTTP_NOT_FOUND)
+    {
+        /* The server's documented "no suitable searches exist" result. This is
+         * a clean no-search outcome, not an error. */
+        return NULL;
+    }
+    if (httpcode != HTTP_SUCCESS)
+    {
+        smm_asset_set_error (asset, SMM_ERROR_SERVER, "unexpected HTTP %ld fetching closest search", httpcode);
+        return NULL;
+    }
+    if (!smm_content_type_is_json (content_type))
+    {
+        smm_asset_set_error (asset, SMM_ERROR_PROTOCOL, "non-JSON response to closest search");
+        return NULL;
+    }
+    return smm_parse_search_json (asset, data, len);
 }
 
 smm_search
@@ -1451,7 +1475,6 @@ smm_asset_get_search (smm_asset asset, double latitude, double longitude)
         smm_asset_set_error (asset, SMM_ERROR_INVALID_ARG, "invalid search coordinates (latitude or longitude)");
         return NULL;
     }
-    smm_search search = NULL;
     struct buffer_s buf = { NULL, 0 };
 
     char *page = NULL;
@@ -1464,26 +1487,15 @@ smm_asset_get_search (smm_asset asset, double latitude, double longitude)
     smm_asset_clear_error (asset);
 
     struct smm_curl_res_s *res = smm_connection_curl_retrieve_url (asset->conn, page, NULL, &buf, false);
+    free (page);
     if (res == NULL)
     {
         smm_asset_set_error (asset, SMM_ERROR_NETWORK, "network failure fetching closest search");
-        free (page);
-        return NULL;
-    }
-    if (!(res->success && res->httpcode == HTTP_SUCCESS))
-    {
-        smm_asset_set_error (asset, SMM_ERROR_SERVER, "unexpected HTTP %ld fetching closest search", res->httpcode);
-        smm_curl_res_free (res);
-        free (page);
         free (buf.data);
         return NULL;
     }
-    free (page);
 
-    if (smm_content_type_is_json (res->content_type))
-    {
-        search = smm_parse_search_json (asset, buf.data, buf.bytes);
-    }
+    smm_search search = smm_search_from_response (asset, res->httpcode, res->content_type, buf.data, buf.bytes);
     smm_curl_res_free (res);
     free (buf.data);
     return search;

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -541,6 +541,109 @@ END_TEST
 START_TEST (test_get_search_zero_id_rejected) { ck_assert_ptr_null (parse_search_with_object_url ("/search/0/")); }
 END_TEST
 
+static smm_asset
+make_connected_test_asset (smm_connection *conn_out)
+{
+    smm_connection conn = smm_asset_connect ("http://example.com", "user", "pass");
+    ck_assert_ptr_nonnull (conn);
+    smm_asset asset = smm_asset_create (conn, "A", "T", 1, 1);
+    ck_assert_ptr_nonnull (asset);
+    *conn_out = conn;
+    return asset;
+}
+
+START_TEST (test_search_from_response_404_is_clean_no_search)
+{
+    smm_connection conn;
+    smm_asset asset = make_connected_test_asset (&conn);
+    const char *body = "No suitable searches exist";
+    smm_search search = smm_search_from_response (asset, 404, "text/plain", body, strlen (body));
+    ck_assert_ptr_null (search);
+    ck_assert_int_eq (smm_asset_get_last_error (asset, NULL, 0), SMM_ERROR_NONE);
+    smm_asset_free_asset (asset);
+    smm_connection_close (conn);
+}
+END_TEST
+
+START_TEST (test_search_from_response_non_json_200_sets_protocol)
+{
+    smm_connection conn;
+    smm_asset asset = make_connected_test_asset (&conn);
+    const char *body = "<html>not json</html>";
+    smm_search search = smm_search_from_response (asset, 200, "text/html", body, strlen (body));
+    ck_assert_ptr_null (search);
+    ck_assert_int_eq (smm_asset_get_last_error (asset, NULL, 0), SMM_ERROR_PROTOCOL);
+    smm_asset_free_asset (asset);
+    smm_connection_close (conn);
+}
+END_TEST
+
+START_TEST (test_search_from_response_invalid_json_sets_parse)
+{
+    smm_connection conn;
+    smm_asset asset = make_connected_test_asset (&conn);
+    const char *body = "not json at all";
+    smm_search search = smm_search_from_response (asset, 200, "application/json", body, strlen (body));
+    ck_assert_ptr_null (search);
+    ck_assert_int_eq (smm_asset_get_last_error (asset, NULL, 0), SMM_ERROR_PARSE);
+    smm_asset_free_asset (asset);
+    smm_connection_close (conn);
+}
+END_TEST
+
+START_TEST (test_search_from_response_missing_object_url_sets_protocol)
+{
+    smm_connection conn;
+    smm_asset asset = make_connected_test_asset (&conn);
+    const char *body = "{\"distance\": 10, \"length\": 100, \"sweep_width\": 50}";
+    smm_search search = smm_search_from_response (asset, 200, "application/json", body, strlen (body));
+    ck_assert_ptr_null (search);
+    ck_assert_int_eq (smm_asset_get_last_error (asset, NULL, 0), SMM_ERROR_PROTOCOL);
+    smm_asset_free_asset (asset);
+    smm_connection_close (conn);
+}
+END_TEST
+
+START_TEST (test_search_from_response_unsafe_object_url_sets_protocol)
+{
+    smm_connection conn;
+    smm_asset asset = make_connected_test_asset (&conn);
+    const char *body
+        = "{\"object_url\": \"/accounts/logout/\", \"distance\": 10, \"length\": 100, \"sweep_width\": 50}";
+    smm_search search = smm_search_from_response (asset, 200, "application/json", body, strlen (body));
+    ck_assert_ptr_null (search);
+    ck_assert_int_eq (smm_asset_get_last_error (asset, NULL, 0), SMM_ERROR_PROTOCOL);
+    smm_asset_free_asset (asset);
+    smm_connection_close (conn);
+}
+END_TEST
+
+START_TEST (test_search_from_response_valid_returns_search)
+{
+    smm_connection conn;
+    smm_asset asset = make_connected_test_asset (&conn);
+    const char *body = "{\"object_url\": \"/search/1/\", \"distance\": 10, \"length\": 100, \"sweep_width\": 50}";
+    smm_search search = smm_search_from_response (asset, 200, "application/json", body, strlen (body));
+    ck_assert_ptr_nonnull (search);
+    ck_assert_int_eq (smm_asset_get_last_error (asset, NULL, 0), SMM_ERROR_NONE);
+    smm_search_destroy (search);
+    smm_asset_free_asset (asset);
+    smm_connection_close (conn);
+}
+END_TEST
+
+START_TEST (test_search_from_response_server_error_sets_server)
+{
+    smm_connection conn;
+    smm_asset asset = make_connected_test_asset (&conn);
+    smm_search search = smm_search_from_response (asset, 500, "text/plain", "oops", 4);
+    ck_assert_ptr_null (search);
+    ck_assert_int_eq (smm_asset_get_last_error (asset, NULL, 0), SMM_ERROR_SERVER);
+    smm_asset_free_asset (asset);
+    smm_connection_close (conn);
+}
+END_TEST
+
 START_TEST (test_get_search_real_numeric_fields)
 {
     /* The server contract does not guarantee integers; a real-valued
@@ -2160,6 +2263,13 @@ smm_suite (void)
     tcase_add_test (tc_search, test_get_search_non_numeric_id_rejected);
     tcase_add_test (tc_search, test_get_search_negative_id_rejected);
     tcase_add_test (tc_search, test_get_search_zero_id_rejected);
+    tcase_add_test (tc_search, test_search_from_response_404_is_clean_no_search);
+    tcase_add_test (tc_search, test_search_from_response_non_json_200_sets_protocol);
+    tcase_add_test (tc_search, test_search_from_response_invalid_json_sets_parse);
+    tcase_add_test (tc_search, test_search_from_response_missing_object_url_sets_protocol);
+    tcase_add_test (tc_search, test_search_from_response_unsafe_object_url_sets_protocol);
+    tcase_add_test (tc_search, test_search_from_response_valid_returns_search);
+    tcase_add_test (tc_search, test_search_from_response_server_error_sets_server);
     suite_add_tcase (s, tc_search);
 
     TCase *tc_url = tcase_create ("URL");


### PR DESCRIPTION
## Description

smm_asset_get_search returned NULL for several server-response failures without recording an asset error, so callers could not distinguish "no search available" from a malformed JSON, an unsafe object_url, or a non-JSON success. It also reported the server's documented "no suitable searches" 404 as SMM_ERROR_SERVER.

Per the server contract (find_next_search returns 200 + JSON with object_url when a search exists, or 404 "No suitable searches exist" otherwise), add a testable smm_search_from_response helper:
  - 404 -> clean no-search: NULL with no error
  - other non-200 -> SMM_ERROR_SERVER
  - 200 non-JSON -> SMM_ERROR_PROTOCOL
  - 200 JSON -> smm_parse_search_json smm_parse_search_json now records SMM_ERROR_PARSE for unparseable JSON and SMM_ERROR_PROTOCOL for a missing or non-/search/<id>/ object_url. smm_asset_get_search delegates response handling to the helper (and frees the response buffer on the network-failure path).

Add unit tests covering 404, non-JSON 200, invalid JSON, missing and unsafe object_url, a valid response, and a 500.

## Summary by Sourcery

Clarify closest-search response handling so asset errors distinguish protocol/parse/server failures from the documented 404 no-search case.

Bug Fixes:
- Treat the server’s 404 "no suitable searches" response for closest search as a clean no-search outcome without setting an error.
- Record appropriate asset errors for malformed JSON, non-JSON 200 responses, invalid or missing /search/<id>/ object_url, and unexpected non-200 HTTP codes when fetching searches.

Enhancements:
- Introduce a reusable smm_search_from_response helper to map HTTP responses to search results and centralize error reporting.
- Tighten smm_parse_search_json to enforce a valid /search/<id>/ object_url as part of a successful closest-search response and to classify parse vs protocol failures.

Tests:
- Add unit tests covering 404 no-search, non-JSON 200 responses, invalid JSON bodies, missing and unsafe object_url values, valid search responses, and 500 server errors for closest-search handling.