### PR TITLE
test: run the full search lifecycle in the integration suite

### DIFF
--- a/tests/integration_test.c
+++ b/tests/integration_test.c
@@ -1,5 +1,6 @@
 #include "smm-asset.h"
 #include <assert.h>
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -66,6 +67,83 @@ main (void)
         return 1;
     }
     printf ("Position reported.\n");
+
+    /* Full search lifecycle against the live server: find the closest search,
+     * fetch its waypoints, accept it, report a position mid-search, and mark
+     * it complete. This is the layer that catches the server changing its
+     * contract — both GET->POST endpoint migrations (position reports, then
+     * search begin/finished) shipped as regressions because only connect +
+     * report-position was exercised here. Provisioning creates a sector
+     * search centred on the position reported above. */
+    printf ("Requesting a search for asset %s...\n", smm_asset_name (assets[0]));
+    smm_search search = smm_asset_get_search (assets[0], -43.5, 172.6);
+    if (!search)
+    {
+        char msg[256];
+        smm_error_code code = smm_asset_get_last_error (assets[0], msg, sizeof (msg));
+        fprintf (stderr, "No search offered (error %d: %s)\n", code, msg);
+        smm_asset_free_assets (assets, count);
+        smm_connection_close (conn);
+        return 1;
+    }
+    printf ("Search offered: distance %" PRIu64 "m, length %" PRIu64 "m, sweep width %" PRIu64 "m\n",
+            smm_search_distance (search), smm_search_length (search), smm_search_sweep_width (search));
+
+    smm_waypoints waypoints = NULL;
+    size_t waypoints_count = 0;
+    if (!smm_search_get_waypoints (search, &waypoints, &waypoints_count))
+    {
+        char msg[256];
+        smm_error_code code = smm_search_get_last_error (search, msg, sizeof (msg));
+        fprintf (stderr, "Failed to get waypoints (error %d: %s)\n", code, msg);
+        smm_search_destroy (search);
+        smm_asset_free_assets (assets, count);
+        smm_connection_close (conn);
+        return 1;
+    }
+    printf ("Search has %zu waypoints\n", waypoints_count);
+    assert (waypoints_count >= 2);
+
+    if (!smm_search_accept (search))
+    {
+        char msg[256];
+        smm_error_code code = smm_search_get_last_error (search, msg, sizeof (msg));
+        fprintf (stderr, "Failed to accept search (error %d: %s)\n", code, msg);
+        smm_waypoints_free (waypoints, waypoints_count);
+        smm_search_destroy (search);
+        smm_asset_free_assets (assets, count);
+        smm_connection_close (conn);
+        return 1;
+    }
+    printf ("Search accepted.\n");
+
+    /* Report a position at the first waypoint, as an asset running the
+     * search would. */
+    if (!smm_asset_report_position (assets[0], waypoints[0]->lat, waypoints[0]->lon, 35, 270, 3))
+    {
+        char msg[256];
+        smm_error_code code = smm_asset_get_last_error (assets[0], msg, sizeof (msg));
+        fprintf (stderr, "Failed to report position mid-search (error %d: %s)\n", code, msg);
+        smm_waypoints_free (waypoints, waypoints_count);
+        smm_search_destroy (search);
+        smm_asset_free_assets (assets, count);
+        smm_connection_close (conn);
+        return 1;
+    }
+    smm_waypoints_free (waypoints, waypoints_count);
+
+    if (!smm_search_complete (search))
+    {
+        char msg[256];
+        smm_error_code code = smm_search_get_last_error (search, msg, sizeof (msg));
+        fprintf (stderr, "Failed to complete search (error %d: %s)\n", code, msg);
+        smm_search_destroy (search);
+        smm_asset_free_assets (assets, count);
+        smm_connection_close (conn);
+        return 1;
+    }
+    printf ("Search completed.\n");
+    smm_search_destroy (search);
 
     smm_asset_free_assets (assets, count);
     smm_connection_close (conn);

--- a/tests/provision.sh
+++ b/tests/provision.sh
@@ -27,7 +27,12 @@ done
 echo "Provisioning test data..."
 $COMPOSE exec -T smm /code/venv/bin/python manage.py shell <<EOF
 from django.contrib.auth.models import User
+from django.contrib.gis.geos import Point
 from assets.models import Asset, AssetType
+from data.models import GeoTimeLabel
+from mission.models import Mission, MissionAsset, MissionUser
+from search.models import Search, SearchParams
+
 if not User.objects.filter(username='testuser').exists():
     User.objects.create_superuser('testuser', 'test@example.com', 'testpass')
 else:
@@ -36,8 +41,28 @@ else:
     u.save()
 
 # Create a test asset type and asset
+user = User.objects.get(username='testuser')
 at, _ = AssetType.objects.get_or_create(name='Test Drone')
-Asset.objects.get_or_create(name='Test Asset', asset_type=at, owner=User.objects.get(username='testuser'))
+asset, _ = Asset.objects.get_or_create(name='Test Asset', asset_type=at, owner=user)
+
+# An open mission with the user and asset attached: the search endpoints
+# resolve the mission from the asset's MissionAsset record, so without this
+# the asset can never be offered a search.
+mission = Mission.objects.filter(mission_name='Integration Test Mission', closed__isnull=True).first()
+if mission is None:
+    mission = Mission.objects.create(mission_name='Integration Test Mission', creator=user)
+MissionUser.objects.get_or_create(mission=mission, user=user, defaults={'creator': user, 'permissions_admin': True})
+MissionAsset.objects.get_or_create(mission=mission, asset=asset, removed=None, defaults={'creator': user})
+
+# A sector search for the asset's type, centred on the position the
+# integration test reports from, so the get_search -> waypoints -> accept ->
+# complete lifecycle has a search to run. Recreated when a previous run
+# completed (or deleted) the last one, keeping provisioning re-runnable.
+if not Search.objects.filter(mission=mission, completed_at__isnull=True,
+                             deleted_at__isnull=True, replaced_at__isnull=True).exists():
+    datum = GeoTimeLabel.objects.create(geo=Point(172.6, -43.5, srid=4326), created_by=user,
+                                        label='Integration test datum', geo_type='poi', mission=mission)
+    Search.create_sector_search(SearchParams(datum, at, user, 100), save=True)
 EOF
 
 echo "Provisioning complete."


### PR DESCRIPTION
## Description

The integration smoke only covered connect + report-position, which is how two GET->POST server migrations (position reports, then search begin/finished) shipped as deployed regressions. Provision an open mission with the test user and asset attached, plus a sector search centred on the reported position, and drive the whole lifecycle over the public API: closest-search lookup, waypoint fetch, accept, a mid-search position report, and completion. Provisioning is re-runnable: a new search is created whenever no current one exists.

Verified against the live Docker stack: 22 waypoints parsed, begin and finished both accepted by the server.

## Summary by Sourcery

Extend the integration test to exercise the full search lifecycle against the live server, from search discovery through completion, using provisioned test data.

Tests:
- Add integration coverage for closest-search lookup, waypoint retrieval, search acceptance, mid-search position reporting, and search completion over the public API.
- Provision a reusable open mission, asset, and sector search in the test Docker stack to support the end-to-end integration search lifecycle test.