### PR TITLE
refactor: single-source the library version

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,12 @@
-AC_INIT([libsmm-asset], [1.1.0])
+dnl Derive the package version from the single source of truth in the public
+dnl header, so configure.ac and src/smm-asset.h can never disagree.
+m4_define([smm_ver_major],
+  m4_esyscmd_s([sed -n 's/^#define SMM_VERSION_MAJOR \([0-9][0-9]*\).*/\1/p' src/smm-asset.h]))
+m4_define([smm_ver_minor],
+  m4_esyscmd_s([sed -n 's/^#define SMM_VERSION_MINOR \([0-9][0-9]*\).*/\1/p' src/smm-asset.h]))
+m4_define([smm_ver_patch],
+  m4_esyscmd_s([sed -n 's/^#define SMM_VERSION_PATCH \([0-9][0-9]*\).*/\1/p' src/smm-asset.h]))
+AC_INIT([libsmm-asset], [smm_ver_major.smm_ver_minor.smm_ver_patch])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign])
 
 AC_CONFIG_HEADERS([config.h])

--- a/src/smm-asset.h
+++ b/src/smm-asset.h
@@ -27,12 +27,22 @@
 #include <stdint.h>
 
 /**
- * Library version. Keep in sync with the package version in configure.ac.
+ * Library version. These three numbers are the single source of truth for the
+ * version: configure.ac derives the package version from them, and
+ * SMM_VERSION_STRING / SMM_VERSION_NUMBER below are composed from them, so the
+ * forms cannot drift apart. Bump these on a release.
  */
 #define SMM_VERSION_MAJOR 1
 #define SMM_VERSION_MINOR 1
 #define SMM_VERSION_PATCH 0
-#define SMM_VERSION_STRING "1.1.0"
+
+/* Compose "major.minor.patch" from the numbers above (two-step expansion so the
+ * macro values, not their names, are stringified). */
+#define SMM_VERSION_STRINGIFY_(x) #x
+#define SMM_VERSION_STRINGIFY(x) SMM_VERSION_STRINGIFY_ (x)
+#define SMM_VERSION_STRING                                                                                             \
+    SMM_VERSION_STRINGIFY (SMM_VERSION_MAJOR)                                                                          \
+    "." SMM_VERSION_STRINGIFY (SMM_VERSION_MINOR) "." SMM_VERSION_STRINGIFY (SMM_VERSION_PATCH)
 
 /**
  * Numeric library version: (major << 16) | (minor << 8) | patch.

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -1916,6 +1916,18 @@ START_TEST (test_version_runtime_matches_headers)
 }
 END_TEST
 
+START_TEST (test_version_string_composed_from_components)
+{
+    /* SMM_VERSION_STRING is now derived from the numeric components by
+     * preprocessor stringification; check it matches an independently composed
+     * "major.minor.patch" so the derivation can never silently produce a
+     * malformed string. */
+    char expected[32];
+    snprintf (expected, sizeof (expected), "%d.%d.%d", SMM_VERSION_MAJOR, SMM_VERSION_MINOR, SMM_VERSION_PATCH);
+    ck_assert_str_eq (SMM_VERSION_STRING, expected);
+}
+END_TEST
+
 START_TEST (test_connection_login_fields_initialised)
 {
     smm_connection conn = smm_asset_connect ("not a url", "user", "pass");
@@ -2144,6 +2156,7 @@ smm_suite (void)
     tcase_add_test (tc_conn, test_connect_only_slashes_is_invalid);
     tcase_add_test (tc_conn, test_debugging_set);
     tcase_add_test (tc_conn, test_version_runtime_matches_headers);
+    tcase_add_test (tc_conn, test_version_string_composed_from_components);
     suite_add_tcase (s, tc_conn);
 
     TCase *tc_position = tcase_create ("Position");


### PR DESCRIPTION
## Description

The version was stated three times: the MAJOR/MINOR/PATCH macros, a separate SMM_VERSION_STRING literal, and AC_INIT in configure.ac — kept in sync by hand (a comment literally said "keep in sync").

Make the three numeric macros in smm-asset.h the single source of truth:
- SMM_VERSION_STRING is now composed from them by preprocessor stringification, so the string can no longer disagree with the numbers.
- configure.ac derives the package version from the header via m4_esyscmd_s, so the build version cannot drift from it either.

A new test asserts SMM_VERSION_STRING matches an independently composed "major.minor.patch"; distcheck confirms the derived tarball version. The header<->configure link is now structural, so it needs no runtime test.

## Summary by Sourcery

Single-source the library and package version so all version forms are derived from the header macros.

Enhancements:
- Generate SMM_VERSION_STRING from the numeric version macros to keep the string and numeric versions in sync.
- Derive the Autotools package version in configure.ac from the public header version macros to prevent drift.

Tests:
- Add a unit test verifying SMM_VERSION_STRING matches an independently composed "major.minor.patch" string.