### PR TITLE
fix: null res->full_uri on asprintf failure

### DIFF
--- a/src/smm-asset-curl.c
+++ b/src/smm-asset-curl.c
@@ -375,6 +375,11 @@ smm_connection_curl_retrieve_url_r (smm_connection conn, const char *path, const
 
     if (asprintf (&res->full_uri, "%s%s", conn->host, path) < 0)
     {
+        /* POSIX leaves *strp undefined on asprintf failure; null it so the
+         * unconditional free in smm_curl_res_free cannot touch an
+         * indeterminate pointer (calloc zeroed it, but do not rely on the
+         * call having left it untouched). */
+        res->full_uri = NULL;
         pthread_mutex_unlock (&conn->lock);
         DEBUG ("failed to allocate full_uri");
         goto out;


### PR DESCRIPTION
## Description

asprintf leaves *strp undefined on failure (POSIX); smm_curl_res_free then frees res->full_uri unconditionally. It is safe today only because res is calloc'd, but null the field explicitly on the failure path so correctness does not depend on the failing asprintf having left the pointer untouched.

Not unit-tested: forcing asprintf to fail is impractical (it would need an allocation large enough to exhaust memory).

## Summary by Sourcery

Bug Fixes:
- Explicitly nullify res->full_uri when asprintf fails so the subsequent unconditional free operates on a well-defined pointer.