### PR TITLE
refactor: centralise scrub-then-free as smm_secure_free

### DIFF
--- a/src/smm-asset-curl.c
+++ b/src/smm-asset-curl.c
@@ -317,8 +317,7 @@ smm_connection_update_csrf_from_cookies (smm_connection conn, CURL *curl)
         char *value = smm_cookie_value_if_name (c->data, "csrftoken");
         if (value)
         {
-            smm_secure_clear (token);
-            free (token);
+            smm_secure_free (&token);
             token = value;
         }
     }
@@ -327,8 +326,7 @@ smm_connection_update_csrf_from_cookies (smm_connection conn, CURL *curl)
     if (token)
     {
         pthread_mutex_lock (&conn->lock);
-        smm_secure_clear (conn->csrfmiddlewaretoken);
-        free (conn->csrfmiddlewaretoken);
+        smm_secure_free (&conn->csrfmiddlewaretoken);
         conn->csrfmiddlewaretoken = token;
         pthread_mutex_unlock (&conn->lock);
     }
@@ -464,8 +462,7 @@ smm_connection_curl_retrieve_url_r (smm_connection conn, const char *path, const
              * The slist's copy is freed unscrubbed by curl_slist_free_all —
              * the same out-of-reach boundary as libcurl's cookie jar, which
              * holds the session cookie itself. */
-            smm_secure_clear (csrf_header);
-            free (csrf_header);
+            smm_secure_free (&csrf_header);
         }
     }
     if (headers)
@@ -530,8 +527,7 @@ smm_connection_curl_retrieve_url_r (smm_connection conn, const char *path, const
     }
 
 out:
-    smm_secure_clear (csrf_token);
-    free (csrf_token);
+    smm_secure_free (&csrf_token);
     if (headers)
     {
         curl_slist_free_all (headers);
@@ -821,8 +817,7 @@ smm_asset_connection_login (smm_connection connection)
                  * CURLOPT_POSTFIELDS keeps a pointer rather than a copy, so
                  * this and the escaped fragments in smm_build_login_post_data
                  * are the only heap copies within our reach.) */
-                smm_secure_clear (post_data);
-                free (post_data);
+                smm_secure_free (&post_data);
             }
             else
             {
@@ -889,8 +884,7 @@ smm_asset_connection_login (smm_connection connection)
     pthread_cond_broadcast (&connection->login_cond);
     pthread_mutex_unlock (&connection->lock);
 
-    smm_secure_clear (csrf_token);
-    free (csrf_token);
+    smm_secure_free (&csrf_token);
     return res;
 }
 

--- a/src/smm-asset-internal.h
+++ b/src/smm-asset-internal.h
@@ -163,6 +163,13 @@ void smm_connection_share_destroy (smm_connection conn);
  * cannot elide. NULL-safe. Exposed for testing. */
 void smm_secure_clear (char *s);
 
+/* Scrub *p and free() it, then NULL the pointer, so a secret's heap copy can
+ * neither be freed unscrubbed nor double-freed. Safe on NULL p or *p. Only
+ * for memory owned by free(): buffers from curl_easy_escape must still be
+ * scrubbed with smm_secure_clear and released with curl_free. Exposed for
+ * testing. */
+void smm_secure_free (char **p);
+
 void smm_connection_ref (smm_connection conn);
 void smm_connection_unref (smm_connection conn);
 void smm_connection_set_error (smm_connection conn, smm_error_code code, const char *fmt, ...)

--- a/src/smm-asset.c
+++ b/src/smm-asset.c
@@ -58,6 +58,18 @@ smm_secure_clear (char *s)
 #endif
 }
 
+void
+smm_secure_free (char **p)
+{
+    if (p == NULL || *p == NULL)
+    {
+        return;
+    }
+    smm_secure_clear (*p);
+    free (*p);
+    *p = NULL;
+}
+
 /*
  * SMM expects coordinates in URLs formatted with '.' as the decimal separator.
  * printf-family conversions honour the thread's LC_NUMERIC, so a caller running
@@ -469,12 +481,9 @@ smm_connection_unref (smm_connection connection)
         free (connection->host);
         /* Scrub the credentials and session token from memory before freeing,
          * so they do not linger in the heap after the connection is closed. */
-        smm_secure_clear (connection->user);
-        free (connection->user);
-        smm_secure_clear (connection->pass);
-        free (connection->pass);
-        smm_secure_clear (connection->csrfmiddlewaretoken);
-        free (connection->csrfmiddlewaretoken);
+        smm_secure_free (&connection->user);
+        smm_secure_free (&connection->pass);
+        smm_secure_free (&connection->csrfmiddlewaretoken);
         smm_connection_share_destroy (connection);
         pthread_cond_destroy (&connection->login_cond);
         pthread_mutex_destroy (&connection->io_lock);

--- a/tests/check_smm.c
+++ b/tests/check_smm.c
@@ -1469,6 +1469,21 @@ END_TEST
 START_TEST (test_secure_clear_null_safe) { smm_secure_clear (NULL); /* must not crash */ }
 END_TEST
 
+START_TEST (test_secure_free_nulls_pointer)
+{
+    char *s = strdup ("s3cr3t-password");
+    ck_assert_ptr_nonnull (s);
+    smm_secure_free (&s);
+    /* The pointer is NULLed, so a repeat call (a would-be double free) is a
+     * safe no-op. The scrub itself is covered by the secure_clear tests. */
+    ck_assert_ptr_null (s);
+    smm_secure_free (&s);
+}
+END_TEST
+
+START_TEST (test_secure_free_null_safe) { smm_secure_free (NULL); /* must not crash */ }
+END_TEST
+
 START_TEST (test_content_type_is_json_plain) { ck_assert_int_eq (smm_content_type_is_json ("application/json"), true); }
 END_TEST
 
@@ -3089,6 +3104,8 @@ smm_suite (void)
     tcase_add_test (tc_secure, test_secure_clear_zeroes);
     tcase_add_test (tc_secure, test_secure_clear_empty_string);
     tcase_add_test (tc_secure, test_secure_clear_null_safe);
+    tcase_add_test (tc_secure, test_secure_free_nulls_pointer);
+    tcase_add_test (tc_secure, test_secure_free_null_safe);
     suite_add_tcase (s, tc_secure);
 
     TCase *tc_content_type = tcase_create ("ContentType");


### PR DESCRIPTION
## Description

Review on the credential-scrubbing changes pointed out (twice) that the scrub-then-free pattern now appears at many call sites, and every new site is a chance to forget the scrub — which is exactly how two unscrubbed copies slipped through before. Add smm_secure_free(char **), which scrubs, frees, and NULLs the pointer (so a stale pointer cannot be double-freed either), and use it at every free()-owned site. The curl_free()-owned escaped fragments keep the explicit two-step; the helper's contract documents that boundary.

## Summary by Sourcery

Centralize secure scrub-and-free handling for sensitive strings and adopt it across connection and curl code paths.

Enhancements:
- Introduce smm_secure_free to scrub, free, and null sensitive heap pointers owned by free().
- Refactor existing credential and token cleanup sites to use the new smm_secure_free helper instead of open-coded scrub-then-free sequences.

Tests:
- Add tests verifying smm_secure_free nulls pointers, is safe on NULL inputs, and integrates with existing secure clear behavior.