### PR TITLE
fix: scrub credentials and session token before freeing the connection

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -30,6 +30,11 @@ AM_CONDITIONAL([INTEGRATION_TESTS], [test "x$enable_integration_tests" = "xyes"]
 AC_CHECK_HEADERS([tidy.h],[],[
 AC_CHECK_HEADERS([tidy/tidy.h])])
 
+# explicit_bzero (glibc/BSD) scrubs secrets without the compiler optimising the
+# store away. Where it is unavailable, smm_secure_clear falls back to a
+# volatile write loop.
+AC_CHECK_FUNCS([explicit_bzero])
+
 AC_CONFIG_FILES([Makefile
 	src/Makefile
 	tests/Makefile

--- a/src/smm-asset-internal.h
+++ b/src/smm-asset-internal.h
@@ -149,6 +149,12 @@ bool smm_curl_global_init (void);
 bool smm_connection_share_init (smm_connection conn);
 void smm_connection_share_destroy (smm_connection conn);
 
+/* Overwrite a NUL-terminated string in place with zero bytes (up to its
+ * terminator) before it is freed, so secrets do not linger in the heap. Uses
+ * explicit_bzero where available, otherwise a volatile write loop the compiler
+ * cannot elide. NULL-safe. Exposed for testing. */
+void smm_secure_clear (char *s);
+
 void smm_connection_ref (smm_connection conn);
 void smm_connection_unref (smm_connection conn);
 void smm_connection_set_error (smm_connection conn, smm_error_code code, const char *fmt, ...)

--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -20,8 +20,10 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
-#include "smm-asset.h"
+#include "config.h"
+
 #include "smm-asset-internal.h"
+#include "smm-asset.h"
 
 #include <errno.h>
 #include <inttypes.h>
@@ -35,6 +37,26 @@
 #include <jansson.h>
 
 _Atomic bool smm_debug = false;
+
+void
+smm_secure_clear (char *s)
+{
+    if (s == NULL)
+    {
+        return;
+    }
+#ifdef HAVE_EXPLICIT_BZERO
+    explicit_bzero (s, strlen (s));
+#else
+    /* Fallback: write through a volatile pointer so the compiler cannot elide
+     * the scrub as a dead store to soon-to-be-freed memory. */
+    volatile char *p = (volatile char *)s;
+    for (size_t n = strlen (s); n > 0; n--)
+    {
+        *p++ = '\0';
+    }
+#endif
+}
 
 /*
  * SMM expects coordinates in URLs formatted with '.' as the decimal separator.
@@ -416,8 +438,13 @@ smm_connection_unref (smm_connection connection)
     {
         pthread_mutex_unlock (&connection->lock);
         free (connection->host);
+        /* Scrub the credentials and session token from memory before freeing,
+         * so they do not linger in the heap after the connection is closed. */
+        smm_secure_clear (connection->user);
         free (connection->user);
+        smm_secure_clear (connection->pass);
         free (connection->pass);
+        smm_secure_clear (connection->csrfmiddlewaretoken);
         free (connection->csrfmiddlewaretoken);
         smm_connection_share_destroy (connection);
         pthread_cond_destroy (&connection->login_cond);

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -1162,6 +1162,33 @@ START_TEST (test_buffer_reset_null_safe)
 }
 END_TEST
 
+START_TEST (test_secure_clear_zeroes)
+{
+    char *s = strdup ("s3cr3t-password");
+    ck_assert_ptr_nonnull (s);
+    size_t len = strlen (s);
+    smm_secure_clear (s);
+    for (size_t i = 0; i < len; i++)
+    {
+        ck_assert_int_eq (s[i], '\0');
+    }
+    free (s);
+}
+END_TEST
+
+START_TEST (test_secure_clear_empty_string)
+{
+    char *s = strdup ("");
+    ck_assert_ptr_nonnull (s);
+    smm_secure_clear (s); /* nothing to clear, must not over-write */
+    ck_assert_int_eq (s[0], '\0');
+    free (s);
+}
+END_TEST
+
+START_TEST (test_secure_clear_null_safe) { smm_secure_clear (NULL); /* must not crash */ }
+END_TEST
+
 START_TEST (test_content_type_is_json_plain) { ck_assert_int_eq (smm_content_type_is_json ("application/json"), true); }
 END_TEST
 
@@ -2246,6 +2273,12 @@ smm_suite (void)
     tcase_add_test (tc_buffer, test_buffer_reset_discards_content);
     tcase_add_test (tc_buffer, test_buffer_reset_null_safe);
     suite_add_tcase (s, tc_buffer);
+
+    TCase *tc_secure = tcase_create ("SecureClear");
+    tcase_add_test (tc_secure, test_secure_clear_zeroes);
+    tcase_add_test (tc_secure, test_secure_clear_empty_string);
+    tcase_add_test (tc_secure, test_secure_clear_null_safe);
+    suite_add_tcase (s, tc_secure);
 
     TCase *tc_content_type = tcase_create ("ContentType");
     tcase_add_test (tc_content_type, test_content_type_is_json_plain);


### PR DESCRIPTION
## Description

smm_connection_unref freed the username, password, and CSRF/session token with plain free(), leaving them in the heap after a connection was closed. Add smm_secure_clear(), which overwrites a NUL-terminated string in place (explicit_bzero where available, else a volatile write loop the compiler cannot elide), and apply it to those three fields before free().

A new AC_CHECK_FUNCS([explicit_bzero]) drives the HAVE_EXPLICIT_BZERO path. The helper is exposed via the internal header and unit-tested (zeroes a populated string, no-ops on an empty string, NULL-safe); the scrub of already-freed memory itself is not observable so it is not asserted directly.

## Summary by Sourcery

Scrub sensitive connection credentials and session tokens from memory before freeing them, using a new secure string clearing helper.

Bug Fixes:
- Ensure usernames, passwords, and CSRF/session tokens are overwritten before being freed so they do not linger in heap memory.

Enhancements:
- Introduce a smm_secure_clear helper that securely zeroes NUL-terminated strings, using explicit_bzero when available or a volatile write loop otherwise.

Build:
- Detect availability of explicit_bzero at configure time via AC_CHECK_FUNCS and conditionally use it in secure clearing logic.

Tests:
- Add unit tests covering smm_secure_clear behavior for populated, empty, and NULL strings.