### PR TITLE
fix: send DEBUG output to stderr, whole lines at a time

### DIFF
--- a/src/smm-asset-internal.h
+++ b/src/smm-asset-internal.h
@@ -51,13 +51,19 @@ enum http_return_codes
 #define SMM_MAX_RESPONSE_BYTES ((size_t)8 * 1024 * 1024)
 
 extern _Atomic bool smm_debug;
+/* Library diagnostics go to stderr: host applications may emit structured
+ * output (pipes, NMEA, JSON) on stdout that interleaved debug lines would
+ * corrupt. The prefix and message are two writes, so hold the stream's stdio
+ * lock across both to keep concurrent threads' lines whole. */
 #define DEBUG(...)                                                                                                     \
     do                                                                                                                 \
     {                                                                                                                  \
         if (smm_debug)                                                                                                 \
         {                                                                                                              \
-            printf ("%s:%i ", __func__, __LINE__);                                                                     \
-            printf (__VA_ARGS__);                                                                                      \
+            flockfile (stderr);                                                                                        \
+            fprintf (stderr, "%s:%i ", __func__, __LINE__);                                                            \
+            fprintf (stderr, __VA_ARGS__);                                                                             \
+            funlockfile (stderr);                                                                                      \
         }                                                                                                              \
     } while (0)
 

--- a/src/smm-asset.h
+++ b/src/smm-asset.h
@@ -85,9 +85,9 @@ typedef enum
  * - Each smm_search is owned by a single thread at a time.  Two threads must
  *   not call functions on the same search concurrently.
  *
- * - smm_asset_debugging_set() must be called before any other threads are
- *   started; the smm_debug flag is declared _Atomic but toggling it after
- *   threads are running may produce interleaved debug output.
+ * - smm_asset_debugging_set() may be called from any thread at any time (the
+ *   flag is _Atomic). Debug output goes to stderr; each message is written
+ *   whole, so concurrent threads' messages do not interleave mid-line.
  */
 
 /**


### PR DESCRIPTION
## Description

The DEBUG macro wrote to stdout, where a host application may be emitting structured output (pipes, NMEA, JSON) that interleaved debug lines would corrupt, and used two separate printf calls, so concurrent threads could interleave one message's prefix with another's body. Write to stderr and hold the stream's stdio lock across both writes; the header's thread-safety caveat about interleaved output is lifted.

## Summary by Sourcery

Route debug logging to stderr and ensure thread-safe, whole-line emission from concurrent threads.

Bug Fixes:
- Send DEBUG macro output to stderr instead of stdout to avoid corrupting host applications' structured stdout streams.
- Guard DEBUG output with stdio locking so concurrent threads emit non-interleaved, whole-line messages.

Documentation:
- Update threading and debugging documentation to reflect atomic, thread-safe debug flag usage and stderr-based logging.