### PR TITLE
Reject non-base URL components in SMM hosts

### DIFF
--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -219,12 +219,24 @@ smm_asset_connect (const char *host, const char *user, const char *pass)
              * libcurl lowercases the scheme, so a plain strcmp is sufficient. */
             char *scheme = NULL;
             char *chost = NULL;
+            char *query = NULL;
+            char *fragment = NULL;
+            char *user_part = NULL;
+            char *password_part = NULL;
             bool http_ok = curl_url_get (curlu, CURLUPART_SCHEME, &scheme, 0) == CURLUE_OK && scheme
                            && (strcmp (scheme, "http") == 0 || strcmp (scheme, "https") == 0)
-                           && curl_url_get (curlu, CURLUPART_HOST, &chost, 0) == CURLUE_OK && chost && chost[0] != '\0';
+                           && curl_url_get (curlu, CURLUPART_HOST, &chost, 0) == CURLUE_OK && chost && chost[0] != '\0'
+                           && curl_url_get (curlu, CURLUPART_QUERY, &query, 0) != CURLUE_OK
+                           && curl_url_get (curlu, CURLUPART_FRAGMENT, &fragment, 0) != CURLUE_OK
+                           && curl_url_get (curlu, CURLUPART_USER, &user_part, 0) != CURLUE_OK
+                           && curl_url_get (curlu, CURLUPART_PASSWORD, &password_part, 0) != CURLUE_OK;
             conn->state = http_ok ? SMM_CONNECTION_NEW : SMM_CONNECTION_HOST_INVALID;
             curl_free (scheme);
             curl_free (chost);
+            curl_free (query);
+            curl_free (fragment);
+            curl_free (user_part);
+            curl_free (password_part);
         }
         curl_url_cleanup (curlu);
     }

--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -81,6 +81,12 @@ smm_c_locale_get (void)
     return smm_c_locale;
 }
 
+static bool
+smm_url_part_absent (CURLU *curlu, CURLUPart part, CURLUcode absent_code, char **out)
+{
+    return curl_url_get (curlu, part, out, 0) == absent_code;
+}
+
 /* asprintf() that formats in the private "C" locale (see above), so coordinate
  * conversions use '.' as the decimal separator regardless of the caller's
  * LC_NUMERIC. Returns the asprintf() result; *strp is undefined on failure.
@@ -223,13 +229,16 @@ smm_asset_connect (const char *host, const char *user, const char *pass)
             char *fragment = NULL;
             char *user_part = NULL;
             char *password_part = NULL;
-            bool http_ok = curl_url_get (curlu, CURLUPART_SCHEME, &scheme, 0) == CURLUE_OK && scheme
-                           && (strcmp (scheme, "http") == 0 || strcmp (scheme, "https") == 0)
-                           && curl_url_get (curlu, CURLUPART_HOST, &chost, 0) == CURLUE_OK && chost && chost[0] != '\0'
-                           && curl_url_get (curlu, CURLUPART_QUERY, &query, 0) != CURLUE_OK
-                           && curl_url_get (curlu, CURLUPART_FRAGMENT, &fragment, 0) != CURLUE_OK
-                           && curl_url_get (curlu, CURLUPART_USER, &user_part, 0) != CURLUE_OK
-                           && curl_url_get (curlu, CURLUPART_PASSWORD, &password_part, 0) != CURLUE_OK;
+            bool scheme_ok = curl_url_get (curlu, CURLUPART_SCHEME, &scheme, 0) == CURLUE_OK && scheme
+                             && (strcmp (scheme, "http") == 0 || strcmp (scheme, "https") == 0);
+            bool host_ok = curl_url_get (curlu, CURLUPART_HOST, &chost, 0) == CURLUE_OK && chost && chost[0] != '\0';
+            bool no_query = smm_url_part_absent (curlu, CURLUPART_QUERY, CURLUE_NO_QUERY, &query);
+            bool no_fragment = smm_url_part_absent (curlu, CURLUPART_FRAGMENT, CURLUE_NO_FRAGMENT, &fragment);
+            /* Userinfo can contain a username without a password, or a
+             * password field without a username; reject either form. */
+            bool no_user = smm_url_part_absent (curlu, CURLUPART_USER, CURLUE_NO_USER, &user_part);
+            bool no_password = smm_url_part_absent (curlu, CURLUPART_PASSWORD, CURLUE_NO_PASSWORD, &password_part);
+            bool http_ok = scheme_ok && host_ok && no_query && no_fragment && no_user && no_password;
             conn->state = http_ok ? SMM_CONNECTION_NEW : SMM_CONNECTION_HOST_INVALID;
             curl_free (scheme);
             curl_free (chost);

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -2,6 +2,7 @@
 #include "smm-asset.h"
 #include <arpa/inet.h>
 #include <check.h>
+#include <errno.h>
 #include <locale.h>
 #include <math.h>
 #include <netinet/in.h>
@@ -653,6 +654,26 @@ struct capture_request_server_s
     char request[2048];
 };
 
+static bool
+write_all (int fd, const char *buf, size_t len)
+{
+    size_t written = 0;
+    while (written < len)
+    {
+        ssize_t nwrite = write (fd, buf + written, len - written);
+        if (nwrite < 0 && errno == EINTR)
+        {
+            continue;
+        }
+        if (nwrite <= 0)
+        {
+            return false;
+        }
+        written += (size_t)nwrite;
+    }
+    return true;
+}
+
 static void *
 capture_search_server_thread (void *arg)
 {
@@ -660,15 +681,26 @@ capture_search_server_thread (void *arg)
     int fd = accept (srv->listen_fd, NULL, NULL);
     if (fd >= 0)
     {
-        ssize_t nread = read (fd, srv->request, sizeof (srv->request) - 1);
-        if (nread > 0)
+        size_t used = 0;
+        while (used + 1 < sizeof (srv->request))
         {
-            srv->request[nread] = '\0';
+            ssize_t nread = read (fd, srv->request + used, sizeof (srv->request) - used - 1);
+            if (nread < 0 && errno == EINTR)
+            {
+                continue;
+            }
+            if (nread <= 0)
+            {
+                break;
+            }
+            used += (size_t)nread;
+            srv->request[used] = '\0';
+            if (strstr (srv->request, "\r\n\r\n") != NULL)
+            {
+                break;
+            }
         }
-        else
-        {
-            srv->request[0] = '\0';
-        }
+        srv->request[used] = '\0';
 
         const char body[] = "{\"object_url\":\"/search/1/\",\"distance\":10,\"length\":100,\"sweep_width\":50}";
         char resp[512];
@@ -680,7 +712,10 @@ capture_search_server_thread (void *arg)
                           "\r\n"
                           "%s",
                           sizeof (body) - 1, body);
-        (void)!write (fd, resp, (size_t)n);
+        if (n > 0 && (size_t)n < sizeof (resp))
+        {
+            (void)!write_all (fd, resp, (size_t)n);
+        }
         close (fd);
     }
     return NULL;

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -2003,6 +2003,33 @@ START_TEST (test_connect_schemeless_invalid)
 }
 END_TEST
 
+START_TEST (test_connect_query_invalid)
+{
+    smm_connection conn = smm_asset_connect ("http://example.com?next=/assets/", "user", "pass");
+    ck_assert_ptr_nonnull (conn);
+    ck_assert_int_eq (smm_asset_connection_get_state (conn), SMM_CONNECTION_HOST_INVALID);
+    smm_connection_close (conn);
+}
+END_TEST
+
+START_TEST (test_connect_fragment_invalid)
+{
+    smm_connection conn = smm_asset_connect ("http://example.com#fragment", "user", "pass");
+    ck_assert_ptr_nonnull (conn);
+    ck_assert_int_eq (smm_asset_connection_get_state (conn), SMM_CONNECTION_HOST_INVALID);
+    smm_connection_close (conn);
+}
+END_TEST
+
+START_TEST (test_connect_userinfo_invalid)
+{
+    smm_connection conn = smm_asset_connect ("http://asset:secret@example.com", "user", "pass");
+    ck_assert_ptr_nonnull (conn);
+    ck_assert_int_eq (smm_asset_connection_get_state (conn), SMM_CONNECTION_HOST_INVALID);
+    smm_connection_close (conn);
+}
+END_TEST
+
 START_TEST (test_connect_null_host)
 {
     smm_connection conn = smm_asset_connect (NULL, "user", "pass");
@@ -2582,6 +2609,9 @@ smm_suite (void)
     tcase_add_test (tc_conn, test_connect_file_scheme_invalid);
     tcase_add_test (tc_conn, test_connect_mailto_scheme_invalid);
     tcase_add_test (tc_conn, test_connect_schemeless_invalid);
+    tcase_add_test (tc_conn, test_connect_query_invalid);
+    tcase_add_test (tc_conn, test_connect_fragment_invalid);
+    tcase_add_test (tc_conn, test_connect_userinfo_invalid);
     tcase_add_test (tc_conn, test_connect_null_host);
     tcase_add_test (tc_conn, test_connect_null_user);
     tcase_add_test (tc_conn, test_connect_null_pass);


### PR DESCRIPTION
## Description

smm_asset_connect accepted hosts such as http://example.com?x and http://example.com#frag because validation only checked the scheme and host. Later request construction appends API paths to the raw host string, producing malformed URLs like http://example.com?x/assets/.

Reject query strings, fragments, and userinfo during CURLU validation while preserving valid http/https hosts and base paths. Add regression tests for query, fragment, and userinfo inputs.

## Summary by Sourcery

Reject non-base URL components in SMM asset connections and harden test HTTP server request handling.

Bug Fixes:
- Treat asset connection hosts containing query strings, fragments, or userinfo as invalid to prevent malformed request URLs.
- Ensure the test capture search server reads full HTTP requests up to headers terminator and writes responses reliably, handling EINTR and partial I/O.

Enhancements:
- Introduce a helper for checking the absence of specific URL parts when validating connection hosts.

Tests:
- Add regression tests asserting that hosts with query strings, fragments, or userinfo are rejected with SMM_CONNECTION_HOST_INVALID.