### PR TITLE
fix: send asset_id in the search-action POST body, not the query string

### DIFF
--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -1330,40 +1330,44 @@ smm_search_action (smm_search search, const char *action)
         return false;
     }
     char *action_page = NULL;
+    char *body = NULL;
     struct buffer_s buf = { NULL, 0 };
 
     /* Build the path from the parsed search id, not a server string, so it can
      * only ever be /search/<id>/<action>/. */
-    if (asprintf (&action_page, "/search/%lld/%s/?asset_id=%lli", search->search_id, action, search->asset_id) < 0)
+    if (asprintf (&action_page, "/search/%lld/%s/", search->search_id, action) < 0)
     {
+        return false;
+    }
+    /* POST, not GET: search state changes (begin/finished) are @require_POST
+     * on the server since the CSRF hardening that also moved position
+     * reporting to POST. asset_id must travel in the POST body: on a POST the
+     * server reads it from the form data only, so a query-string asset_id is
+     * invisible and the action 404s. */
+    if (asprintf (&body, "asset_id=%lli", search->asset_id) < 0)
+    {
+        free (action_page);
         return false;
     }
     smm_search_clear_error (search);
 
-    /* POST, not GET: search state changes (begin/finished) are @require_POST
-     * on the server since the CSRF hardening that also moved position
-     * reporting to POST.  An empty body is enough -- asset_id rides in the
-     * query string and the view accepts it from GET or POST. */
-    struct smm_curl_res_s *res = smm_connection_curl_retrieve_url (search->conn, action_page, "", &buf, false);
+    struct smm_curl_res_s *res = smm_connection_curl_retrieve_url (search->conn, action_page, body, &buf, false);
+    free (action_page);
+    free (body);
     if (res == NULL)
     {
         smm_search_set_error (search, SMM_ERROR_NETWORK, "network failure sending %s action", action);
-        free (action_page);
         return false;
     }
-    else if (!(res->success && res->httpcode == HTTP_SUCCESS))
+    if (!(res->success && res->httpcode == HTTP_SUCCESS))
     {
         smm_search_set_error (search, SMM_ERROR_SERVER, "unexpected HTTP %ld from %s action", res->httpcode, action);
         smm_curl_res_free (res);
-        free (action_page);
         free (buf.data);
         return false;
     }
 
     smm_curl_res_free (res);
-    free (action_page);
-    action_page = NULL;
-
     free (buf.data);
 
     return true;

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -720,9 +720,23 @@ capture_search_server_thread (void *arg)
             }
             used += (size_t)nread;
             srv->request[used] = '\0';
-            if (strstr (srv->request, "\r\n\r\n") != NULL)
+            /* Read past the header block until the whole Content-Length body
+             * has arrived too, so a request whose body lands in a separate
+             * TCP segment is still captured completely. */
+            const char *hdr_end = strstr (srv->request, "\r\n\r\n");
+            if (hdr_end != NULL)
             {
-                break;
+                size_t body_want = 0;
+                const char *cl = strstr (srv->request, "Content-Length: ");
+                if (cl != NULL)
+                {
+                    body_want = strtoul (cl + sizeof ("Content-Length: ") - 1, NULL, 10);
+                }
+                size_t body_have = used - (size_t)(hdr_end + 4 - srv->request);
+                if (body_have >= body_want)
+                {
+                    break;
+                }
             }
         }
         srv->request[used] = '\0';
@@ -837,20 +851,22 @@ check_search_action_sends_post (bool (*action) (smm_search), const char *expecte
     smm_connection_close (conn);
 
     ck_assert_ptr_nonnull (strstr (srv.request, expected_request_line));
-    /* An empty POST body: asset_id travels in the query string. */
-    ck_assert_ptr_nonnull (strstr (srv.request, "Content-Length: 0\r\n"));
+    /* asset_id must be in the POST body (anchored after the header block):
+     * on a POST the server reads form data only, so a query-string asset_id
+     * is invisible and the action 404s. */
+    ck_assert_ptr_nonnull (strstr (srv.request, "\r\n\r\nasset_id=7"));
     ck_assert_ptr_nonnull (strstr (srv.request, "X-CSRFToken: tok123abc\r\n"));
 }
 
 START_TEST (test_search_accept_sends_post)
 {
-    check_search_action_sends_post (smm_search_accept, "POST /search/1/begin/?asset_id=7 HTTP/1.1");
+    check_search_action_sends_post (smm_search_accept, "POST /search/1/begin/ HTTP/1.1");
 }
 END_TEST
 
 START_TEST (test_search_complete_sends_post)
 {
-    check_search_action_sends_post (smm_search_complete, "POST /search/1/finished/?asset_id=7 HTTP/1.1");
+    check_search_action_sends_post (smm_search_complete, "POST /search/1/finished/ HTTP/1.1");
 }
 END_TEST
 


### PR DESCRIPTION
## Description

The POST migration of the search begin/finished actions kept asset_id in the query string, but on a POST the server's asset_id_in_get_post decorator reads form data only, so the query-string asset_id was invisible and both actions 404'd against a real SMM (caught by the new integration lifecycle test on its first run). Move asset_id into the POST body and update the wire-format unit tests to match; the capture server now reads Content-Length worth of body so the assertion cannot race a body arriving in a separate segment.

## Summary by Sourcery

Send search action asset IDs in the POST body instead of the query string and update tests to reflect the new wire format.

Bug Fixes:
- Ensure search begin/finished actions are correctly routed by including asset_id in POST form data instead of the query string, avoiding 404 responses when talking to a real SMM server.

Tests:
- Update the search action wire-format tests to expect asset_id in the POST body and robustly capture full HTTP requests including bodies based on Content-Length.