### PR TITLE
fix: re-authenticate and retry a POST rejected with 403 (CSRF)

### DIFF
--- a/src/smm-asset-curl.c
+++ b/src/smm-asset-curl.c
@@ -869,6 +869,7 @@ smm_connection_curl_retrieve_url (smm_connection conn, const char *path, const c
 {
     bool retry = true;
     int retries = 0;
+    bool csrf_retried = false;
     struct smm_curl_res_s *res
         = smm_connection_curl_retrieve_url_r (conn, path, post_data, buf ? to_buffer : NULL, buf, json);
 
@@ -898,6 +899,22 @@ smm_connection_curl_retrieve_url (smm_connection conn, const char *path, const c
             if (!retry)
             {
                 DEBUG ("Redirected to %s\n", res->redirect_url);
+            }
+        }
+        else if (post_data != NULL && res->httpcode == HTTP_FORBIDDEN && !csrf_retried)
+        {
+            /* Django answers a CSRF failure with 403, not a login redirect.
+             * The usual cause is a CSRF token that has gone stale (e.g. the
+             * server rotated it since this session's token was captured), so
+             * re-authenticate once to refresh it and retry the POST; the retry
+             * re-reads the freshly rotated token. Bounded to a single attempt
+             * (csrf_retried) so a genuine permission denial, which a re-login
+             * cannot fix, does not loop. */
+            csrf_retried = true;
+            DEBUG ("403 on POST to %s; refreshing session and retrying once\n", path);
+            if (smm_asset_connection_login (conn))
+            {
+                retry = true;
             }
         }
         if (retry && retries < 3)

--- a/src/smm-asset-internal.h
+++ b/src/smm-asset-internal.h
@@ -36,6 +36,7 @@ enum http_return_codes
     HTTP_MOVED_PERMANENTLY = 301,
     HTTP_FOUND = 302,
     HTTP_SEE_OTHER = 303,
+    HTTP_FORBIDDEN = 403,
     HTTP_NOT_FOUND = 404,
 };
 

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -1537,6 +1537,152 @@ START_TEST (test_successful_request_sets_connected)
 }
 END_TEST
 
+/* Drives the CSRF-403 re-auth flow over four sequential connections:
+ *   1. the initial POST            -> 403 (CSRF rejected)
+ *   2. the login-page GET          -> 200 with a csrfmiddlewaretoken form
+ *   3. the login POST              -> 302 (login succeeds)
+ *   4. the retried POST            -> retry_status (200 happy path, or 403 to
+ *                                     prove the re-auth is bounded to one try)
+ * Each response sets Connection: close, so every request is a fresh accept. */
+struct csrf_server_s
+{
+    int listen_fd;
+    long retry_status;
+};
+
+static void *
+csrf_retry_server_thread (void *arg)
+{
+    struct csrf_server_s *srv = (struct csrf_server_s *)arg;
+    static const char login_html[] = "<html><body><form method=\"post\">"
+                                     "<input type=\"hidden\" name=\"csrfmiddlewaretoken\" value=\"tok123abc\">"
+                                     "</form></body></html>";
+    for (int step = 0; step < 4; step++)
+    {
+        int fd = accept (srv->listen_fd, NULL, NULL);
+        if (fd < 0)
+        {
+            break;
+        }
+        char req[2048];
+        (void)!read (fd, req, sizeof (req));
+        char resp[1024];
+        int n = 0;
+        switch (step)
+        {
+            case 0: /* initial POST: CSRF rejected */
+                n = snprintf (resp, sizeof (resp),
+                              "HTTP/1.1 403 Forbidden\r\nContent-Type: text/html\r\n"
+                              "Content-Length: 0\r\nConnection: close\r\n\r\n");
+                break;
+            case 1: /* login page with the CSRF token */
+                n = snprintf (resp, sizeof (resp),
+                              "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n"
+                              "Set-Cookie: csrftoken=tok123abc; Path=/\r\n"
+                              "Content-Length: %zu\r\nConnection: close\r\n\r\n%s",
+                              sizeof (login_html) - 1, login_html);
+                break;
+            case 2: /* login POST succeeds (Django answers 302) */
+                n = snprintf (resp, sizeof (resp),
+                              "HTTP/1.1 302 Found\r\nLocation: /\r\n"
+                              "Set-Cookie: csrftoken=tok123abc; Path=/\r\n"
+                              "Content-Length: 0\r\nConnection: close\r\n\r\n");
+                break;
+            default: /* the retried POST */
+                if (srv->retry_status == 200)
+                {
+                    n = snprintf (resp, sizeof (resp),
+                                  "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n"
+                                  "Content-Length: 2\r\nConnection: close\r\n\r\n{}");
+                }
+                else
+                {
+                    n = snprintf (resp, sizeof (resp),
+                                  "HTTP/1.1 403 Forbidden\r\nContent-Type: text/html\r\n"
+                                  "Content-Length: 0\r\nConnection: close\r\n\r\n");
+                }
+                break;
+        }
+        (void)!write (fd, resp, (size_t)n);
+        close (fd);
+    }
+    return NULL;
+}
+
+static smm_connection
+csrf_server_start (struct csrf_server_s *srv, pthread_t *thread, long retry_status)
+{
+    struct sockaddr_in addr;
+    socklen_t addr_len = sizeof (addr);
+
+    srv->retry_status = retry_status;
+    srv->listen_fd = socket (AF_INET, SOCK_STREAM, 0);
+    ck_assert_int_ge (srv->listen_fd, 0);
+    memset (&addr, 0, sizeof (addr));
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl (INADDR_LOOPBACK);
+    addr.sin_port = 0; /* ephemeral */
+    ck_assert_int_eq (bind (srv->listen_fd, (struct sockaddr *)&addr, sizeof (addr)), 0);
+    ck_assert_int_eq (listen (srv->listen_fd, 4), 0);
+    ck_assert_int_eq (getsockname (srv->listen_fd, (struct sockaddr *)&addr, &addr_len), 0);
+    uint16_t port = ntohs (addr.sin_port);
+
+    ck_assert_int_eq (pthread_create (thread, NULL, csrf_retry_server_thread, srv), 0);
+
+    char host[64];
+    snprintf (host, sizeof (host), "http://127.0.0.1:%u", port);
+    smm_connection conn = smm_asset_connect (host, "user", "pass");
+    ck_assert_ptr_nonnull (conn);
+    return conn;
+}
+
+START_TEST (test_post_403_triggers_reauth_and_retry)
+{
+    struct csrf_server_s srv;
+    pthread_t thread;
+    smm_connection conn = csrf_server_start (&srv, &thread, 200);
+
+    /* The first POST is rejected with 403; the library must re-authenticate
+     * and retry, and the retried POST (now carrying the refreshed token)
+     * succeeds. */
+    struct buffer_s buf = { NULL, 0 };
+    struct smm_curl_res_s *res
+        = smm_connection_curl_retrieve_url (conn, "/data/assets/1/position/add/", "lat=0.0&lon=0.0", &buf, false);
+    ck_assert_ptr_nonnull (res);
+    ck_assert_int_eq (res->success, true);
+    ck_assert_int_eq (res->httpcode, 200);
+
+    smm_curl_res_free (res);
+    free (buf.data);
+    pthread_join (thread, NULL);
+    close (srv.listen_fd);
+    smm_connection_close (conn);
+}
+END_TEST
+
+START_TEST (test_post_403_reauth_is_bounded)
+{
+    struct csrf_server_s srv;
+    pthread_t thread;
+    smm_connection conn = csrf_server_start (&srv, &thread, 403);
+
+    /* Re-auth succeeds but the retried POST is still 403 (e.g. a genuine
+     * permission denial). The library must not loop: it re-authenticates once,
+     * then surfaces the 403 rather than retrying forever. */
+    struct buffer_s buf = { NULL, 0 };
+    struct smm_curl_res_s *res
+        = smm_connection_curl_retrieve_url (conn, "/data/assets/1/position/add/", "lat=0.0&lon=0.0", &buf, false);
+    ck_assert_ptr_nonnull (res);
+    ck_assert_int_eq (res->httpcode, 403);
+
+    smm_curl_res_free (res);
+    free (buf.data);
+    pthread_join (thread, NULL);
+    close (srv.listen_fd);
+    smm_connection_close (conn);
+}
+END_TEST
+
 START_TEST (test_curl_retrieve_url_r_returns_null_on_no_response)
 {
     /* Exercises the httpcode==0 cleanup path in smm_connection_curl_retrieve_url_r.
@@ -2204,6 +2350,8 @@ smm_suite (void)
     tcase_add_test (tc_conn, test_try_https_upgrade_preserves_port);
     tcase_add_test (tc_conn, test_eager_login_follows_https_upgrade);
     tcase_add_test (tc_conn, test_successful_request_sets_connected);
+    tcase_add_test (tc_conn, test_post_403_triggers_reauth_and_retry);
+    tcase_add_test (tc_conn, test_post_403_reauth_is_bounded);
     tcase_add_test (tc_conn, test_state_for_curl_error_http_error_keeps_state);
     tcase_add_test (tc_conn, test_state_for_curl_error_connection_failures);
     tcase_add_test (tc_conn, test_invalid_host);


### PR DESCRIPTION
## Description

The retry loop only recovered from an expired session when the server answered with a redirect to the login page. Django, however, answers a CSRF failure with 403 Forbidden, not a redirect, so a POST sent with a stale CSRF token surfaced as a hard SMM_ERROR_SERVER instead of being retried.

When a POST returns 403, re-authenticate once and retry; the retried request re-reads the freshly rotated CSRF token. The re-login is bounded to a single attempt so a genuine permission denial (which a re-login cannot fix) does not loop.

Tested end to end with a loopback server driving the full flow: an initial POST 403, a login GET/POST round-trip, then the retried POST -- both that the retry succeeds on 200 and that a persistent 403 is surfaced after exactly one re-auth rather than looping.

## Summary by Sourcery

Handle POST requests that return HTTP 403 by refreshing the session once and retrying, ensuring stale CSRF tokens trigger re-authentication rather than hard failure.

Bug Fixes:
- Fix POST requests rejected with HTTP 403 due to stale CSRF tokens so they re-authenticate once instead of surfacing an immediate server error.

Enhancements:
- Introduce explicit HTTP_FORBIDDEN (403) constant to support CSRF-related retry logic.

Tests:
- Add end-to-end tests driving a simulated CSRF failure and login flow to verify POST 403 triggers a single re-authenticated retry and does not loop on persistent 403 responses.