### PR TITLE
release: prepare 1.1.0

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,26 @@
+libsmm-asset 1.1.0
+==================
+
+New API and hardening release; fully backwards compatible with 1.0.0
+(SONAME libsmmasset.so.0 unchanged).
+
+ * New smm_asset_connection_timeouts_set() lets callers override the
+   per-connection libcurl connect and transfer timeouts.
+ * Position reports are now submitted via POST with a CSRF token, matching
+   the current Search Management Map API, instead of an interpreted GET URL.
+ * Stricter, fail-closed input validation: asset and search ids must be
+   positive, GOTO and outbound positions and search coordinates must be
+   fresh and within range, and search object_url paths must match
+   /search/<id>/. Malformed or empty route geometry is now rejected when
+   parsing waypoints.
+ * get_search() reports parse and protocol errors and distinguishes a 404
+   "no search" result instead of failing silently.
+ * Hardened HTTP handling: reject non-http(s) URL schemes in
+   smm_asset_connect(), guard the libcurl write callbacks against
+   size * nmemb overflow, cap login-page buffering at SMM_MAX_RESPONSE_BYTES,
+   and initialize libcurl global state exactly once via pthread_once.
+ * Fixed a connection reference leak when smm_asset_create() fails.
+
 libsmm-asset 1.0.0
 ==================
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([libsmm-asset], [1.0.0])
+AC_INIT([libsmm-asset], [1.1.0])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign])
 
 AC_CONFIG_HEADERS([config.h])

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,15 @@
+libsmm-asset (1.1.0) unstable; urgency=medium
+
+  * New smm_asset_connection_timeouts_set() for per-connection libcurl
+    connect/transfer timeouts (compatible ABI addition; SONAME unchanged).
+  * Report asset position via POST with a CSRF token.
+  * Stricter input validation for ids, coordinates and search object_url;
+    reject malformed or empty route geometry.
+  * get_search() reports parse/protocol errors and a 404 no-search result.
+  * Hardened HTTP handling; see NEWS for the full summary.
+
+ -- Scott Parlane <sjp@canterburyairpatrol.org>  Sun, 29 Jun 2026 00:00:00 +0000
+
 libsmm-asset (1.0.0) unstable; urgency=medium
 
   * First stable release.

--- a/src/smm-asset.h
+++ b/src/smm-asset.h
@@ -30,9 +30,9 @@
  * Library version. Keep in sync with the package version in configure.ac.
  */
 #define SMM_VERSION_MAJOR 1
-#define SMM_VERSION_MINOR 0
+#define SMM_VERSION_MINOR 1
 #define SMM_VERSION_PATCH 0
-#define SMM_VERSION_STRING "1.0.0"
+#define SMM_VERSION_STRING "1.1.0"
 
 /**
  * Numeric library version: (major << 16) | (minor << 8) | patch.


### PR DESCRIPTION
## Description

Bump the package version to 1.1.0 in configure.ac and the SMM_VERSION_* macros in smm-asset.h, and document the release in NEWS and debian/changelog.

This is a backwards-compatible feature/hardening release over 1.0.0: it adds smm_asset_connection_timeouts_set() and tightens input validation and HTTP handling. The ABI gains one symbol with no changes to existing interfaces, so the libtool version-info (already 1:0:1 from the timeout-setter commit) and SONAME (libsmmasset.so.0) are unchanged.

## Summary by Sourcery

Prepare the 1.1.0 release of libsmm-asset by updating version metadata and release notes.

Build:
- Update package and library version numbers to 1.1.0 in build configuration and headers.

Documentation:
- Add release notes for version 1.1.0 to NEWS and Debian changelog.

Chores:
- Align library version macros with the new 1.1.0 release version.