### PR TITLE
ci: add AddressSanitizer + UndefinedBehaviorSanitizer job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,42 @@ jobs:
     - name: make distcheck
       run: make distcheck
 
+  # Dynamic analysis: build the library and unit tests with AddressSanitizer
+  # and UndefinedBehaviorSanitizer and run the suite under them. This catches
+  # memory errors (overflows, use-after-free) and undefined behaviour that the
+  # static gates cannot see. -fno-sanitize-recover=all turns every finding into
+  # a hard failure rather than a logged warning.
+  sanitizers:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v7
+    - name: Install Deps
+      run: sudo apt update && sudo apt install -y libcurl4-openssl-dev libtidy-dev libjansson-dev check locales-all
+    - name: autogen
+      run: ./autogen.sh
+    - name: configure
+      run: |
+        ./configure \
+          CFLAGS="-fsanitize=address,undefined -fno-sanitize-recover=all -fno-omit-frame-pointer -g -O1" \
+          LDFLAGS="-fsanitize=address,undefined"
+    - name: make
+      run: make
+    # CK_FORK=no runs the suite in a single process so LeakSanitizer reports
+    # once at exit with clean attribution. Known third-party init allocations
+    # (libcurl/OpenSSL/tidy, and the deliberately un-cleaned libcurl global
+    # state) are filtered by tests/lsan.supp; the suppressions path must be
+    # absolute because the test binary runs from the tests/ directory.
+    - name: make check (asan+ubsan)
+      run: |
+        ASAN_OPTIONS=detect_leaks=1:abort_on_error=1 \
+        LSAN_OPTIONS=suppressions=$(pwd)/tests/lsan.supp \
+        UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 \
+        CK_FORK=no \
+        make check
+    - name: Show test log on failure
+      if: failure()
+      run: cat tests/test-suite.log 2>/dev/null || true
+
   # The Docker integration stack depends on an external SMM image and a live
   # database, so it is kept in its own job: a flaky or unhealthy external
   # service fails only this job, not the unit tests, distcheck, or static

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -14,4 +14,4 @@ integration_test_CFLAGS = -I$(top_srcdir)/src
 integration_test_LDADD = $(top_builddir)/src/libsmmasset.la
 endif
 
-EXTRA_DIST = docker-compose.yml provision.sh
+EXTRA_DIST = docker-compose.yml provision.sh lsan.supp

--- a/tests/lsan.supp
+++ b/tests/lsan.supp
@@ -1,0 +1,15 @@
+# LeakSanitizer suppressions for the sanitizer CI job.
+#
+# These target one-time initialisation in third-party libraries that the test
+# process never tears down, so leak detection stays meaningful for libsmm-asset
+# itself without failing on allocations we do not own.
+#
+# Note: libsmm-asset deliberately never calls curl_global_cleanup() (see
+# smm_curl_global_init in src/smm-asset-curl.c) because, as a shared library, it
+# cannot know when the host application is finished with libcurl. The libcurl
+# global state is therefore expected to remain allocated at exit.
+leak:libcurl
+leak:libcrypto
+leak:libssl
+leak:libtidy
+leak:curl_global_init


### PR DESCRIPTION
## Description

The static gates (cppcheck, clang-tidy, CodeQL) cannot see runtime memory errors or undefined behaviour, which matters for a C library doing manual allocation and pointer arithmetic. Add a sanitizers job that builds the library and unit tests with -fsanitize=address,undefined and runs the suite under them. -fno-sanitize-recover=all makes every finding a hard failure.

The suite runs with CK_FORK=no so LeakSanitizer reports once at exit with clean attribution. tests/lsan.supp filters one-time third-party init allocations (libcurl/OpenSSL/tidy) and libcurl's deliberately un-cleaned global state, so leak detection stays meaningful for our own code without failing on memory we do not own. The suppressions path is passed absolute because the test binary runs from the tests/ directory.

Verified locally: the existing suite is clean under both sanitizers.

## Summary by Sourcery

Add CI coverage for runtime memory and undefined behavior errors using sanitizers in the test suite.

CI:
- Introduce a GitHub Actions job that builds and runs tests under AddressSanitizer and UndefinedBehaviorSanitizer, treating sanitizer findings as hard failures.

Tests:
- Distribute LeakSanitizer suppression configuration file for tests to filter expected third‑party and global-state leaks.