### PR TITLE
fix: report connect initialisation failures one way, then refuse requests

### DIFF
--- a/src/smm-asset-curl.c
+++ b/src/smm-asset-curl.c
@@ -363,6 +363,17 @@ smm_connection_curl_retrieve_url_r (smm_connection conn, const char *path, const
     }
 
     pthread_mutex_lock (&conn->lock);
+    /* A NULL share means smm_asset_connect failed to initialise libcurl (the
+     * connection is in SMM_CONNECTION_FAILURE with the error recorded).
+     * Refuse the request up front rather than driving libcurl without its
+     * global init. */
+    if (conn->share == NULL)
+    {
+        pthread_mutex_unlock (&conn->lock);
+        DEBUG ("connection has no share (initialisation failed); refusing request\n");
+        free (res);
+        return NULL;
+    }
     verify_tls = conn->verify_tls;
     connect_timeout = conn->connect_timeout_secs;
     transfer_timeout = conn->transfer_timeout_secs;

--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -196,17 +196,24 @@ smm_asset_connect (const char *host, const char *user, const char *pass)
     /* libcurl's global state must be initialised before any other libcurl call
      * (curl_share_init and curl_url below, and every request on this
      * connection). Do it here, the single chokepoint through which every
-     * libcurl-using path is reached. */
+     * libcurl-using path is reached.
+     *
+     * Initialisation failures return the connection in SMM_CONNECTION_FAILURE
+     * with a last_error recorded, never NULL (NULL is reserved for allocation
+     * failure), so callers have one convention to check. Either failure leaves
+     * conn->share NULL, which the request path refuses up front. */
     if (!smm_curl_global_init ())
     {
         conn->state = SMM_CONNECTION_FAILURE;
+        smm_connection_set_error (conn, SMM_ERROR_NETWORK, "libcurl initialisation failed");
         return conn;
     }
 
     if (!smm_connection_share_init (conn))
     {
-        smm_connection_unref (conn);
-        return NULL;
+        conn->state = SMM_CONNECTION_FAILURE;
+        smm_connection_set_error (conn, SMM_ERROR_NETWORK, "libcurl share initialisation failed");
+        return conn;
     }
 
     /* Early host validation, on the normalised host actually used in URLs */

--- a/src/smm-asset.h
+++ b/src/smm-asset.h
@@ -195,7 +195,11 @@ void smm_asset_debugging_set (bool debug);
  * @param user the username to authenticate as
  * @param pass the password to authenticate with
  *
- * @return an smm_connection object, check the status with @ref smm_asset_connection_get_state
+ * @return NULL only for NULL arguments or allocation failure; otherwise an
+ *         smm_connection object whose state reflects any initialisation
+ *         failure — check it with @ref smm_asset_connection_get_state and
+ *         @ref smm_connection_get_last_error. A connection in
+ *         SMM_CONNECTION_FAILURE from initialisation refuses all requests.
  */
 smm_connection smm_asset_connect (const char *host, const char *user, const char *pass);
 

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -1640,6 +1640,26 @@ START_TEST (test_https_upgrade_non_http_http_host)
 }
 END_TEST
 
+START_TEST (test_request_refused_without_share)
+{
+    /* A connection whose libcurl share is missing is one whose
+     * initialisation failed (smm_asset_connect returns it in
+     * SMM_CONNECTION_FAILURE); the request path must refuse it up front
+     * rather than driving libcurl unconfigured. Simulate by destroying the
+     * share on an otherwise-valid connection. */
+    smm_connection conn = smm_asset_connect ("http://127.0.0.1:1", "user", "pass");
+    ck_assert_ptr_nonnull (conn);
+    smm_connection_share_destroy (conn);
+
+    struct buffer_s buf = { NULL, 0 };
+    struct smm_curl_res_s *res = smm_connection_curl_retrieve_url (conn, "/assets/", NULL, &buf, false);
+    ck_assert_ptr_null (res);
+    ck_assert_ptr_null (buf.data);
+
+    smm_connection_close (conn);
+}
+END_TEST
+
 START_TEST (test_redirect_is_login_page_matches)
 {
     ck_assert_int_eq (smm_redirect_is_login_page ("https://example.com/accounts/login/"), true);
@@ -2870,6 +2890,7 @@ smm_suite (void)
     tcase_add_test (tc_conn, test_https_upgrade_null_args);
     tcase_add_test (tc_conn, test_https_upgrade_non_http_http_host);
     tcase_add_test (tc_conn, test_https_upgrade_already_https);
+    tcase_add_test (tc_conn, test_request_refused_without_share);
     tcase_add_test (tc_conn, test_redirect_is_login_page_matches);
     tcase_add_test (tc_conn, test_redirect_is_login_page_rejects_lookalikes);
     tcase_add_test (tc_conn, test_try_https_upgrade_switches_host);


### PR DESCRIPTION
## Description

smm_asset_connect reported its two libcurl init failures differently: global-init failure returned a connection in SMM_CONNECTION_FAILURE (with no last_error, and requests would then drive libcurl without its global init), while share-init failure returned NULL — so callers needed both a NULL check and a state check to catch every failure. Unify on one convention: NULL only for NULL arguments or allocation failure; otherwise the connection comes back with its state and last_error telling the story, and the request path refuses up front when the share is missing rather than running libcurl unconfigured.

## Summary by Sourcery

Unify smm_asset_connect failure handling and ensure connections whose libcurl initialisation fails consistently refuse requests rather than running without proper libcurl setup.

Bug Fixes:
- Ensure smm_asset_connect always returns a connection object with failure state and recorded error for libcurl initialisation issues instead of sometimes returning NULL.
- Prevent requests from being executed when a connection has no libcurl share by refusing such requests up front in the curl retrieval path.

Enhancements:
- Document the updated smm_asset_connect return and error-reporting contract in the public header to clarify caller expectations.

Tests:
- Add a regression test verifying that connections missing a libcurl share cause requests to be refused and no response buffer to be populated.