### PR TITLE
fix: do not crash on valueless attributes in the login page

### DIFF
--- a/src/smm-asset-curl.c
+++ b/src/smm-asset-curl.c
@@ -556,20 +556,29 @@ extract_csrfmiddlewaretoken (TidyDoc tdoc, TidyNode tnod, char **token, int dept
             {
                 bool is_csrf = false;
                 ctmbstr value = NULL;
-                /* check the attributes */
+                /* check the attributes. Tidy returns NULL from tidyAttrName
+                 * for a malformed/anonymous attribute and from tidyAttrValue
+                 * for a valueless one (e.g. "<input name>"); both must be
+                 * skipped, not dereferenced — a hostile or broken login page
+                 * must degrade to "no token found", never crash the host. */
                 for (TidyAttr attr = tidyAttrFirst (child); attr; attr = tidyAttrNext (attr))
                 {
                     ctmbstr attrName = tidyAttrName (attr);
+                    ctmbstr attrValue = tidyAttrValue (attr);
+                    if (attrName == NULL || attrValue == NULL)
+                    {
+                        continue;
+                    }
                     if (strcmp (attrName, "name") == 0)
                     {
-                        if (strcmp (tidyAttrValue (attr), "csrfmiddlewaretoken") == 0)
+                        if (strcmp (attrValue, "csrfmiddlewaretoken") == 0)
                         {
                             is_csrf = true;
                         }
                     }
                     else if (strcmp (attrName, "value") == 0)
                     {
-                        value = tidyAttrValue (attr);
+                        value = attrValue;
                     }
                 }
                 if (is_csrf && value)

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -85,6 +85,31 @@ START_TEST (test_csrf_extraction_deeply_nested)
 }
 END_TEST
 
+START_TEST (test_csrf_extraction_valueless_attribute)
+{
+    /* Tidy reports NULL for the value of a valueless attribute; the walker
+     * must skip it, not dereference it. Regression test for a segfault on
+     * "<input name>". */
+    const char *html = "<html><body><input name><input name value>"
+                       "<input name=\"csrfmiddlewaretoken\" value></body></html>";
+    char *token = smm_parse_csrf_token (html, strlen (html));
+    ck_assert_ptr_null (token);
+}
+END_TEST
+
+START_TEST (test_csrf_extraction_valueless_then_valid)
+{
+    /* A valueless attribute earlier in the document must not stop a later,
+     * well-formed token from being extracted. */
+    const char *html = "<html><body><input name>"
+                       "<input name=\"csrfmiddlewaretoken\" value=\"abcd1234\"></body></html>";
+    char *token = smm_parse_csrf_token (html, strlen (html));
+    ck_assert_ptr_nonnull (token);
+    ck_assert_str_eq (token, "abcd1234");
+    free (token);
+}
+END_TEST
+
 START_TEST (test_assets_parsing)
 {
     const char *json = "{\"assets\": [{\"id\": 1, \"type_id\": 2, \"name\": \"Asset 1\", \"type_name\": \"Type "
@@ -2783,6 +2808,8 @@ smm_suite (void)
     tcase_add_test (tc_csrf, test_csrf_extraction_invalid_chars);
     tcase_add_test (tc_csrf, test_csrf_extraction_too_long);
     tcase_add_test (tc_csrf, test_csrf_extraction_deeply_nested);
+    tcase_add_test (tc_csrf, test_csrf_extraction_valueless_attribute);
+    tcase_add_test (tc_csrf, test_csrf_extraction_valueless_then_valid);
     suite_add_tcase (s, tc_csrf);
 
     TCase *tc_assets = tcase_create ("Assets");


### PR DESCRIPTION
## Description

Tidy returns NULL from tidyAttrValue for a valueless attribute (and from tidyAttrName for a malformed one), so a login page containing "<input name>" segfaulted the host application in
extract_csrfmiddlewaretoken. Skip such attributes: a hostile or broken login page must degrade to "no token found" (and from there to SMM_CONNECTION_PROTOCOL_ERROR), never crash.

## Summary by Sourcery

Prevent crashes when parsing CSRF tokens from malformed or valueless input attributes on the login page.

Bug Fixes:
- Skip malformed or valueless input attributes when extracting the csrfmiddlewaretoken to avoid dereferencing NULL and crashing.

Tests:
- Add regression tests covering valueless input attributes and ensuring valid CSRF tokens are still extracted when present later in the document.