### PR TITLE
docs: fix error paths in README usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,16 @@ Basic API usage example
 
 int main(int argc, char *argv[])
 {
-	smm_assets assets;
-	size_t assets_count;
+	smm_assets assets = NULL;
+	size_t assets_count = 0;
 	smm_asset asset = NULL;
 
 	smm_connection conn = smm_asset_connect ("http://localhost/", "asset", "assetpassword");
+	if (conn == NULL)
+	{
+		return 1;
+	}
+
 	if (smm_asset_get_assets (conn, &assets, &assets_count))
 	{
 		for (size_t i = 0; i < assets_count; i++)
@@ -82,6 +87,8 @@ int main(int argc, char *argv[])
 
 	smm_asset_free_assets (assets, assets_count);
 	smm_connection_close (conn);
+
+	return 0;
 }
 ```
 


### PR DESCRIPTION
## Description

The usage example declared assets/assets_count uninitialised, never checked smm_asset_connect for NULL, and called smm_asset_free_assets unconditionally. Initialise assets = NULL / assets_count = 0, return early when the connection is NULL, and add a trailing return 0 so the cleanup is always reached with valid values. Verified the snippet compiles and links against the library.

## Summary by Sourcery

Documentation:
- Update README usage example to initialize asset variables, check for NULL connections, and return a proper status code.