### PR TITLE
refactor: remove unused smm_url_path_is_safe

### DIFF
--- a/src/smm-asset-internal.h
+++ b/src/smm-asset-internal.h
@@ -215,11 +215,6 @@ bool smm_https_upgrade_is_same_host (const char *http_host, const char *https_re
  * Acquires conn->lock internally; callers must not hold conn->lock. */
 bool smm_connection_try_https_upgrade (smm_connection conn, const char *redirect_url);
 
-/* Returns true if url is a safe relative path: starts with '/', contains
- * no '..' segments, no query ('?'), no fragment ('#'), and no percent-
- * encoded characters ('%'). */
-bool smm_url_path_is_safe (const char *url);
-
 /* Returns true if content_type is the application/json media type, ignoring
  * ASCII case, leading whitespace, and any parameters (e.g. "; charset=utf-8").
  * A NULL content_type returns false. */

--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -893,22 +893,6 @@ smm_content_type_is_json (const char *content_type)
 }
 
 bool
-smm_url_path_is_safe (const char *url)
-{
-    if (url == NULL || url[0] != '/')
-        return false;
-    if (strstr (url, "..") != NULL)
-        return false;
-    if (strchr (url, '?') != NULL)
-        return false;
-    if (strchr (url, '#') != NULL)
-        return false;
-    if (strchr (url, '%') != NULL)
-        return false;
-    return true;
-}
-
-bool
 smm_coords_valid (double lat, double lon)
 {
     /* Reject NaN/infinity outright, then bound to valid WGS84 ranges so a bad
@@ -1372,8 +1356,8 @@ smm_json_number_to_u64 (const json_t *value)
  * documented shape "/search/<positive-id>/" and writes the id to *id_out.
  * Returns false for any other path. Driving the actual request paths from this
  * parsed id (rather than reusing an arbitrary server string) keeps the search
- * API from being pointed at an unintended same-host endpoint, which the generic
- * smm_url_path_is_safe() predicate alone would allow (e.g. /accounts/logout/). */
+ * API from being pointed at an unintended same-host endpoint such as
+ * /accounts/logout/. */
 static bool
 smm_search_parse_object_url (const char *url, long long *id_out)
 {
@@ -1421,9 +1405,9 @@ smm_parse_search_json (smm_asset asset, const char *data, size_t len)
         {
             url = json_string_value (tmp);
         }
-        /* Accept only the documented "/search/<positive-id>/" shape. The
-         * generic smm_url_path_is_safe() predicate is kept for other callers
-         * but is not the trust boundary for search actions. */
+        /* Accept only the documented "/search/<positive-id>/" shape; the
+         * parsed id (not the raw string) is the trust boundary for search
+         * actions. */
         bool url_ok = smm_search_parse_object_url (url, &search_id);
         if (url_ok)
         {

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -1092,40 +1092,6 @@ START_TEST (test_search_action_sets_search_error_not_conn)
 }
 END_TEST
 
-START_TEST (test_url_path_safe_valid)
-{
-    ck_assert_int_eq (smm_url_path_is_safe ("/search/1/"), true);
-    ck_assert_int_eq (smm_url_path_is_safe ("/search/42/begin/"), true);
-    ck_assert_int_eq (smm_url_path_is_safe ("/"), true);
-}
-END_TEST
-
-START_TEST (test_url_path_safe_dotdot)
-{
-    ck_assert_int_eq (smm_url_path_is_safe ("/search/1/../../admin/"), false);
-    ck_assert_int_eq (smm_url_path_is_safe ("/.."), false);
-}
-END_TEST
-
-START_TEST (test_url_path_safe_query) { ck_assert_int_eq (smm_url_path_is_safe ("/search/1/?injected=evil"), false); }
-END_TEST
-
-START_TEST (test_url_path_safe_fragment) { ck_assert_int_eq (smm_url_path_is_safe ("/search/1/#frag"), false); }
-END_TEST
-
-START_TEST (test_url_path_safe_encoded) { ck_assert_int_eq (smm_url_path_is_safe ("/search/%2e%2e/admin/"), false); }
-END_TEST
-
-START_TEST (test_url_path_safe_absolute)
-{
-    ck_assert_int_eq (smm_url_path_is_safe ("http://example.com/search/1/"), false);
-    ck_assert_int_eq (smm_url_path_is_safe ("https://example.com/search/1/"), false);
-}
-END_TEST
-
-START_TEST (test_url_path_safe_null) { ck_assert_int_eq (smm_url_path_is_safe (NULL), false); }
-END_TEST
-
 START_TEST (test_to_buffer_accumulates)
 {
     struct buffer_s buf = { NULL, 0 };
@@ -2271,16 +2237,6 @@ smm_suite (void)
     tcase_add_test (tc_search, test_search_from_response_valid_returns_search);
     tcase_add_test (tc_search, test_search_from_response_server_error_sets_server);
     suite_add_tcase (s, tc_search);
-
-    TCase *tc_url = tcase_create ("URL");
-    tcase_add_test (tc_url, test_url_path_safe_valid);
-    tcase_add_test (tc_url, test_url_path_safe_dotdot);
-    tcase_add_test (tc_url, test_url_path_safe_query);
-    tcase_add_test (tc_url, test_url_path_safe_fragment);
-    tcase_add_test (tc_url, test_url_path_safe_encoded);
-    tcase_add_test (tc_url, test_url_path_safe_absolute);
-    tcase_add_test (tc_url, test_url_path_safe_null);
-    suite_add_tcase (s, tc_url);
 
     TCase *tc_buffer = tcase_create ("Buffer");
     tcase_add_test (tc_buffer, test_to_buffer_accumulates);


### PR DESCRIPTION
## Description

Its sole production caller was removed in 115cecd when search object_url validation moved to smm_search_parse_object_url (parsing the id and building request paths locally). The generic predicate had no remaining callers and misleadingly read as a live trust boundary.

Drop the function, its declaration, and its dedicated test case; refresh two comments that referenced it. No ABI impact (it was never exported).

## Summary by Sourcery

Remove the unused smm_url_path_is_safe helper and its tests, updating nearby comments to reflect the current search URL validation approach.

Enhancements:
- Clarify search URL validation comments to emphasize smm_search_parse_object_url and parsed IDs as the trust boundary.

Tests:
- Delete the dedicated URL safety test case group for smm_url_path_is_safe.