### PR TITLE
fix: detect the login redirect by path, not substring

### DIFF
--- a/src/smm-asset-curl.c
+++ b/src/smm-asset-curl.c
@@ -873,6 +873,50 @@ smm_asset_connection_login (smm_connection connection)
 }
 
 bool
+smm_redirect_is_login_page (const char *redirect_url)
+{
+    /* Match on the URL's path component only, so a query string or fragment
+     * that merely mentions the login page (e.g. "?next=/accounts/login/")
+     * cannot masquerade as a login redirect. The path must end in the Django
+     * login page at a segment boundary (the leading '/' in the needle),
+     * tolerating a server-configured base path prefix and a missing trailing
+     * slash. */
+    static const char login_path[] = "/accounts/login";
+    const size_t login_len = sizeof (login_path) - 1;
+
+    if (redirect_url == NULL)
+    {
+        return false;
+    }
+
+    CURLU *curlu = curl_url ();
+    if (curlu == NULL)
+    {
+        return false;
+    }
+
+    bool is_login = false;
+    /* CURLINFO_REDIRECT_URL is always absolute, so a plain parse suffices;
+     * anything unparseable is not a login redirect. */
+    if (curl_url_set (curlu, CURLUPART_URL, redirect_url, 0) == CURLUE_OK)
+    {
+        char *path = NULL;
+        if (curl_url_get (curlu, CURLUPART_PATH, &path, 0) == CURLUE_OK && path)
+        {
+            size_t len = strlen (path);
+            if (len > 0 && path[len - 1] == '/')
+            {
+                len--;
+            }
+            is_login = len >= login_len && strncmp (path + len - login_len, login_path, login_len) == 0;
+            curl_free (path);
+        }
+    }
+    curl_url_cleanup (curlu);
+    return is_login;
+}
+
+bool
 smm_httpcode_is_redirect (long httpcode)
 {
     /* The redirects we follow: 301 (e.g. Django's SECURE_SSL_REDIRECT
@@ -1001,7 +1045,7 @@ smm_connection_curl_retrieve_url (smm_connection conn, const char *path, const c
                 retry = true;
             }
 
-            if (!retry && strstr (res->redirect_url, "accounts/login") != NULL)
+            if (!retry && smm_redirect_is_login_page (res->redirect_url))
             {
                 DEBUG ("Login required\n");
                 if (smm_asset_connection_login (conn))

--- a/src/smm-asset-internal.h
+++ b/src/smm-asset-internal.h
@@ -213,6 +213,14 @@ smm_search smm_search_from_response (smm_asset asset, long httpcode, const char 
  * (301, 302, 303). */
 bool smm_httpcode_is_redirect (long httpcode);
 
+/* Returns true if redirect_url's path component ends with the Django login
+ * page ("/accounts/login/", trailing slash optional, base-path prefix
+ * allowed) at a path-segment boundary. Matching on the parsed path — not the
+ * whole URL — keeps a query string or fragment that merely mentions the
+ * login page from being mistaken for a login redirect. NULL or an
+ * unparseable URL returns false. Exposed for testing. */
+bool smm_redirect_is_login_page (const char *redirect_url);
+
 /* Returns true if https_redirect is an HTTPS upgrade of http_host to the
  * same host:port — used to guard against redirect-based downgrade attacks. */
 bool smm_https_upgrade_is_same_host (const char *http_host, const char *https_redirect);

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -1570,6 +1570,34 @@ START_TEST (test_https_upgrade_non_http_http_host)
 }
 END_TEST
 
+START_TEST (test_redirect_is_login_page_matches)
+{
+    ck_assert_int_eq (smm_redirect_is_login_page ("https://example.com/accounts/login/"), true);
+    /* Django appends ?next=<original path>. */
+    ck_assert_int_eq (smm_redirect_is_login_page ("https://example.com/accounts/login/?next=/assets/"), true);
+    /* A server-configured base path prefixes the login path. */
+    ck_assert_int_eq (smm_redirect_is_login_page ("https://example.com/smm/accounts/login/"), true);
+    /* Trailing slash is optional. */
+    ck_assert_int_eq (smm_redirect_is_login_page ("https://example.com/accounts/login"), true);
+    ck_assert_int_eq (smm_redirect_is_login_page ("http://example.com:8080/accounts/login/"), true);
+}
+END_TEST
+
+START_TEST (test_redirect_is_login_page_rejects_lookalikes)
+{
+    /* The login path in the query string or fragment is not a login
+     * redirect; only the path component counts. */
+    ck_assert_int_eq (smm_redirect_is_login_page ("https://example.com/docs/?highlight=accounts/login"), false);
+    ck_assert_int_eq (smm_redirect_is_login_page ("https://example.com/dashboard/?next=/accounts/login/"), false);
+    ck_assert_int_eq (smm_redirect_is_login_page ("https://example.com/#accounts/login"), false);
+    /* The match is anchored at a path-segment boundary. */
+    ck_assert_int_eq (smm_redirect_is_login_page ("https://example.com/xaccounts/login/"), false);
+    ck_assert_int_eq (smm_redirect_is_login_page ("https://example.com/accounts/login2/"), false);
+    ck_assert_int_eq (smm_redirect_is_login_page ("https://example.com/accounts/"), false);
+    ck_assert_int_eq (smm_redirect_is_login_page (NULL), false);
+}
+END_TEST
+
 START_TEST (test_try_https_upgrade_switches_host)
 {
     smm_connection conn = smm_asset_connect ("http://example.com", "user", "pass");
@@ -2772,6 +2800,8 @@ smm_suite (void)
     tcase_add_test (tc_conn, test_https_upgrade_null_args);
     tcase_add_test (tc_conn, test_https_upgrade_non_http_http_host);
     tcase_add_test (tc_conn, test_https_upgrade_already_https);
+    tcase_add_test (tc_conn, test_redirect_is_login_page_matches);
+    tcase_add_test (tc_conn, test_redirect_is_login_page_rejects_lookalikes);
     tcase_add_test (tc_conn, test_try_https_upgrade_switches_host);
     tcase_add_test (tc_conn, test_try_https_upgrade_drops_explicit_default_port);
     tcase_add_test (tc_conn, test_try_https_upgrade_rejects_other_host);


### PR DESCRIPTION
## Description

The retry loop decided "this redirect means we must authenticate" with strstr(redirect_url, "accounts/login"), which matches the text anywhere in the URL — including a ?next=/accounts/login/ query on an unrelated page. Parse the redirect URL with the CURLU machinery instead and match only a path component ending in /accounts/login/ at a segment boundary (base-path prefix allowed, trailing slash optional). A false positive was benign (a spurious login attempt against our own host), but the check now says what it means.

## Summary by Sourcery

Tighten detection of authentication redirects to the Django login page by parsing redirect URLs and matching on the path component only, and add tests to cover valid and lookalike login redirects.

Bug Fixes:
- Avoid falsely treating redirects that only mention /accounts/login/ in query strings or fragments as login redirects.

Tests:
- Add unit tests validating correct identification of login-page redirects and rejection of lookalike URLs.