### PR TITLE
docs: complete the 1.1.0 changelog for post-prepare changes

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -8,6 +8,16 @@ New API and hardening release; fully backwards compatible with 1.0.0
    per-connection libcurl connect and transfer timeouts.
  * Position reports are now submitted via POST with a CSRF token, matching
    the current Search Management Map API, instead of an interpreted GET URL.
+   A POST rejected with HTTP 403 (typically a CSRF token the server has
+   rotated) triggers a single re-authenticate-and-retry, and the rotated
+   csrftoken cookie set at login is now preserved for subsequent requests.
+ * Closest-search lookups now request application/json explicitly.
+ * Per-connection network I/O is serialised so the shared cookie jar stays
+   consistent when one connection is used from several threads; use separate
+   connections for genuinely parallel transfers.
+ * A connection transitions to SMM_CONNECTION_CONNECTED after the first
+   successful request, not only after an explicit
+   smm_asset_connection_login().
  * Stricter, fail-closed input validation: asset and search ids must be
    positive, GOTO and outbound positions and search coordinates must be
    fresh and within range, and search object_url paths must match
@@ -15,10 +25,13 @@ New API and hardening release; fully backwards compatible with 1.0.0
    parsing waypoints.
  * get_search() reports parse and protocol errors and distinguishes a 404
    "no search" result instead of failing silently.
- * Hardened HTTP handling: reject non-http(s) URL schemes in
-   smm_asset_connect(), guard the libcurl write callbacks against
-   size * nmemb overflow, cap login-page buffering at SMM_MAX_RESPONSE_BYTES,
-   and initialize libcurl global state exactly once via pthread_once.
+ * Hardened HTTP handling: smm_asset_connect() rejects host URLs that are
+   not http(s) or that carry userinfo, query, or fragment components; the
+   libcurl write callbacks are guarded against size * nmemb overflow;
+   login-page buffering is capped at SMM_MAX_RESPONSE_BYTES; and libcurl
+   global state is initialized exactly once via pthread_once.
+ * Credentials and the session token are scrubbed from memory before the
+   connection is freed.
  * Fixed a connection reference leak when smm_asset_create() fails.
 
 libsmm-asset 1.0.0

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,13 +2,20 @@ libsmm-asset (1.1.0) unstable; urgency=medium
 
   * New smm_asset_connection_timeouts_set() for per-connection libcurl
     connect/transfer timeouts (compatible ABI addition; SONAME unchanged).
-  * Report asset position via POST with a CSRF token.
+  * Report asset position via POST with a CSRF token; retry once on a 403
+    by re-authenticating, and preserve the rotated csrftoken cookie.
+  * Request application/json explicitly for closest-search lookups.
+  * Serialise per-connection network I/O to keep the shared cookie jar
+    consistent across threads.
+  * Mark the connection CONNECTED after the first successful request.
   * Stricter input validation for ids, coordinates and search object_url;
-    reject malformed or empty route geometry.
+    reject malformed or empty route geometry; reject host URLs carrying
+    userinfo, query, or fragment components.
   * get_search() reports parse/protocol errors and a 404 no-search result.
+  * Scrub credentials and the session token before freeing the connection.
   * Hardened HTTP handling; see NEWS for the full summary.
 
- -- Scott Parlane <sjp@canterburyairpatrol.org>  Sun, 29 Jun 2026 00:00:00 +0000
+ -- Scott Parlane <sjp@canterburyairpatrol.org>  Mon, 30 Jun 2026 00:00:00 +0000
 
 libsmm-asset (1.0.0) unstable; urgency=medium
 


### PR DESCRIPTION
## Description

The NEWS and debian/changelog entries were written at "release: prepare 1.1.0" time, before several user-visible changes landed. Record them: the 403/CSRF re-auth-and-retry and rotated-cookie preservation, the explicit application/json closest-search request, per-connection I/O serialisation, the CONNECTED-after-first-request transition, the userinfo/query/fragment host rejection, and credential/session-token scrubbing before free. Set the debian release date to the finalisation date.

## Summary by Sourcery

Update release notes for version 1.1.0 to reflect post-prepare user-visible changes and finalise Debian packaging metadata.

Build:
- Update debian/changelog with the final 1.1.0 release date and description of late-breaking changes.

Documentation:
- Expand NEWS to document additional 1.1.0 user-visible changes, including auth handling, request semantics, connection behaviour, and security-related scrubbing.