### PR TITLE
release: prepare 1.1.1

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,48 @@
+libsmm-asset 1.1.1
+==================
+
+Bug-fix release; fully backwards compatible with 1.1.0 (SONAME
+libsmmasset.so.0 unchanged, no interface changes).
+
+ * Search begin/finished actions are now sent as POST with asset_id in the
+   request body, matching the current Search Management Map API. Against
+   current servers the old GET was rejected (405/404), so an asset could
+   never accept a search; deployed systems should upgrade.
+ * Fixed a crash on login pages containing a valueless attribute (e.g.
+   "<input name>"): a malformed or hostile login page now degrades to a
+   protocol error instead of a NULL dereference.
+ * The login POST body and escaped credentials are scrubbed before being
+   freed, extending the 1.1.0 credential-scrubbing policy to every heap
+   copy of the password within the library's reach. Transient CSRF/session
+   token copies (cookie rotation, the per-request snapshot and header, and
+   login parsing) get the same treatment, and the scrub-then-free pattern
+   is centralised in an internal helper so a future call site cannot
+   forget the scrub.
+ * The response body buffer is now freed on every network-failure path,
+   closing a narrow leak in get_assets, get_waypoints, and the search
+   actions.
+ * The HTTP->HTTPS upgrade now matches hosts with explicit default ports
+   ("http://host:80" -> "https://host") and compares hostnames
+   case-insensitively (including bracketed IPv6 literals); an explicit :80
+   is dropped from the upgraded host instead of driving TLS at port 80.
+ * The login redirect is detected from the redirect URL's parsed path
+   ("/accounts/login/" at a segment boundary), not a substring match over
+   the whole URL.
+ * Every failure path now records a per-object last_error, and errors are
+   cleared on entry, so smm_asset_get_search()'s documented NULL +
+   SMM_ERROR_NONE "no suitable search" contract holds on all paths (now
+   documented in the header, with the README example updated).
+ * smm_asset_connect() failures are reported one way: NULL only for NULL
+   arguments or allocation failure, otherwise a connection whose state and
+   last_error describe the initialisation failure; such a connection
+   refuses requests instead of driving libcurl unconfigured.
+ * Debug output moved from stdout to stderr and is written whole-line, so
+   concurrent threads' messages no longer interleave and application
+   stdout is never polluted.
+ * The integration suite now drives the full search lifecycle (closest
+   search, waypoints, accept, mid-search position report, complete)
+   against a live SMM stack.
+
 libsmm-asset 1.1.0
 ==================
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,24 @@
+libsmm-asset (1.1.1) unstable; urgency=medium
+
+  * Send search begin/finished as POST with asset_id in the body; the old
+    GET is rejected by current SMM servers, so assets could never accept a
+    search (deployed-system regression fix).
+  * Fix a crash on login pages containing a valueless attribute.
+  * Scrub the login POST body, escaped credentials, and every transient
+    CSRF-token copy before freeing.
+  * Free the response buffer on all network-failure paths.
+  * Match explicit default ports and hostname case in the HTTPS upgrade;
+    drop an explicit :80 from the upgraded host.
+  * Detect the login redirect by parsed path, not URL substring.
+  * Record a last_error on every failure path and clear it on entry;
+    document get_search()'s NULL + SMM_ERROR_NONE no-search contract.
+  * Consistent smm_asset_connect() failure reporting; a connection whose
+    initialisation failed refuses requests.
+  * Debug output goes to stderr, written whole-line.
+  * Integration suite covers the full search lifecycle.
+
+ -- Scott Parlane <sjp@canterburyairpatrol.org>  Thu, 03 Jul 2026 00:00:00 +0000
+
 libsmm-asset (1.1.0) unstable; urgency=medium
 
   * New smm_asset_connection_timeouts_set() for per-connection libcurl

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -17,7 +17,7 @@ libsmmasset_internal_la_LIBADD = $(TIDY_LIBS) $(CURL_LIBS) $(JANSSON_LIBS)
 lib_LTLIBRARIES = libsmmasset.la
 libsmmasset_la_SOURCES =
 libsmmasset_la_LIBADD = libsmmasset-internal.la $(TIDY_LIBS) $(CURL_LIBS) $(JANSSON_LIBS)
-libsmmasset_la_LDFLAGS = -no-undefined -version-info 1:0:1 -export-symbols $(srcdir)/libsmmasset.sym
+libsmmasset_la_LDFLAGS = -no-undefined -version-info 1:1:1 -export-symbols $(srcdir)/libsmmasset.sym
 
 EXTRA_DIST = libsmmasset.sym
 

--- a/src/smm-asset.h
+++ b/src/smm-asset.h
@@ -34,7 +34,7 @@
  */
 #define SMM_VERSION_MAJOR 1
 #define SMM_VERSION_MINOR 1
-#define SMM_VERSION_PATCH 0
+#define SMM_VERSION_PATCH 1
 
 /* Compose "major.minor.patch" from the numbers above (two-step expansion so the
  * macro values, not their names, are stringified). */


### PR DESCRIPTION
## Description

Bug-fix release, no interface changes: libtool version-info goes 1:0:1 -> 1:1:1 (revision bump, SONAME libsmmasset.so.0 unchanged). The headline fix is the search begin/finished actions, which current SMM servers reject as sent by 1.1.0, so assets can never accept a search; NEWS and debian/changelog carry the full list.

## Summary by Sourcery

Prepare the 1.1.1 patch release of libsmmasset with an updated library version and packaging metadata.

Enhancements:
- Increment the library libtool version-info to reflect the new patch release without changing the SONAME.
- Update the SMM patch version macro to 1.1.1 for consistency with the release.

Build:
- Adjust build configuration to use libtool version-info 1:1:1 for libsmmasset.

Documentation:
- Update NEWS with the 1.1.1 release notes.

Chores:
- Update Debian packaging changelog for the 1.1.1 release.