### PR TITLE
fix: report asset position via POST with CSRF token

### DIFF
--- a/src/smm-asset-curl.c
+++ b/src/smm-asset-curl.c
@@ -264,6 +264,71 @@ smm_buffer_reset (struct buffer_s *buf)
     }
 }
 
+/* If a libcurl CURLINFO_COOKIELIST line names the wanted cookie, return a copy
+ * of its value, else NULL. The line is Netscape format with seven tab-separated
+ * fields: domain, flag, path, secure, expiry, name, value. */
+static char *
+smm_cookie_value_if_name (const char *line, const char *name)
+{
+    const char *fields[7];
+    int n = 0;
+    const char *p = line;
+
+    fields[n++] = p;
+    while (n < 7 && (p = strchr (p, '\t')) != NULL)
+    {
+        p++;
+        fields[n++] = p;
+    }
+    if (n < 7)
+    {
+        return NULL;
+    }
+
+    /* The name occupies [fields[5], fields[6] - 1) (the byte before the value
+     * is the separating tab); the value runs from fields[6] to end of line. */
+    size_t name_len = (size_t)(fields[6] - 1 - fields[5]);
+    if (strlen (name) != name_len || strncmp (fields[5], name, name_len) != 0)
+    {
+        return NULL;
+    }
+    return strdup (fields[6]);
+}
+
+/* Refresh the connection's stored CSRF token from the csrftoken cookie in the
+ * handle's cookie jar. Django rotates the CSRF token on login, so the token
+ * captured from the login page goes stale; tracking the cookie after every
+ * request keeps a token that matches the cookie the server will check. */
+static void
+smm_connection_update_csrf_from_cookies (smm_connection conn, CURL *curl)
+{
+    struct curl_slist *cookies = NULL;
+    if (curl_easy_getinfo (curl, CURLINFO_COOKIELIST, &cookies) != CURLE_OK)
+    {
+        return;
+    }
+
+    char *token = NULL;
+    for (const struct curl_slist *c = cookies; c != NULL; c = c->next)
+    {
+        char *value = smm_cookie_value_if_name (c->data, "csrftoken");
+        if (value)
+        {
+            free (token);
+            token = value;
+        }
+    }
+    curl_slist_free_all (cookies);
+
+    if (token)
+    {
+        pthread_mutex_lock (&conn->lock);
+        free (conn->csrfmiddlewaretoken);
+        conn->csrfmiddlewaretoken = token;
+        pthread_mutex_unlock (&conn->lock);
+    }
+}
+
 struct smm_curl_res_s *
 smm_connection_curl_retrieve_url_r (smm_connection conn, const char *path, const char *post_data,
                                     size_t (*write_func) (char *ptr, size_t size, size_t nmemb, void *userdata),
@@ -276,6 +341,7 @@ smm_connection_curl_retrieve_url_r (smm_connection conn, const char *path, const
     long transfer_timeout = 0;
     CURLSH *share = NULL;
     struct curl_slist *headers = NULL;
+    char *csrf_token = NULL;
     bool have_ref = false;
 
     /* Never log post_data: for the login request it carries the user's
@@ -299,6 +365,11 @@ smm_connection_curl_retrieve_url_r (smm_connection conn, const char *path, const
     connect_timeout = conn->connect_timeout_secs;
     transfer_timeout = conn->transfer_timeout_secs;
     share = conn->share;
+    /* Snapshot the current CSRF token so a POST can present it as a header. */
+    if (post_data && conn->csrfmiddlewaretoken)
+    {
+        csrf_token = strdup (conn->csrfmiddlewaretoken);
+    }
     conn->refcount++;
     have_ref = true;
 
@@ -354,6 +425,21 @@ smm_connection_curl_retrieve_url_r (smm_connection conn, const char *path, const
     if (json)
     {
         headers = curl_slist_append (headers, "Accept: application/json");
+    }
+    /* Present the CSRF token as a header on POSTs. Using the header (rather than
+     * a form field) means a request retried after a lazy login re-reads the
+     * freshly rotated token, instead of resending a body fixed before login. */
+    if (csrf_token)
+    {
+        char *csrf_header = NULL;
+        if (asprintf (&csrf_header, "X-CSRFToken: %s", csrf_token) >= 0)
+        {
+            headers = curl_slist_append (headers, csrf_header);
+            free (csrf_header);
+        }
+    }
+    if (headers)
+    {
         curl_easy_setopt (curl, CURLOPT_HTTPHEADER, headers);
     }
 
@@ -361,6 +447,10 @@ smm_connection_curl_retrieve_url_r (smm_connection conn, const char *path, const
     CURLcode cres = curl_easy_perform (curl);
     DEBUG ("curl returned %i\n", cres);
     res->success = (cres == CURLE_OK);
+
+    /* Keep the stored CSRF token current with the cookie jar (the server may
+     * set or rotate the csrftoken cookie on any response, notably login). */
+    smm_connection_update_csrf_from_cookies (conn, curl);
 
     if (cres != CURLE_OK)
     {
@@ -410,6 +500,7 @@ smm_connection_curl_retrieve_url_r (smm_connection conn, const char *path, const
     }
 
 out:
+    free (csrf_token);
     if (headers)
     {
         curl_slist_free_all (headers);

--- a/src/smm-asset-internal.h
+++ b/src/smm-asset-internal.h
@@ -182,8 +182,7 @@ smm_asset smm_asset_create (smm_connection connection, const char *name, const c
                             long long asset_type_id);
 void smm_asset_free_asset (smm_asset assets);
 
-char *smm_asset_build_position_url (long long asset_id, double lat, double lon, int32_t alt, uint16_t heading,
-                                    uint8_t fix);
+char *smm_asset_build_position_body (double lat, double lon, int32_t alt, uint16_t heading, uint8_t fix);
 
 /* Validate outbound coordinates: finite and within WGS84 ranges
  * (lat [-90,90], lon [-180,180]). */

--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -931,17 +931,18 @@ smm_position_inputs_valid (double lat, double lon, uint16_t heading, uint8_t fix
 }
 
 char *
-smm_asset_build_position_url (long long asset_id, double lat, double lon, int32_t alt, uint16_t heading, uint8_t fix)
+smm_asset_build_position_body (double lat, double lon, int32_t alt, uint16_t heading, uint8_t fix)
 {
-    char *page = NULL;
-    if (smm_asprintf_c_locale (&page,
-                               "/data/assets/%lld/position/add/?lat=%lf&lon=%lf&alt=%" PRId32 "&heading=%u&fix=%u",
-                               asset_id, lat, lon, alt, heading, fix)
+    char *body = NULL;
+    /* application/x-www-form-urlencoded body for the position POST. The
+     * coordinates are formatted in the C locale so the decimal separator is
+     * always '.'. */
+    if (smm_asprintf_c_locale (&body, "lat=%lf&lon=%lf&alt=%" PRId32 "&heading=%u&fix=%u", lat, lon, alt, heading, fix)
         < 0)
     {
         return NULL;
     }
-    return page;
+    return body;
 }
 
 bool
@@ -960,30 +961,38 @@ smm_asset_report_position (smm_asset asset, double latitude, double longitude, i
     }
     struct buffer_s buf = { NULL, 0 };
 
-    char *page = smm_asset_build_position_url (asset->asset_id, latitude, longitude, altitude, heading, fix);
-    if (page == NULL)
+    /* The endpoint is POST-only (it mutates state); the position fields go in
+     * the request body and the CSRF token is added as a header by the curl
+     * layer for session-authenticated connections. */
+    char *body = smm_asset_build_position_body (latitude, longitude, altitude, heading, fix);
+    if (body == NULL)
     {
+        return false;
+    }
+    char *page = NULL;
+    if (asprintf (&page, "/data/assets/%lld/position/add/", asset->asset_id) < 0)
+    {
+        free (body);
         return false;
     }
     smm_asset_clear_error (asset);
 
-    struct smm_curl_res_s *res = smm_connection_curl_retrieve_url (asset->conn, page, NULL, &buf, false);
+    struct smm_curl_res_s *res = smm_connection_curl_retrieve_url (asset->conn, page, body, &buf, false);
+    free (page);
+    free (body);
     if (res == NULL)
     {
         smm_asset_set_error (asset, SMM_ERROR_NETWORK, "network failure reporting position");
-        free (page);
+        free (buf.data);
         return false;
     }
     if (!(res->success && res->httpcode == HTTP_SUCCESS))
     {
         smm_asset_set_error (asset, SMM_ERROR_SERVER, "unexpected HTTP %ld from position report", res->httpcode);
         smm_curl_res_free (res);
-        free (page);
         free (buf.data);
         return false;
     }
-
-    free (page);
 
     /* if json data was returned, update the current action */
     if (smm_content_type_is_json (res->content_type))

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -931,26 +931,26 @@ START_TEST (test_set_command_from_plaintext_with_trailing)
 }
 END_TEST
 
-START_TEST (test_build_position_url_heading)
+START_TEST (test_build_position_body_heading)
 {
-    char *url = smm_asset_build_position_url (42, -43.5, 172.6, 100, 270, 3);
-    ck_assert_ptr_nonnull (url);
-    ck_assert_ptr_nonnull (strstr (url, "heading="));
-    ck_assert_ptr_null (strstr (url, "bearing="));
-    free (url);
+    char *body = smm_asset_build_position_body (-43.5, 172.6, 100, 270, 3);
+    ck_assert_ptr_nonnull (body);
+    ck_assert_ptr_nonnull (strstr (body, "heading="));
+    ck_assert_ptr_null (strstr (body, "bearing="));
+    free (body);
 }
 END_TEST
 
 /* Coordinates must always use '.' as the decimal separator regardless of the
  * caller's LC_NUMERIC. We assert this under the current locale (always) and,
  * when a comma-decimal locale is installed, under that locale too. */
-START_TEST (test_build_position_url_locale_independent)
+START_TEST (test_build_position_body_locale_independent)
 {
-    char *url = smm_asset_build_position_url (42, -43.5, 172.6, 100, 270, 3);
-    ck_assert_ptr_nonnull (url);
-    ck_assert_ptr_nonnull (strstr (url, "lat=-43.500000"));
-    ck_assert_ptr_nonnull (strstr (url, "lon=172.600000"));
-    free (url);
+    char *body = smm_asset_build_position_body (-43.5, 172.6, 100, 270, 3);
+    ck_assert_ptr_nonnull (body);
+    ck_assert_ptr_nonnull (strstr (body, "lat=-43.500000"));
+    ck_assert_ptr_nonnull (strstr (body, "lon=172.600000"));
+    free (body);
 
     /* Try a few locales that format decimals with a comma. If none are
      * installed (e.g. a minimal CI image) the loop is a no-op and the
@@ -964,14 +964,14 @@ START_TEST (test_build_position_url_locale_independent)
             continue;
         }
         locale_t old = uselocale (loc);
-        url = smm_asset_build_position_url (42, -43.5, 172.6, 100, 270, 3);
+        body = smm_asset_build_position_body (-43.5, 172.6, 100, 270, 3);
         uselocale (old);
         freelocale (loc);
 
-        ck_assert_ptr_nonnull (url);
-        ck_assert_ptr_nonnull (strstr (url, "lat=-43.500000"));
-        ck_assert_ptr_null (strstr (url, ","));
-        free (url);
+        ck_assert_ptr_nonnull (body);
+        ck_assert_ptr_nonnull (strstr (body, "lat=-43.500000"));
+        ck_assert_ptr_null (strstr (body, ","));
+        free (body);
         break;
     }
 }
@@ -1852,55 +1852,55 @@ START_TEST (test_search_distance_and_length)
 }
 END_TEST
 
-START_TEST (test_build_position_url_values)
+START_TEST (test_build_position_body_values)
 {
-    char *url = smm_asset_build_position_url (7, -43.5, 172.6, 35, 270, 3);
-    ck_assert_ptr_nonnull (url);
-    ck_assert_ptr_nonnull (strstr (url, "assets/7/"));
-    ck_assert_ptr_nonnull (strstr (url, "alt=35"));
-    ck_assert_ptr_nonnull (strstr (url, "heading=270"));
-    ck_assert_ptr_nonnull (strstr (url, "fix=3"));
-    free (url);
+    char *body = smm_asset_build_position_body (-43.5, 172.6, 35, 270, 3);
+    ck_assert_ptr_nonnull (body);
+    ck_assert_ptr_nonnull (strstr (body, "lat=-43.500000"));
+    ck_assert_ptr_nonnull (strstr (body, "alt=35"));
+    ck_assert_ptr_nonnull (strstr (body, "heading=270"));
+    ck_assert_ptr_nonnull (strstr (body, "fix=3"));
+    free (body);
 }
 END_TEST
 
-START_TEST (test_build_position_url_negative_altitude)
+START_TEST (test_build_position_body_negative_altitude)
 {
     /* Altitude may be below mean sea level; it must be sent as a signed value,
      * not wrapped through an unsigned conversion. */
-    char *url = smm_asset_build_position_url (7, -43.5, 172.6, -12, 270, 3);
-    ck_assert_ptr_nonnull (url);
-    ck_assert_ptr_nonnull (strstr (url, "alt=-12"));
-    free (url);
+    char *body = smm_asset_build_position_body (-43.5, 172.6, -12, 270, 3);
+    ck_assert_ptr_nonnull (body);
+    ck_assert_ptr_nonnull (strstr (body, "alt=-12"));
+    free (body);
 }
 END_TEST
 
-START_TEST (test_build_position_url_altitude_int32_range)
+START_TEST (test_build_position_body_altitude_int32_range)
 {
     /* The altitude parameter is int32_t; the full range must format intact. */
-    char *url = smm_asset_build_position_url (7, -43.5, 172.6, INT32_MIN, 270, 3);
-    ck_assert_ptr_nonnull (url);
-    ck_assert_ptr_nonnull (strstr (url, "alt=-2147483648"));
-    free (url);
+    char *body = smm_asset_build_position_body (-43.5, 172.6, INT32_MIN, 270, 3);
+    ck_assert_ptr_nonnull (body);
+    ck_assert_ptr_nonnull (strstr (body, "alt=-2147483648"));
+    free (body);
 
-    url = smm_asset_build_position_url (7, -43.5, 172.6, INT32_MAX, 270, 3);
-    ck_assert_ptr_nonnull (url);
-    ck_assert_ptr_nonnull (strstr (url, "alt=2147483647"));
-    free (url);
+    body = smm_asset_build_position_body (-43.5, 172.6, INT32_MAX, 270, 3);
+    ck_assert_ptr_nonnull (body);
+    ck_assert_ptr_nonnull (strstr (body, "alt=2147483647"));
+    free (body);
 }
 END_TEST
 
-START_TEST (test_build_position_url_heading_boundary)
+START_TEST (test_build_position_body_heading_boundary)
 {
-    char *url0 = smm_asset_build_position_url (1, 0.0, 0.0, 0, 0, 0);
-    ck_assert_ptr_nonnull (url0);
-    ck_assert_ptr_nonnull (strstr (url0, "heading=0"));
-    free (url0);
+    char *body0 = smm_asset_build_position_body (0.0, 0.0, 0, 0, 0);
+    ck_assert_ptr_nonnull (body0);
+    ck_assert_ptr_nonnull (strstr (body0, "heading=0"));
+    free (body0);
 
-    char *url359 = smm_asset_build_position_url (1, 0.0, 0.0, 0, 359, 0);
-    ck_assert_ptr_nonnull (url359);
-    ck_assert_ptr_nonnull (strstr (url359, "heading=359"));
-    free (url359);
+    char *body359 = smm_asset_build_position_body (0.0, 0.0, 0, 359, 0);
+    ck_assert_ptr_nonnull (body359);
+    ck_assert_ptr_nonnull (strstr (body359, "heading=359"));
+    free (body359);
 }
 END_TEST
 
@@ -2154,8 +2154,8 @@ smm_suite (void)
     suite_add_tcase (s, tc_conn);
 
     TCase *tc_position = tcase_create ("Position");
-    tcase_add_test (tc_position, test_build_position_url_heading);
-    tcase_add_test (tc_position, test_build_position_url_locale_independent);
+    tcase_add_test (tc_position, test_build_position_body_heading);
+    tcase_add_test (tc_position, test_build_position_body_locale_independent);
     tcase_add_test (tc_position, test_set_command_from_plaintext_continue);
     tcase_add_test (tc_position, test_set_command_from_plaintext_other);
     tcase_add_test (tc_position, test_set_command_from_plaintext_null);
@@ -2300,10 +2300,10 @@ smm_suite (void)
     suite_add_tcase (s, tc_content_type);
 
     TCase *tc_position_ext = tcase_create ("PositionExt");
-    tcase_add_test (tc_position_ext, test_build_position_url_values);
-    tcase_add_test (tc_position_ext, test_build_position_url_negative_altitude);
-    tcase_add_test (tc_position_ext, test_build_position_url_altitude_int32_range);
-    tcase_add_test (tc_position_ext, test_build_position_url_heading_boundary);
+    tcase_add_test (tc_position_ext, test_build_position_body_values);
+    tcase_add_test (tc_position_ext, test_build_position_body_negative_altitude);
+    tcase_add_test (tc_position_ext, test_build_position_body_altitude_int32_range);
+    tcase_add_test (tc_position_ext, test_build_position_body_heading_boundary);
     tcase_add_test (tc_position_ext, test_asset_last_goto_pos_not_goto);
     tcase_add_test (tc_position_ext, test_asset_last_goto_pos_goto);
     tcase_add_test (tc_position_ext, test_goto_then_malformed_goto_clears_position);

--- a/tests/integration_test.c
+++ b/tests/integration_test.c
@@ -53,6 +53,20 @@ main (void)
         printf ("Asset: %s (%s)\n", smm_asset_name (assets[i]), smm_asset_type (assets[i]));
     }
 
+    /* Report a position. The endpoint is POST-only and CSRF-protected, so this
+     * exercises the POST body and the X-CSRFToken header against a live server. */
+    printf ("Reporting position for asset %s...\n", smm_asset_name (assets[0]));
+    if (!smm_asset_report_position (assets[0], -43.5, 172.6, 35, 270, 3))
+    {
+        char msg[256];
+        smm_error_code code = smm_asset_get_last_error (assets[0], msg, sizeof (msg));
+        fprintf (stderr, "Failed to report position (error %d: %s)\n", code, msg);
+        smm_asset_free_assets (assets, count);
+        smm_connection_close (conn);
+        return 1;
+    }
+    printf ("Position reported.\n");
+
     smm_asset_free_assets (assets, count);
     smm_connection_close (conn);
 


### PR DESCRIPTION
## Description

The position endpoint /data/assets/<id>/position/add/ is now POST-only (@require_POST) because recording a position mutates state; GET is refused. Switch smm_asset_report_position from a GET with query parameters to a POST with an application/x-www-form-urlencoded body (lat/lon/alt/heading/fix), built locale-independently.

The endpoint is CSRF-protected for session-authenticated connections, and Django rotates the CSRF token on login, so the token captured from the login page is stale afterwards. Track the csrftoken cookie from the jar after every request and present the current value in an X-CSRFToken header on POSTs. Using the header (not a form field) means a request retried after a lazy login re-reads the freshly rotated token instead of resending a body fixed before login. Login keeps using its body token.

Replace smm_asset_build_position_url with smm_asset_build_position_body and update its unit tests; extend the integration test to report a position, exercising the POST + CSRF flow against a live server.

Verified end to end against the current search-management-map image: make check and the integration test both pass.

## Summary by Sourcery

Switch asset position reporting from GET query parameters to POST form bodies with CSRF header support and update tests and integration flow accordingly.

Bug Fixes:
- Ensure session-authenticated POSTs carry a fresh CSRF token by tracking the csrftoken cookie and sending it via X-CSRFToken header.
- Maintain locale-independent formatting of position coordinates in the request body.

Enhancements:
- Refactor position URL builder into a body builder for application/x-www-form-urlencoded POSTs.
- Extend integration tests to exercise live position reporting via POST.

Tests:
- Update and expand unit tests around position body construction, including locale and boundary cases.
- Extend the integration test to cover reporting a position end to end.