### PR TITLE
fix: normalise host comparison for the https upgrade

### DIFF
--- a/src/smm-asset-curl.c
+++ b/src/smm-asset-curl.c
@@ -697,8 +697,16 @@ smm_connection_try_https_upgrade (smm_connection conn, const char *redirect_url)
     if (strncmp (conn->host, http_scheme, http_scheme_len) == 0
         && smm_https_upgrade_is_same_host (conn->host, redirect_url))
     {
+        /* Adopt the redirect's authority rather than reusing the http one:
+         * the two may differ in default-port spelling ("http://host:80" must
+         * become "https://host", not "https://host:80", which would drive TLS
+         * at port 80). Any base path is preserved from the original host. */
+        const char *orig_auth = conn->host + http_scheme_len;
+        size_t orig_auth_len = strcspn (orig_auth, "/?#");
+        const char *redir_auth = redirect_url + sizeof ("https://") - 1;
+        size_t redir_auth_len = strcspn (redir_auth, "/?#");
         char *new_host = NULL;
-        if (asprintf (&new_host, "https://%s", conn->host + http_scheme_len) >= 0)
+        if (asprintf (&new_host, "https://%.*s%s", (int)redir_auth_len, redir_auth, orig_auth + orig_auth_len) >= 0)
         {
             free (conn->host);
             conn->host = new_host;
@@ -872,6 +880,47 @@ smm_httpcode_is_redirect (long httpcode)
     return httpcode == HTTP_MOVED_PERMANENTLY || httpcode == HTTP_FOUND || httpcode == HTTP_SEE_OTHER;
 }
 
+/* Split an authority span ("host[:port]", len bytes, not NUL-terminated at
+ * len) into its host and optional port. Handles bracketed IPv6 literals, whose
+ * colons are part of the host. A missing port leaves *port NULL. */
+static void
+smm_split_authority (const char *auth, size_t len, const char **host, size_t *host_len, const char **port,
+                     size_t *port_len)
+{
+    *host = auth;
+    *host_len = len;
+    *port = NULL;
+    *port_len = 0;
+
+    const char *colon = NULL;
+    if (len > 0 && auth[0] == '[')
+    {
+        /* Bracketed IPv6 literal: the host is the bracketed span; a port may
+         * follow after "]:". An unterminated bracket leaves the whole span as
+         * the host (it will simply fail to match a well-formed one). */
+        const char *close = memchr (auth, ']', len);
+        if (close == NULL)
+        {
+            return;
+        }
+        *host_len = (size_t)(close + 1 - auth);
+        if (*host_len < len && close[1] == ':')
+        {
+            colon = close + 1;
+        }
+    }
+    else
+    {
+        colon = memchr (auth, ':', len);
+    }
+    if (colon != NULL)
+    {
+        *host_len = (size_t)(colon - auth);
+        *port = colon + 1;
+        *port_len = len - (size_t)(*port - auth);
+    }
+}
+
 bool
 smm_https_upgrade_is_same_host (const char *http_host, const char *https_redirect)
 {
@@ -882,14 +931,50 @@ smm_https_upgrade_is_same_host (const char *http_host, const char *https_redirec
     if (strncmp (https_redirect, "https://", 8) != 0)
         return false;
 
-    const char *orig_host = http_host + 7;
-    const char *redir_host = https_redirect + 8;
+    const char *orig_auth = http_host + 7;
+    const char *redir_auth = https_redirect + 8;
 
-    /* Host ends at '/', '?', '#', or end of string */
-    size_t orig_len = strcspn (orig_host, "/?#");
-    size_t redir_len = strcspn (redir_host, "/?#");
+    /* The authority ends at '/', '?', '#', or end of string */
+    size_t orig_auth_len = strcspn (orig_auth, "/?#");
+    size_t redir_auth_len = strcspn (redir_auth, "/?#");
 
-    return orig_len == redir_len && strncmp (orig_host, redir_host, orig_len) == 0;
+    const char *orig_host = NULL;
+    const char *redir_host = NULL;
+    const char *orig_port = NULL;
+    const char *redir_port = NULL;
+    size_t orig_host_len = 0;
+    size_t redir_host_len = 0;
+    size_t orig_port_len = 0;
+    size_t redir_port_len = 0;
+    smm_split_authority (orig_auth, orig_auth_len, &orig_host, &orig_host_len, &orig_port, &orig_port_len);
+    smm_split_authority (redir_auth, redir_auth_len, &redir_host, &redir_host_len, &redir_port, &redir_port_len);
+
+    /* DNS names are case-insensitive, so compare the hostnames that way; an
+     * empty host never matches. */
+    if (orig_host_len == 0 || orig_host_len != redir_host_len
+        || !smm_ascii_caseeq (orig_host, redir_host, orig_host_len))
+        return false;
+
+    /* A missing port means the scheme default. */
+    if (orig_port == NULL)
+    {
+        orig_port = "80";
+        orig_port_len = 2;
+    }
+    if (redir_port == NULL)
+    {
+        redir_port = "443";
+        redir_port_len = 3;
+    }
+
+    /* Same explicit port carried through (e.g. :8080 -> :8080), or the
+     * standard http->https default-port upgrade (80 -> 443, spelled out or
+     * implied). Anything else (e.g. :8080 -> :8443) is not verifiably the
+     * same server, so the downgrade guard stays closed. */
+    if (orig_port_len == redir_port_len && strncmp (orig_port, redir_port, orig_port_len) == 0)
+        return true;
+    return orig_port_len == 2 && strncmp (orig_port, "80", 2) == 0 && redir_port_len == 3
+           && strncmp (redir_port, "443", 3) == 0;
 }
 
 struct smm_curl_res_s *

--- a/src/smm-asset-internal.h
+++ b/src/smm-asset-internal.h
@@ -227,3 +227,8 @@ bool smm_connection_try_https_upgrade (smm_connection conn, const char *redirect
  * ASCII case, leading whitespace, and any parameters (e.g. "; charset=utf-8").
  * A NULL content_type returns false. */
 bool smm_content_type_is_json (const char *content_type);
+
+/* ASCII-only, case-insensitive comparison of the first n bytes; stops (and
+ * mismatches) at a NUL on either side. Locale-independent, unlike
+ * strncasecmp. */
+bool smm_ascii_caseeq (const char *a, const char *b, size_t n);

--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -899,9 +899,10 @@ smm_asset_set_command_from_plaintext (smm_asset asset, const char *data, size_t 
 }
 
 /* ASCII-only, case-insensitive comparison of the first n bytes. Used for
- * media-type matching so the result does not depend on the caller's locale
- * (e.g. the Turkish dotless-i rule that would break strncasecmp). */
-static bool
+ * media-type and hostname matching so the result does not depend on the
+ * caller's locale (e.g. the Turkish dotless-i rule that would break
+ * strncasecmp). */
+bool
 smm_ascii_caseeq (const char *a, const char *b, size_t n)
 {
     for (size_t i = 0; i < n; i++)

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -1514,8 +1514,44 @@ END_TEST
 
 START_TEST (test_https_upgrade_different_port)
 {
-    ck_assert_int_eq (smm_https_upgrade_is_same_host ("http://example.com:80", "https://example.com:443/login/"),
+    /* Genuinely different, non-default ports are not verifiably the same
+     * server; the downgrade guard stays closed. */
+    ck_assert_int_eq (smm_https_upgrade_is_same_host ("http://example.com:8080", "https://example.com:8443/login/"),
                       false);
+    ck_assert_int_eq (smm_https_upgrade_is_same_host ("http://example.com:8080", "https://example.com/login/"), false);
+    ck_assert_int_eq (smm_https_upgrade_is_same_host ("http://example.com", "https://example.com:8443/login/"), false);
+}
+END_TEST
+
+START_TEST (test_https_upgrade_explicit_default_ports)
+{
+    /* An explicit default port is the same origin as the implied one: the
+     * standard http(80)->https(443) upgrade must match however the defaults
+     * are spelled. */
+    ck_assert_int_eq (smm_https_upgrade_is_same_host ("http://example.com:80", "https://example.com/login/"), true);
+    ck_assert_int_eq (smm_https_upgrade_is_same_host ("http://example.com", "https://example.com:443/login/"), true);
+    ck_assert_int_eq (smm_https_upgrade_is_same_host ("http://example.com:80", "https://example.com:443/login/"), true);
+}
+END_TEST
+
+START_TEST (test_https_upgrade_hostname_case_insensitive)
+{
+    /* DNS names are case-insensitive; a server that answers with a
+     * differently-cased canonical name is still the same host. */
+    ck_assert_int_eq (smm_https_upgrade_is_same_host ("http://Example.COM", "https://example.com/login/"), true);
+    ck_assert_int_eq (smm_https_upgrade_is_same_host ("http://example.com:8080", "https://EXAMPLE.com:8080/login/"),
+                      true);
+}
+END_TEST
+
+START_TEST (test_https_upgrade_ipv6_literal)
+{
+    /* Bracketed IPv6 literals: the colons inside the brackets are part of
+     * the host, not a port separator. */
+    ck_assert_int_eq (smm_https_upgrade_is_same_host ("http://[::1]:8080", "https://[::1]:8080/login/"), true);
+    ck_assert_int_eq (smm_https_upgrade_is_same_host ("http://[::1]", "https://[::1]/login/"), true);
+    ck_assert_int_eq (smm_https_upgrade_is_same_host ("http://[::1]", "https://[::2]/login/"), false);
+    ck_assert_int_eq (smm_https_upgrade_is_same_host ("http://[::1]:8080", "https://[::1]:8443/login/"), false);
 }
 END_TEST
 
@@ -1537,6 +1573,19 @@ END_TEST
 START_TEST (test_try_https_upgrade_switches_host)
 {
     smm_connection conn = smm_asset_connect ("http://example.com", "user", "pass");
+    ck_assert_ptr_nonnull (conn);
+    ck_assert_int_eq (smm_connection_try_https_upgrade (conn, "https://example.com/accounts/login/"), true);
+    ck_assert_str_eq (conn->host, "https://example.com");
+    smm_connection_close (conn);
+}
+END_TEST
+
+START_TEST (test_try_https_upgrade_drops_explicit_default_port)
+{
+    /* The upgraded host adopts the redirect's authority: an explicit :80 on
+     * the http host must not be carried into the https host (that would
+     * drive TLS at port 80). */
+    smm_connection conn = smm_asset_connect ("http://example.com:80", "user", "pass");
     ck_assert_ptr_nonnull (conn);
     ck_assert_int_eq (smm_connection_try_https_upgrade (conn, "https://example.com/accounts/login/"), true);
     ck_assert_str_eq (conn->host, "https://example.com");
@@ -2717,10 +2766,14 @@ smm_suite (void)
     tcase_add_test (tc_conn, test_https_upgrade_different_host);
     tcase_add_test (tc_conn, test_https_upgrade_subdomain);
     tcase_add_test (tc_conn, test_https_upgrade_different_port);
+    tcase_add_test (tc_conn, test_https_upgrade_explicit_default_ports);
+    tcase_add_test (tc_conn, test_https_upgrade_hostname_case_insensitive);
+    tcase_add_test (tc_conn, test_https_upgrade_ipv6_literal);
     tcase_add_test (tc_conn, test_https_upgrade_null_args);
     tcase_add_test (tc_conn, test_https_upgrade_non_http_http_host);
     tcase_add_test (tc_conn, test_https_upgrade_already_https);
     tcase_add_test (tc_conn, test_try_https_upgrade_switches_host);
+    tcase_add_test (tc_conn, test_try_https_upgrade_drops_explicit_default_port);
     tcase_add_test (tc_conn, test_try_https_upgrade_rejects_other_host);
     tcase_add_test (tc_conn, test_try_https_upgrade_null_args);
     tcase_add_test (tc_conn, test_try_https_upgrade_preserves_port);


### PR DESCRIPTION
## Description

smm_https_upgrade_is_same_host compared the two host[:port] spans byte-for-byte, so an explicit default port ("http://host:80" redirected to "https://host/") or a hostname case difference failed the match and login against such a deployment hard-failed with no hint why. Split the authority properly (including bracketed IPv6 literals), compare hostnames ASCII-case-insensitively, and treat a missing port as the scheme default so the standard 80->443 upgrade matches however it is spelled. Genuinely different ports still fail closed.

The upgraded host now adopts the redirect's authority rather than reusing the http one, so an explicit :80 is not carried into the https host (which would have driven TLS at port 80).

## Summary by Sourcery

Normalize HTTPS upgrade host comparison and ensure upgraded connections adopt the redirect’s authority safely.

Bug Fixes:
- Treat explicit and implicit default ports (http:80/https:443) as equivalent when validating HTTPS upgrades so legitimate redirects no longer fail.
- Compare hostnames case-insensitively and correctly parse IPv6 literal authorities when checking HTTPS upgrade origins.
- Ensure upgraded HTTPS connections drop explicit default :80 from the authority to avoid attempting TLS on port 80.

Enhancements:
- Expose and reuse a locale-independent ASCII case-insensitive comparison helper for both media-type and hostname matching.

Tests:
- Add test coverage for default-port equivalence, hostname case-insensitivity, IPv6 literal handling, non-default port rejection, and preserving/dropping ports during HTTPS upgrade.