### PR TITLE
fix: add printf format attributes to set_error helpers

### DIFF
--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -249,6 +249,9 @@ smm_asset_connection_timeouts_set (smm_connection connection, long connect_secs,
     }
 }
 
+static void smm_asset_set_error (smm_asset asset, smm_error_code code, const char *fmt, ...)
+    __attribute__ ((format (printf, 3, 4)));
+
 static void
 smm_asset_set_error (smm_asset asset, smm_error_code code, const char *fmt, ...)
 {
@@ -294,6 +297,9 @@ smm_asset_get_last_error (smm_asset asset, char *message, size_t message_len)
     pthread_mutex_unlock (&asset->lock);
     return code;
 }
+
+static void smm_search_set_error (smm_search search, smm_error_code code, const char *fmt, ...)
+    __attribute__ ((format (printf, 3, 4)));
 
 static void
 smm_search_set_error (smm_search search, smm_error_code code, const char *fmt, ...)


### PR DESCRIPTION
## Description

smm_asset_set_error and smm_search_set_error forward a format string to vsnprintf but lacked the format(printf, 3, 4) attribute, which clang's -Wmissing-format-attribute flagged. Add it (matching the existing smm_asprintf_c_locale and smm_connection_set_error declarations) so the compiler type-checks the format string against its arguments at every call site. No call-site mismatches surfaced.

## Summary by Sourcery

Bug Fixes:
- Address missing printf-format attributes on smm_asset_set_error and smm_search_set_error to silence compiler warnings and prevent format-string mismatches.