### PR TITLE
docs: explain how a NULL from get_search distinguishes "no search"

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,16 +57,32 @@ int main(int argc, char *argv[])
 		/* Report this assets position as 43 deg South, 172 deg East, 35 meters high, heading west, 3d fix */ 
 		smm_asset_report_position (asset, -43, 172, 35, 270, 3);
 
-		/* You can also get a search to conduct by */
-		smm_search search;
-		while ((search = smm_asset_get_search (asset, -43, 172)) != NULL)
+		/* You can also get a search to conduct. A declined accept (another
+		 * asset may have taken the search first) is retried with a fresh
+		 * lookup, bounded so a persistent decline cannot loop forever. */
+		smm_search search = NULL;
+		for (int attempt = 0; attempt < 3; attempt++)
 		{
+			search = smm_asset_get_search (asset, -43, 172);
+			if (search == NULL)
+			{
+				if (smm_asset_get_last_error (asset, NULL, 0) == SMM_ERROR_NONE)
+				{
+					/* No suitable search right now; try again later */
+				}
+				else
+				{
+					/* The lookup failed (network/server error) */
+				}
+				break;
+			}
 			if (smm_search_accept (search))
 			{
 				break;
 			}
 			/* The server declined this search; discard it and ask again */
 			smm_search_destroy (search);
+			search = NULL;
 		}
 
 		if (search != NULL)

--- a/src/smm-asset.h
+++ b/src/smm-asset.h
@@ -356,12 +356,19 @@ bool smm_asset_last_goto_pos (smm_asset asset, double *lat, double *lon);
 /**
  * Get a search to perform from the SMM
  *
+ * A NULL return is ambiguous without consulting the error state, which this
+ * call clears on entry: NULL with @ref smm_asset_get_last_error reporting
+ * SMM_ERROR_NONE means the server has no suitable search right now (a clean
+ * outcome, worth retrying later); NULL with any other code is a failure
+ * (network, server, parse, ...).
+ *
  * @param asset The Asset to conduct the search
  * @param latitude the current latitude of the asset in degrees
  * @param longitude the current longitude of the asset in degrees
  *
- * @return the closest or next queued search for this asset type, it will need to be accepted with @ref
- * smm_search_accept before searching begins
+ * @return the closest or next queued search for this asset type, or NULL (see
+ * above). A returned search must be accepted with @ref smm_search_accept
+ * before searching begins
  */
 smm_search smm_asset_get_search (smm_asset asset, double latitude, double longitude);
 


### PR DESCRIPTION
## Description

smm_asset_get_search() returns NULL both for the server's clean "no suitable searches" result and for every failure; the distinguishing mechanism (the call clears the asset error on entry, so NULL + SMM_ERROR_NONE means no search) existed but was undocumented. Spell it out in the header, and make the README example check it after a NULL return. The example's accept loop is also bounded now, so a persistent decline cannot spin forever.

## Summary by Sourcery

Clarify how to interpret NULL results from smm_asset_get_search and update the README example to handle this correctly and avoid unbounded retry loops.

Bug Fixes:
- Update the README search example to check the asset error state on NULL from smm_asset_get_search and to bound retries to prevent infinite looping on persistent declines.

Documentation:
- Document the semantics of NULL returns from smm_asset_get_search in the public header comments, including how to distinguish clean "no search" from failures.