### PR TITLE
fix: mark the connection CONNECTED after a successful request

### DIFF
--- a/src/smm-asset-curl.c
+++ b/src/smm-asset-curl.c
@@ -911,5 +911,19 @@ smm_connection_curl_retrieve_url (smm_connection conn, const char *path, const c
         }
     }
 
+    /* A successful 200 from a real API endpoint means the session is good: the
+     * server answered the request rather than redirecting us to the login
+     * page. Reflect that in the connection state, which otherwise stays NEW
+     * when the first request happens to succeed without a login round-trip
+     * (e.g. cookies already valid on the shared handle). The login-page fetch
+     * itself uses the raw _r path, so it never reaches here and cannot flip the
+     * state to CONNECTED before authentication actually completes. */
+    if (res != NULL && res->success && res->httpcode == HTTP_SUCCESS)
+    {
+        pthread_mutex_lock (&conn->lock);
+        conn->state = SMM_CONNECTION_CONNECTED;
+        pthread_mutex_unlock (&conn->lock);
+    }
+
     return res;
 }

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -1453,6 +1453,77 @@ START_TEST (test_eager_login_follows_https_upgrade)
 }
 END_TEST
 
+/* One-shot server that answers the first request with a 200 and a tiny JSON
+ * body, used to check that a successful API request marks the connection
+ * CONNECTED. */
+static void *
+ok_200_server_thread (void *arg)
+{
+    struct redirect_server_s *srv = (struct redirect_server_s *)arg;
+    int fd = accept (srv->listen_fd, NULL, NULL);
+    if (fd >= 0)
+    {
+        char req[1024];
+        (void)!read (fd, req, sizeof (req));
+        const char body[] = "{}";
+        char resp[256];
+        int n = snprintf (resp, sizeof (resp),
+                          "HTTP/1.1 200 OK\r\n"
+                          "Content-Type: application/json\r\n"
+                          "Content-Length: %zu\r\n"
+                          "Connection: close\r\n"
+                          "\r\n"
+                          "%s",
+                          sizeof (body) - 1, body);
+        (void)!write (fd, resp, (size_t)n);
+        close (fd);
+    }
+    return NULL;
+}
+
+START_TEST (test_successful_request_sets_connected)
+{
+    struct redirect_server_s srv;
+    struct sockaddr_in addr;
+    socklen_t addr_len = sizeof (addr);
+
+    srv.listen_fd = socket (AF_INET, SOCK_STREAM, 0);
+    ck_assert_int_ge (srv.listen_fd, 0);
+    memset (&addr, 0, sizeof (addr));
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl (INADDR_LOOPBACK);
+    addr.sin_port = 0; /* ephemeral */
+    ck_assert_int_eq (bind (srv.listen_fd, (struct sockaddr *)&addr, sizeof (addr)), 0);
+    ck_assert_int_eq (listen (srv.listen_fd, 1), 0);
+    ck_assert_int_eq (getsockname (srv.listen_fd, (struct sockaddr *)&addr, &addr_len), 0);
+    srv.port = ntohs (addr.sin_port);
+
+    pthread_t thread;
+    ck_assert_int_eq (pthread_create (&thread, NULL, ok_200_server_thread, &srv), 0);
+
+    char host[64];
+    snprintf (host, sizeof (host), "http://127.0.0.1:%u", srv.port);
+    smm_connection conn = smm_asset_connect (host, "user", "pass");
+    ck_assert_ptr_nonnull (conn);
+    /* Freshly connected: state is NEW until a request succeeds. */
+    ck_assert_int_eq (smm_asset_connection_get_state (conn), SMM_CONNECTION_NEW);
+
+    struct buffer_s buf = { NULL, 0 };
+    struct smm_curl_res_s *res = smm_connection_curl_retrieve_url (conn, "/assets/", NULL, &buf, true);
+    ck_assert_ptr_nonnull (res);
+    ck_assert_int_eq (res->success, true);
+    ck_assert_int_eq (res->httpcode, 200);
+    /* The successful request must have transitioned the state to CONNECTED. */
+    ck_assert_int_eq (smm_asset_connection_get_state (conn), SMM_CONNECTION_CONNECTED);
+
+    smm_curl_res_free (res);
+    free (buf.data);
+    pthread_join (thread, NULL);
+    close (srv.listen_fd);
+    smm_connection_close (conn);
+}
+END_TEST
+
 START_TEST (test_curl_retrieve_url_r_returns_null_on_no_response)
 {
     /* Exercises the httpcode==0 cleanup path in smm_connection_curl_retrieve_url_r.
@@ -2118,6 +2189,7 @@ smm_suite (void)
     tcase_add_test (tc_conn, test_try_https_upgrade_rejects_other_host);
     tcase_add_test (tc_conn, test_try_https_upgrade_null_args);
     tcase_add_test (tc_conn, test_eager_login_follows_https_upgrade);
+    tcase_add_test (tc_conn, test_successful_request_sets_connected);
     tcase_add_test (tc_conn, test_state_for_curl_error_http_error_keeps_state);
     tcase_add_test (tc_conn, test_state_for_curl_error_connection_failures);
     tcase_add_test (tc_conn, test_invalid_host);


### PR DESCRIPTION
## Description

The connection state only became CONNECTED inside the login round-trip, so a first request that succeeded without one (e.g. cookies already valid on the shared handle) left the state stuck at NEW despite a working session.

Set CONNECTED in the retrying smm_connection_curl_retrieve_url wrapper when a request returns 200. This is the wrapper used by the real API endpoints; the login-page fetch uses the raw _r path, which never reaches here, so the state cannot be flipped to CONNECTED before authentication actually completes.

Tested with a one-shot loopback server: a fresh connection reports NEW, and after a successful 200 request reports CONNECTED.

## Summary by Sourcery

Ensure asset connections transition to CONNECTED after a successful API request rather than only during the login flow.

Bug Fixes:
- Fix connection state remaining NEW when the first API request succeeds without an explicit login round-trip.

Tests:
- Add a loopback server test verifying that a successful 200 API response updates the connection state to CONNECTED.